### PR TITLE
SortOptions deserializer should support function deserialize(parser, mapper, event)

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/SortOptions.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/SortOptions.java
@@ -23,13 +23,7 @@
 
 package co.elastic.clients.elasticsearch._types;
 
-import co.elastic.clients.json.JsonEnum;
-import co.elastic.clients.json.JsonpDeserializable;
-import co.elastic.clients.json.JsonpDeserializer;
-import co.elastic.clients.json.JsonpMapper;
-import co.elastic.clients.json.JsonpSerializable;
-import co.elastic.clients.json.JsonpUtils;
-import co.elastic.clients.json.ObjectDeserializer;
+import co.elastic.clients.json.*;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import co.elastic.clients.util.ObjectBuilderBase;
@@ -285,47 +279,67 @@ public class SortOptions implements TaggedUnion<SortOptions.Kind, Object>, Jsonp
 
 	}
 
-	public static final JsonpDeserializer<SortOptions> _DESERIALIZER = JsonpDeserializer.lazy(() -> JsonpDeserializer
-			.of(EnumSet.of(JsonParser.Event.START_OBJECT, JsonParser.Event.VALUE_STRING), (parser, mapper) -> {
-				SortOptions.Builder b = new SortOptions.Builder();
+	public static final JsonpDeserializer<SortOptions> _DESERIALIZER = JsonpDeserializer.lazy(() ->
+			new JsonpDeserializerBase<SortOptions>(
+					EnumSet.of(JsonParser.Event.START_OBJECT, JsonParser.Event.VALUE_STRING)) {
 
-				JsonParser.Event event = parser.next();
-				if (event == JsonParser.Event.VALUE_STRING) {
-					switch (parser.getString()) {
-						case "_score" :
-							b.score(s -> s);
-							break;
-						case "_doc" :
-							b.doc(d -> d);
-							break;
-						default :
-							b.field(f -> f.field(parser.getString()));
-					}
-					return b.build();
-				}
+		@Override
+		public SortOptions deserialize(JsonParser parser, JsonpMapper mapper) {
+			JsonParser.Event event = parser.next();
+			if (event == JsonParser.Event.VALUE_STRING) {
+				return processStringEvent(parser);
+			}
+			JsonpUtils.expectEvent(parser, JsonParser.Event.START_OBJECT, event);
+			return processObjectEvent(parser, mapper);
+		}
 
-				JsonpUtils.expectEvent(parser, JsonParser.Event.START_OBJECT, event);
-				JsonpUtils.expectNextEvent(parser, JsonParser.Event.KEY_NAME);
-				switch (parser.getString()) {
-					case "_score" :
-						b.score(ScoreSort._DESERIALIZER.deserialize(parser, mapper));
-						break;
-					case "_doc" :
-						b.doc(ScoreSort._DESERIALIZER.deserialize(parser, mapper));
-						break;
-					case "_geo_distance" :
-						b.geoDistance(GeoDistanceSort._DESERIALIZER.deserialize(parser, mapper));
-						break;
-					case "_script" :
-						b.script(ScriptSort._DESERIALIZER.deserialize(parser, mapper));
-						break;
-					default :
-						// Consumes END_OBJECT
-						return b.field(FieldSort._DESERIALIZER.deserialize(parser, mapper, JsonParser.Event.KEY_NAME))
-								.build();
-				}
+		@Override
+		public SortOptions deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
+			if (event == JsonParser.Event.VALUE_STRING) {
+				return processStringEvent(parser);
+			} else {
+				return processObjectEvent(parser, mapper);
+			}
+		}
 
-				JsonpUtils.expectNextEvent(parser, JsonParser.Event.END_OBJECT);
-				return b.build();
-			}));
+		private SortOptions processStringEvent(JsonParser parser) {
+			Builder b = new Builder();
+			switch (parser.getString()) {
+				case "_score" :
+					b.score(s -> s);
+					break;
+				case "_doc" :
+					b.doc(d -> d);
+					break;
+				default :
+					b.field(f -> f.field(parser.getString()));
+			}
+			return b.build();
+		}
+
+		private SortOptions processObjectEvent(JsonParser parser, JsonpMapper mapper) {
+			Builder b = new Builder();
+			JsonpUtils.expectNextEvent(parser, JsonParser.Event.KEY_NAME);
+			switch (parser.getString()) {
+				case "_score" :
+					b.score(ScoreSort._DESERIALIZER.deserialize(parser, mapper));
+					break;
+				case "_doc" :
+					b.doc(ScoreSort._DESERIALIZER.deserialize(parser, mapper));
+					break;
+				case "_geo_distance" :
+					b.geoDistance(GeoDistanceSort._DESERIALIZER.deserialize(parser, mapper));
+					break;
+				case "_script" :
+					b.script(ScriptSort._DESERIALIZER.deserialize(parser, mapper));
+					break;
+				default :
+					// Consumes END_OBJECT
+					return b.field(FieldSort._DESERIALIZER.deserialize(parser, mapper, JsonParser.Event.KEY_NAME))
+							.build();
+			}
+			JsonpUtils.expectNextEvent(parser, JsonParser.Event.END_OBJECT);
+			return b.build();
+		}
+	});
 }

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/json/SearchSeDeTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/json/SearchSeDeTest.java
@@ -1,0 +1,36 @@
+package co.elastic.clients.elasticsearch.json;
+
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import jakarta.json.stream.JsonParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+public class SearchSeDeTest extends Assert {
+
+    @Test
+    public void deserialize() {
+        String json = "{\n" +
+                "  \"size\": 9999,\n" +
+                "  \"query\": {\n" +
+                "    \"match_all\": {}\n" +
+                "  },\n" +
+                "  \"sort\": [\n" +
+                "    {\n" +
+                "      \"modify_time\": {\n" +
+                "        \"order\": \"desc\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"track_total_hits\": 2147483647\n" +
+                "}";
+
+        JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+        JsonParser parser = jsonpMapper.jsonProvider().createParser(new StringReader(json));
+        final SearchRequest deserialize = SearchRequest._DESERIALIZER.deserialize(parser, jsonpMapper);
+        assertNotNull(deserialize);
+    }
+}


### PR DESCRIPTION
When deserialize the json to SearchRequest
```
{
  "size": 9999,
  "query": {
    "match_all": {}
  },
  "sort": [
    {
      "modify_time": {
        "order": "desc"
      }
    }
  ],
  "track_total_hits": 2147483647
}
```

Array deserializer use function `deserialize(parser, mapper, event)` to  deserialize each item in sort block, it will be failed because SortOption not implement this function