### PR TITLE
Add support for typed-key arrays, refactor and add tests

### DIFF
--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/ElasticsearchTestServer.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/ElasticsearchTestServer.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.elasticsearch;
+
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jsonb.JsonbJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import java.time.Duration;
+
+public class ElasticsearchTestServer implements AutoCloseable {
+
+    private volatile ElasticsearchContainer container;
+    private int port;
+    private final JsonpMapper mapper = new JsonbJsonpMapper();
+    private RestClient restClient;
+    private ElasticsearchTransport transport;
+    private ElasticsearchClient client;
+
+    private static ElasticsearchTestServer global;
+
+    public static synchronized ElasticsearchTestServer global() {
+        if (global == null) {
+            System.out.println("Starting global ES test server.");
+            global = new ElasticsearchTestServer();
+            global.setup();
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                System.out.println("Stopping global ES test server.");
+                global.close();
+            }));
+        }
+        return global;
+    }
+
+    private synchronized void setup() {
+        container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.16.2")
+            .withEnv("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
+            .withEnv("path.repo", "/tmp") // for snapshots
+            .withStartupTimeout(Duration.ofSeconds(30))
+            .withPassword("changeme");
+        container.start();
+        port = container.getMappedPort(9200);
+
+        BasicCredentialsProvider credsProv = new BasicCredentialsProvider();
+        credsProv.setCredentials(
+            AuthScope.ANY, new UsernamePasswordCredentials("elastic", "changeme")
+        );
+        restClient = RestClient.builder(new HttpHost("localhost", port))
+            .setHttpClientConfigCallback(hc -> hc.setDefaultCredentialsProvider(credsProv))
+            .build();
+        transport = new RestClientTransport(restClient, mapper);
+        client = new ElasticsearchClient(transport);
+    }
+
+    @Override
+    public void close() {
+        if (this == global) {
+            // Closed with a shutdown hook
+            return;
+        }
+
+        if (container != null) {
+            container.stop();
+        }
+        container = null;
+    }
+
+    public int port() {
+        return port;
+    }
+
+    public RestClient restClient() {
+        return restClient;
+    }
+
+    public ElasticsearchTransport transport() {
+        return transport;
+    }
+
+    public JsonpMapper mapper() {
+        return mapper;
+    }
+
+    public ElasticsearchClient client() {
+        return client;
+    }
+}

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/spec_issues/SpecIssuesTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/spec_issues/SpecIssuesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.elasticsearch.spec_issues;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.ElasticsearchTestServer;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.json.JsonpDeserializer;
+import jakarta.json.stream.JsonParser;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+/**
+ * Test issues related to the API specifications.
+ *
+ * Depending on the feedback provided, this may involve either loading a JSON file or sending requests to an ES server.
+ */
+public class SpecIssuesTest extends ModelTestCase {
+
+    @Test
+    public void i0107_rangeBucketKey() {
+        // https://github.com/elastic/elasticsearch-java/issues/107
+        loadRsrc("issue-0107-response.json", SearchResponse.createSearchResponseDeserializer(JsonData._DESERIALIZER));
+    }
+
+    @Test
+    public void i0078_deserializeSearchRequest() {
+        // https://github.com/elastic/elasticsearch-java/issues/78
+        loadRsrc("issue-0078.json", SearchRequest._DESERIALIZER);
+    }
+
+    @Test
+    public void i0057_suggestDeserialization() {
+        // https://github.com/elastic/elasticsearch-java/issues/57
+        // Note: the _type properties have been removed so that the test works in 8.x too.
+        SearchResponse<JsonData> resp = loadRsrc("issue-0057-response.json",
+            SearchResponse.createSearchResponseDeserializer(JsonData._DESERIALIZER));
+
+        assertEquals(1, resp.suggest().get("completion:completion1").size());
+        assertEquals("hash", resp.suggest().get("completion:completion1").get(0).completion().text());
+        assertEquals("HashMap-Complete1", resp.suggest().get("completion:completion1").get(0).completion().options().get(0).text());
+    }
+
+    @Test
+    public void i0056_hitsMetadataTotal() throws Exception {
+        // https://github.com/elastic/elasticsearch-java/issues/56
+        SearchResponse<JsonData> res = ElasticsearchTestServer.global().client()
+            .search(srb -> srb
+                .trackTotalHits(thb -> thb.enabled(false)), JsonData.class);
+    }
+
+    private <T> T loadRsrc(String res, JsonpDeserializer<T> deser) {
+        InputStream is = this.getClass().getResourceAsStream(res);
+        assertNotNull("Resource not found: " + res, is);
+        JsonParser parser = mapper.jsonProvider().createParser(is);
+        return deser.deserialize(parser, mapper);
+    }
+}

--- a/java-client/src/test/resources/co/elastic/clients/elasticsearch/spec_issues/issue-0057-response.json
+++ b/java-client/src/test/resources/co/elastic/clients/elasticsearch/spec_issues/issue-0057-response.json
@@ -1,0 +1,62 @@
+{
+  "took": 67,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "suggest": {
+    "completion#completion:completion1": [
+      {
+        "text": "hash",
+        "offset": 0,
+        "length": 4,
+        "options": [
+          {
+            "text": "HashMap-Complete1",
+            "_index": "document",
+            "_id": "2",
+            "_score": 1.0
+          },
+          {
+            "text": "HashSet-Complete1",
+            "_index": "document",
+            "_id": "1",
+            "_score": 1.0
+          }
+        ]
+      }
+    ],
+    "completion#completion:completion2": [
+      {
+        "text": "hash",
+        "offset": 0,
+        "length": 4,
+        "options": [
+          {
+            "text": "HashMap-Complete2",
+            "_index": "document",
+            "_id": "2",
+            "_score": 1.0
+          },
+          {
+            "text": "HashSet-Complete2",
+            "_index": "document",
+            "_id": "1",
+            "_score": 1.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/java-client/src/test/resources/co/elastic/clients/elasticsearch/spec_issues/issue-0078.json
+++ b/java-client/src/test/resources/co/elastic/clients/elasticsearch/spec_issues/issue-0078.json
@@ -1,0 +1,14 @@
+{
+  "size": 9999,
+  "query": {
+    "match_all": {}
+  },
+  "sort": [
+    {
+      "modify_time": {
+        "order": "desc"
+      }
+    }
+  ],
+  "track_total_hits": 2147483647
+}

--- a/java-client/src/test/resources/co/elastic/clients/elasticsearch/spec_issues/issue-0107-response.json
+++ b/java-client/src/test/resources/co/elastic/clients/elasticsearch/spec_issues/issue-0107-response.json
@@ -1,0 +1,52 @@
+{
+  "took" : 1,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 5,
+      "relation" : "eq"
+    },
+    "max_score" : null,
+    "hits" : [ ]
+  },
+  "aggregations": {
+    "date_range#date_ranges": {
+      "buckets": [
+        {
+          "key": "2Wk",
+          "from": 1.6408224E12,
+          "from_as_string": "2021-12-30T00:00:00.000Z",
+          "to": 1.642032E12,
+          "to_as_string": "2022-01-06T00:00:00.000Z",
+          "doc_count": 0,
+          "avg#avgCost": {
+            "value": null
+          },
+          "cardinality#uniqueUsers": {
+            "value": 0
+          }
+        },
+        {
+          "key": "1Wk",
+          "from": 1.6414272E12,
+          "from_as_string": "2022-01-06T00:00:00.000Z",
+          "to": 1.642032E12,
+          "to_as_string": "2022-01-13T00:00:00.000Z",
+          "doc_count": 0,
+          "avg#avgCost": {
+            "value": null
+          },
+          "cardinality#uniqueUsers": {
+            "value": 0
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
* Adds support for typed-key arrays, used in suggest responses.
* Extract Elasticsearch container initialization to a separate class that allows creating multiple ES servers, and also provide a global one. Using the global ES server avoids the overhead of container startup, but must be used with care to avoid conflicting states that may cause state failures.

Along with previous code generation changes, fixes #56, fixes #57, fixes #78, fixes #81, fixes #107