### PR TITLE
Using Temurin builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -4,14 +4,17 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 11 ]
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
 
       - name: Check style and license headers
         run: |


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. Also, I've added a matrix to later add JDK 17 (next LTS release). Gradle currently does not support JDK early access releases.