### PR TITLE
Fix javadoc links, using branch information provided by the doc build system

### DIFF
--- a/docs/index-local.asciidoc
+++ b/docs/index-local.asciidoc
@@ -1,6 +1,4 @@
 // Allow building docs locally without a checkout of the Elasticsearch repo
 :elasticsearch-root: {docdir}/local/elasticsearch
 
-// Version is needed to build locally, its value doesn't matter.
-:version: 7.16.2
 include::index.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,10 +1,24 @@
 = Elasticsearch Java API Client
 
-:branch: master
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :java-client: Java API Client
 :doc-tests: {docdir}/../java-client/src/test/java/co/elastic/clients/documentation
+
+ifeval::["{release-state}"=="unreleased"]
+:java-client-javadoc: https://snapshots.elastic.co/javadoc/co/elastic/clients/elasticsearch-java/{version}-SNAPSHOT
+:rest-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}-SNAPSHOT
+:rest-client-sniffer-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}-SNAPSHOT
+:version_qualified: {bare_version}-SNAPSHOT
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+:java-client-javadoc: https://artifacts.elastic.co/javadoc/co/elastic/clients/elasticsearch-java/{version}
+:rest-client-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}
+:rest-client-sniffer-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}
+:version_qualified: {bare_version}
+endif::[]
 
 include::introduction.asciidoc[]
 include::installation.asciidoc[]
@@ -12,8 +26,5 @@ include::connecting.asciidoc[]
 include::migrate.asciidoc[]
 include::api-conventions.asciidoc[]
 include::javadoc-and-source.asciidoc[]
-
-:java-client!:
-:doc-tests!:
 
 include::{elasticsearch-root}/docs/java-rest/low-level/index.asciidoc[]

--- a/docs/javadoc-and-source.asciidoc
+++ b/docs/javadoc-and-source.asciidoc
@@ -1,6 +1,6 @@
 [[java-client-javadoc]]
 == Javadoc and source code
 
-The javadoc for the {java-client} can be found at https://artifacts.elastic.co/javadoc/co/elastic/clients/elasticsearch-java/{version}/index.html.
+The javadoc for the {java-client} can be found at {java-client-javadoc}/index.html.
 
 The source code is at https://github.com/elastic/elasticsearch-java/ and is licensed under the Apache 2.0 License.


### PR DESCRIPTION
Fixes javadoc links for Java API client, Low Level Rest Client and Sniffer by using the use the `source_branch` attribute provided by the build system.

Fixes #83