### PR TITLE
Use Singular instead of Plural when adding 1 element

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndexTemplateRequest.java
@@ -343,7 +343,7 @@ public final class PutIndexTemplateRequest extends RequestBase implements JsonpS
 		/**
 		 * Add a value to {@link #indexPatterns(List)}, creating the list if needed.
 		 */
-		public Builder addIndexPatterns(String value) {
+		public Builder addIndexPattern(String value) {
 			if (this.indexPatterns == null) {
 				this.indexPatterns = new ArrayList<>();
 			}

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutTemplateRequest.java
@@ -428,7 +428,7 @@ public final class PutTemplateRequest extends RequestBase implements JsonpSerial
 		/**
 		 * Add a value to {@link #indexPatterns(List)}, creating the list if needed.
 		 */
-		public Builder addIndexPatterns(String value) {
+		public Builder addIndexPattern(String value) {
 			if (this.indexPatterns == null) {
 				this.indexPatterns = new ArrayList<>();
 			}


### PR DESCRIPTION
I think that `addIndexPattern(String)` is a better name than `addIndexPatterns(String)` as we are adding only one element.

I believe we should extend this principle to the other methods and APIs but before doing more, I prefer starting a discussion :)