### PR TITLE
Installation doc: correct json-b url

### DIFF
--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -7,7 +7,7 @@ Requirements:
 * A JSON object mapping library to allow seamless integration of
   your application classes with the Elasticsearch API. The Java client has 
   support for https://github.com/FasterXML/jackson[Jackson] or a 
-  http://json-b.net/[JSON-B] library like 
+  https://javaee.github.io/jsonb-spec/[JSON-B] library like 
   https://github.com/eclipse-ee4j/yasson[Eclipse Yasson].
 
 


### PR DESCRIPTION
Seems like json-b.net domain expired and was bought by something else