### PR TITLE
Copy config into ci docker image

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -34,6 +34,7 @@ COPY LICENSE.txt NOTICE.txt ./
 # Prefetch dependencies
 COPY build.gradle.kts settings.gradle.kts ./
 COPY buildSrc ./buildSrc/
+COPY config ./config/
 COPY java-client/build.gradle.kts ./java-client/
 RUN ./gradlew resolveDependencies
 


### PR DESCRIPTION
Copy the config directory into the docker image used by CI. Without this
the build command used by the unified build process fails.

```
env DEPENDENCIES_REPORTS_DIR=$PWD \
    DEPENDENCIES_REPORT=dependencies-report.csv \
  .ci/make.sh assemble 8.0.0-SNAPSHOT
```