### PR TITLE
[7.x][DOCS] Removes partintro from book index

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,16 +1,11 @@
 = Elasticsearch Java High-level client
 
-[partintro]
---
-
 The {es} Java High-level REST Client is an experimental Java client for {es}. 
 It removes all dependencies to the {es} server code base.
 
 * <<introduction>>
 * <<installation>>
 * <<connecting>>
-
---
 
 :branch: master
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]


### PR DESCRIPTION
## Overview

This PR backports the changes of the following commit to the 7.x branch: https://github.com/elastic/elasticsearch-java/pull/22