### PR TITLE
Promote client stability in docs

### DIFF
--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -1,9 +1,9 @@
 [[connecting]]
 == Connecting
 
-experimental[]
+beta[]
 
-The code snippet below shows how to initialize a low level REST client and the 
+The code snippet below shows how to initialize a low level REST client and the
 Jackson object mapper to configure an ElasticsearchClient:
 
 
@@ -19,7 +19,7 @@ Transport transport = new RestClientTransport(restClient, new JacksonJsonpMapper
 ElasticsearchClient client = new ElasticsearchClient(transport);
 --------------------------------------------------
 
-Authentication is managed by the 
+Authentication is managed by the
 https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low-level Rest Client].
-For further details on configuring authentication, refer to the 
+For further details on configuring authentication, refer to the
 https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_basic_authentication.html[documentation].

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -1,21 +1,21 @@
 [[installation]]
 == Installation
 
-experimental[]
+beta[]
 
 This page guides you through the installation process of the client.
 
 Requirements:
 
-* Java 8 or later. The library provides high-level type-safe classes 
-  and methods for all {es} APIs. It sits on top of the 
-  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[Low Level Rest Client] 
+* Java 8 or later. The library provides high-level type-safe classes
+  and methods for all {es} APIs. It sits on top of the
+  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[Low Level Rest Client]
   that manages all http communications.
- 
-* The JSON implementation used by the Java client is pluggable and you must add 
-  a JSON object mapping library as a dependency to your project. It has support 
-  for https://github.com/FasterXML/jackson[Jackson] or a 
-  http://json-b.net/[JSON-B] library like 
+
+* The JSON implementation used by the Java client is pluggable and you must add
+  a JSON object mapping library as a dependency to your project. It has support
+  for https://github.com/FasterXML/jackson[Jackson] or a
+  http://json-b.net/[JSON-B] library like
   https://github.com/eclipse-ee4j/yasson[Eclipse Yasson].
 
 
@@ -39,7 +39,7 @@ dependencies {
 [[maven]]
 === Installation in a Maven project by using Jackson
 
-In the `pom.xml` of your project, add the following repository definition and 
+In the `pom.xml` of your project, add the following repository definition and
 dependencies:
 
 ["source","xml",subs="attributes"]
@@ -66,11 +66,11 @@ dependencies:
 [[compatibility]]
 === Compatibility
 
-The `main` branch targets the next major release (8.0), the `7.x` branch targets 
-the next minor release. Support is still incomplete as the API code is generated 
+The `main` branch targets the next major release (8.0), the `7.x` branch targets
+the next minor release. Support is still incomplete as the API code is generated
 from the {es} Specification that is also still a work in progress.
 
-The {es} Java client is forward compatible; meaning that the client supports 
-communicating with greater or equal minor versions of {es}. {es} language 
-clients are only backwards compatible with default distributions and without 
-guarantees made. 
+The {es} Java client is forward compatible; meaning that the client supports
+communicating with greater or equal minor versions of {es}. {es} language
+clients are only backwards compatible with default distributions and without
+guarantees made.

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -1,10 +1,10 @@
 [[introduction]]
 == Introduction
 
-experimental[]
+beta[]
 
-This is the official Java API client for {es}. The client provides strongly 
-typed requests and responses for all {es} APIs. It delegates protocol handling 
-to an http client such as the 
-https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-low.html[{es} Low Level REST client] 
+This is the official Java API client for {es}. The client provides strongly
+typed requests and responses for all {es} APIs. It delegates protocol handling
+to an http client such as the
+https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-low.html[{es} Low Level REST client]
 that takes care of all transport-level concerns.


### PR DESCRIPTION
Correct the docs stability disclaimer by promoting the client to `beta`.