### PR TITLE
[DOCS] Updates the link in Introduction that points to LLRC

### DIFF
--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -5,6 +5,5 @@ experimental[]
 
 This is the official Java API client for {es}. The client provides strongly 
 typed requests and responses for all {es} APIs. It delegates protocol handling 
-to an http client such as the 
-https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-low.html[{es} Low Level REST client] 
-that takes care of all transport-level concerns.
+to an http client such as the <<java-rest-low>> that takes care of all 
+transport-level concerns.


### PR DESCRIPTION
## Overview

This PR updates the link in the Intro section to point to the new LLRC section in the Java API book.

[Introduction](https://elasticsearch-java_29.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-api-client/master/introduction.html)