### PR TITLE
[8.0] Make Jackson object mapper available from custom deserializers (#129)

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
@@ -40,10 +40,11 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
     private final ObjectMapper objectMapper;
 
     public JacksonJsonpMapper(ObjectMapper objectMapper) {
-        this.provider = new JacksonJsonProvider();
         this.objectMapper = objectMapper
             .configure(SerializationFeature.INDENT_OUTPUT, false)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        // Creating the json factory from the mapper ensures it will be returned by JsonParser.getCodec()
+        this.provider = new JacksonJsonProvider(this.objectMapper.getFactory());
     }
 
     public JacksonJsonpMapper() {

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/json/jackson/JacksonMapperTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/json/jackson/JacksonMapperTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.elasticsearch.json.jackson;
+
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class JacksonMapperTest extends ModelTestCase {
+
+    @Test
+    public void testCustomDeserializer() {
+        // See https://github.com/elastic/elasticsearch-java/issues/120
+        JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+
+        String json = "{\"_index\":\"foo\",\"_id\":\"1\",\"_source\":{\"model\":\"Foo\",\"age\":42}}";
+
+        Hit<TestData> testDataHit = fromJson(json,
+            Hit.createHitDeserializer(JsonpDeserializer.of(TestData.class)),
+            jsonpMapper
+        );
+        TestData data = testDataHit.source();
+        assertEquals("Foo", data.theModel);
+        assertEquals(42, data.theAge);
+    }
+
+    @JsonDeserialize(using = TestData.TestDeserializer.class)
+    public static class TestData {
+        public String theModel;
+        public int theAge;
+
+        public static class TestDeserializer extends JsonDeserializer<TestData> {
+
+            @Override
+            public TestData deserialize(JsonParser jp, DeserializationContext ctx) throws IOException {
+                JsonNode node = jp.getCodec().readTree(jp);
+
+                TestData res = new TestData();
+                if (node.has("age")) {
+                    res.theAge = node.get("age").asInt();
+                }
+                if (node.has("model")) {
+                    res.theModel = node.get("model").asText();
+                }
+                return res;
+            }
+        }
+    }
+}

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/ModelTestCase.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/ModelTestCase.java
@@ -101,9 +101,14 @@ public abstract class ModelTestCase extends Assert {
     }
 
     protected <T> T fromJson(String json, JsonpDeserializer<T> deserializer) {
+        return fromJson(json, deserializer, mapper);
+    }
+
+    protected <T> T fromJson(String json, JsonpDeserializer<T> deserializer, JsonpMapper mapper) {
         JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
         return deserializer.deserialize(parser, mapper);
     }
+
 
     public static void assertGetterType(Class<?> expected, Class<?> clazz, String name) {
         Method method;


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Make Jackson object mapper available from custom deserializers (#129)