### PR TITLE
Fix jsonb url

### DIFF
--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -6,8 +6,8 @@ Requirements:
 * Java 8 or later.
 * A JSON object mapping library to allow seamless integration of
   your application classes with the Elasticsearch API. The Java client has 
-  support for https://github.com/FasterXML/jackson[Jackson] or a 
-  http://json-b.net/[JSON-B] library like 
+  support for https://github.com/FasterXML/jackson[Jackson] or a
+  https://github.com/eclipse-ee4j/jsonb-api[JSON-B] library like
   https://github.com/eclipse-ee4j/yasson[Eclipse Yasson].
 
 

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -28,7 +28,7 @@ initial feedback and this led to a few breaking changes in this version:
 * all API data types are now supported, and there are no more raw `JsonValue` properties.
 * the supporting JSON framework and transport classes have been refactored and improved.
   However the high level APIs used by applications haven't changed so there should be
-  no of very little impact on existing application code.
+  no or very little impact on existing application code.
 
 This version of the {java-client} supports all {es} APIs are implemented except the
 Vector tile search API and the Find structure API.

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -192,7 +192,7 @@ dependencies {
     api("org.eclipse.parsson:parsson:1.0.0")
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-    // http://json-b.net/
+    // https://github.com/eclipse-ee4j/jsonb-api
     compileOnly("jakarta.json.bind", "jakarta.json.bind-api", "2.0.0")
     testImplementation("jakarta.json.bind", "jakarta.json.bind-api", "2.0.0")
 


### PR DESCRIPTION
Updates the URL to the JSON-B specification. The previous one was abandoned as part of the move from JavaEE to JakartaEE.

Also fixes #148 (typo).