### PR TITLE
Fix META-INF path for LICENSE.TXT and NOTICE.TXT

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -42,8 +42,8 @@ tasks.withType<Jar> {
     }
 
     metaInf {
-        into(".").from("../LICENSE.txt")
-        into(".").from("../NOTICE.txt")
+        from("../LICENSE.txt")
+        from("../NOTICE.txt")
     }
 }
 


### PR DESCRIPTION
Changes the directory structure of the jar from

```
META-INF/
META-INF/MANIFEST.MF
META-INF/./
META-INF/./LICENSE.txt
META-INF/./NOTICE.txt
```

to

```
META-INF/
META-INF/MANIFEST.MF
META-INF/NOTICE.txt
META-INF/LICENSE.txt
```

Closes #5 