### PR TITLE
[7.16][DOCS] Removes duplicated compatibility section

### DIFF
--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -57,16 +57,3 @@ dependencies:
 
 </project>
 --------------------------------------------------
-
-[discrete]
-[[compatibility]]
-=== Compatibility
-
-The `main` branch targets the next major release (8.0), the `7.x` branch targets
-the next minor release. Support is still incomplete as the API code is generated
-from the {es} Specification that is also still a work in progress.
-
-The {es} Java client is forward compatible; meaning that the client supports
-communicating with greater or equal minor versions of {es}. {es} language
-clients are only backwards compatible with default distributions and without
-guarantees made.


### PR DESCRIPTION
## Overview

There are two `Compatibility` sections in the docs on 7.16: one in the Introduction page and one in the Installation page. To be 7.16 in line with main, this PR removes the duplication from the Installation page.