### PR TITLE
Include withJson docs only in correct versions

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -3,6 +3,8 @@
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
+include::_releases.asciidoc[]
+
 :java-client: Java API Client
 :doc-tests: {docdir}/../java-client/src/test/java/co/elastic/clients/documentation
 
@@ -25,7 +27,9 @@ include::installation.asciidoc[]
 include::connecting.asciidoc[]
 include::migrate.asciidoc[]
 include::api-conventions.asciidoc[]
+ifdef::is_main_branch,v8_1_1_released,v7_17_2_released[]
 include::loading-json.asciidoc[]
+endif::is_main_branch,v8_1_1_released,v7_17_2_released[]
 include::javadoc-and-source.asciidoc[]
 
 include::{elasticsearch-root}/docs/java-rest/low-level/index.asciidoc[]

--- a/docs/loading-json.asciidoc
+++ b/docs/loading-json.asciidoc
@@ -1,6 +1,14 @@
 [[loading-json]]
 == Creating API objects from JSON data
 
+ifeval::["{minor-version}" == "7.17"]
+NOTE: This feature was added in version 7.17.2
+endif::[]
+
+ifeval::["{minor-version}" == "8.1"]
+NOTE: This feature was added in version 8.1.1
+endif::[]
+
 A common workflow during application development with Elasticsearch is to use the Kibana Developer Console to interactively prepare and test queries, aggregations, index mappings and other complex API calls. This results in working JSON snippets that you may want to use in your application.
 
 As translating these JSON snippets to Java code can be time-consuming and error-prone, most of the data classes in the {java-client} can be loaded from JSON text: object builders have `withJson()` methods that populate the builder from raw JSON. This also allows you to combine dynamically loaded JSON with programmatic construction of objects.


### PR DESCRIPTION
Only include documentation of the `withJson` feature in versions `8.1.1`+ and `7.1.2`+