### PR TITLE
Add links to javadoc and source code

### DIFF
--- a/docs/index-local.asciidoc
+++ b/docs/index-local.asciidoc
@@ -1,4 +1,6 @@
 // Allow building docs locally without a checkout of the Elasticsearch repo
 :elasticsearch-root: {docdir}/local/elasticsearch
 
+// Version is needed to build locally, its value doesn't matter.
+:version: 7.16.2
 include::index.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -3,7 +3,6 @@
 :branch: master
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:version: 7.16.0
 :java-client: Java API Client
 :doc-tests: {docdir}/../java-client/src/test/java/co/elastic/clients/documentation
 
@@ -12,8 +11,8 @@ include::installation.asciidoc[]
 include::connecting.asciidoc[]
 include::migrate.asciidoc[]
 include::api-conventions.asciidoc[]
+include::javadoc-and-source.asciidoc[]
 
-:version!:
 :java-client!:
 :doc-tests!:
 

--- a/docs/javadoc-and-source.asciidoc
+++ b/docs/javadoc-and-source.asciidoc
@@ -1,0 +1,6 @@
+[[java-client-javadoc]]
+== Javadoc and source code
+
+The javadoc for the {java-client} can be found at https://artifacts.elastic.co/javadoc/co/elastic/clients/elasticsearch-java/{version}/index.html.
+
+The source code is at https://github.com/elastic/elasticsearch-java/ and is licensed under the Apache 2.0 License.


### PR DESCRIPTION
New docs section linking to javadocs and source code.