### PR TITLE
Change the JSON-P implementation from Glassfish to Parsson

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -126,10 +126,14 @@ dependencies {
     // https://search.maven.org/artifact/com.google.code.findbugs/jsr305
     api("com.google.code.findbugs:jsr305:3.0.2")
 
-    // Needed even if using Jackson to have an implementation of the Jsonp object model
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/jsonp
-    api("org.glassfish", "jakarta.json", "2.0.1")
+    api("jakarta.json:jakarta.json-api:2.0.1")
+
+    // Needed even if using Jackson to have an implementation of the Jsonp object model
+    // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+    // https://github.com/eclipse-ee4j/parsson
+    api("org.eclipse.parsson:parsson:1.0.0")
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // http://json-b.net/


### PR DESCRIPTION
With the move from `javax.json` to `jakarta.json`, the Glassfish reference implementation of JSON-P has been updated to implement interfaces from `jakarta.json` but its class names haven't changed, causing conflicts in environments where the `javax.json` variant is present such as JEE8.

The `jakarta.json` variant of Glassfish is now available under a new name, [Eclipse Parsson](https://github.com/eclipse-ee4j/parsson). This PR updates the dependencies to replace Glassfish with Parsson.

Fixes #55