### PR TITLE
Add mapping exception with JSON path and location

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonParser.java
+++ b/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonParser.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonLocation;
+import jakarta.json.stream.JsonParser;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public abstract class DelegatingJsonParser implements JsonParser {
+
+    private final JsonParser parser;
+
+    public DelegatingJsonParser(JsonParser parser) {
+        this.parser = parser;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return parser.hasNext();
+    }
+
+    @Override
+    public Event next() {
+        return parser.next();
+    }
+
+    @Override
+    public String getString() {
+        return parser.getString();
+    }
+
+    @Override
+    public boolean isIntegralNumber() {
+        return parser.isIntegralNumber();
+    }
+
+    @Override
+    public int getInt() {
+        return parser.getInt();
+    }
+
+    @Override
+    public long getLong() {
+        return parser.getLong();
+    }
+
+    @Override
+    public BigDecimal getBigDecimal() {
+        return parser.getBigDecimal();
+    }
+
+    @Override
+    public JsonLocation getLocation() {
+        return parser.getLocation();
+    }
+
+    @Override
+    public JsonObject getObject() {
+        return parser.getObject();
+    }
+
+    @Override
+    public JsonValue getValue() {
+        return parser.getValue();
+    }
+
+    @Override
+    public JsonArray getArray() {
+        return parser.getArray();
+    }
+
+    @Override
+    public Stream<JsonValue> getArrayStream() {
+        return parser.getArrayStream();
+    }
+
+    @Override
+    public Stream<Map.Entry<String, JsonValue>> getObjectStream() {
+        return parser.getObjectStream();
+    }
+
+    @Override
+    public Stream<JsonValue> getValueStream() {
+        return parser.getValueStream();
+    }
+
+    @Override
+    public void skipArray() {
+        parser.skipArray();
+    }
+
+    @Override
+    public void skipObject() {
+        parser.skipObject();
+    }
+
+    @Override
+    public void close() {
+        parser.close();
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/json/JsonEnum.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonEnum.java
@@ -85,7 +85,7 @@ public interface JsonEnum extends JsonpSerializable {
         public T deserialize(String value, JsonParser parser) {
             T result = this.lookupTable.get(value);
             if (result == null) {
-                throw new JsonParsingException("Invalid enum '" + value + "'", parser.getLocation());
+                throw new JsonpMappingException("Invalid enum '" + value + "'", parser.getLocation());
             }
             return result;
         }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonLocationImpl.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonLocationImpl.java
@@ -19,43 +19,37 @@
 
 package co.elastic.clients.json;
 
-import jakarta.json.spi.JsonProvider;
-import jakarta.json.stream.JsonGenerator;
-import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonLocation;
 
-import javax.annotation.Nullable;
+class JsonLocationImpl implements JsonLocation {
 
-public abstract class DelegatingJsonpMapper implements JsonpMapper {
+    private final long columnNo;
+    private final long lineNo;
+    private final long offset;
 
-    protected final JsonpMapper mapper;
-
-    public DelegatingJsonpMapper(JsonpMapper mapper) {
-        this.mapper = mapper;
+    JsonLocationImpl(long lineNo, long columnNo, long streamOffset) {
+        this.lineNo = lineNo;
+        this.columnNo = columnNo;
+        this.offset = streamOffset;
     }
 
     @Override
-    public JsonProvider jsonProvider() {
-        return mapper.jsonProvider();
+    public long getLineNumber() {
+        return lineNo;
     }
 
     @Override
-    public <T> T deserialize(JsonParser parser, Class<T> clazz) {
-        return mapper.deserialize(parser, clazz);
+    public long getColumnNumber() {
+        return columnNo;
     }
 
     @Override
-    public <T> void serialize(T value, JsonGenerator generator) {
-        mapper.serialize(value, generator);
+    public long getStreamOffset() {
+        return offset;
     }
 
     @Override
-    public boolean ignoreUnknownFields() {
-        return mapper.ignoreUnknownFields();
-    }
-
-    @Override
-    @Nullable
-    public <T> T attribute(String name) {
-        return mapper.attribute(name);
+    public String toString() {
+        return "(line no=" + lineNo + ", column no=" + columnNo + ", offset=" + offset + ")";
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
@@ -214,6 +214,6 @@ public interface JsonpDeserializer<V> {
     static <K extends JsonEnum, V> JsonpDeserializer<Map<K, V>> enumMapDeserializer(
         JsonpDeserializer<K> keyDeserializer, JsonpDeserializer<V> valueDeserializer
     ) {
-        return new JsonpDeserializerBase.EnumMapDeserializer<K, V>(keyDeserializer, valueDeserializer);
+        return new JsonpDeserializerBase.EnumMapDeserializer<>(keyDeserializer, valueDeserializer);
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpMapperBase.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpMapperBase.java
@@ -55,7 +55,7 @@ public abstract class JsonpMapperBase implements JsonpMapper {
         }
 
         if (clazz == Void.class) {
-            return (JsonpDeserializer<T>)JsonpDeserializerBase.VoidDeserializer.INSTANCE;
+            return (JsonpDeserializer<T>)JsonpDeserializerBase.VOID;
         }
 
         return null;

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpMappingException.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpMappingException.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.stream.JsonLocation;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParsingException;
+
+import java.util.LinkedList;
+import java.util.regex.Pattern;
+
+/**
+ * A mapping exception. The exception message contains the JSON path and location where the problem happened.
+ */
+public class JsonpMappingException extends JsonParsingException {
+    private final LinkedList<Object> path = new LinkedList<>();
+    private Object ref;
+
+    public JsonpMappingException(String message, JsonLocation location) {
+        super(message, location);
+    }
+
+    public JsonpMappingException(String message, Throwable cause, JsonLocation location) {
+        super(message, cause, location);
+    }
+
+    public JsonpMappingException(Throwable cause, JsonLocation location) {
+        super(cause.toString(), cause, location);
+    }
+
+    private static final Pattern identifier = Pattern.compile("[_a-zA-Z][_a-zA-Z0-9]*");
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder("Error deserializing");
+        if (ref != null) {
+            sb.append(' ');
+            String className = ref.getClass().getName();
+            if (className.endsWith("$Builder")) {
+                sb.append(className, 0, className.length() - "$Builder".length());
+            } else {
+                sb.append(className);
+            }
+        }
+        sb.append(": ").append(super.getMessage());
+
+        if (!path.isEmpty()) {
+            sb.append(" (JSON path: ");
+            path(sb);
+            sb.append(") ");
+        }
+
+        sb.append(getLocation());
+        return sb.toString();
+    }
+
+    /**
+     * The JSON path where this exception happened.
+     */
+    public String path() {
+        StringBuilder sb = new StringBuilder();
+        path(sb);
+        return sb.toString();
+    }
+
+    // Package-visible for testing
+    void path(StringBuilder sb) {
+        String sep = "";
+        for (Object item : path) {
+            if (item instanceof Integer) {
+                sb.append("[").append(((Integer) item).intValue()).append("]");
+            } else {
+                String str = item.toString();
+                if (identifier.matcher(str).matches()) {
+                    sb.append(sep).append(item);
+                } else {
+                    sb.append("['").append(str).append("']");
+                }
+            }
+            sep = ".";
+        }
+    }
+
+    public JsonpMappingException prepend(Object ref, String name) {
+        return prepend0(ref, name);
+    }
+
+    public JsonpMappingException prepend(Object ref, int idx) {
+        return prepend0(ref, idx);
+    }
+
+    private JsonpMappingException prepend0 (Object ref, Object pathItem) {
+        if (pathItem != null) {
+            this.path.addFirst(pathItem);
+        }
+        // Keep the deepest object reference in the JSON hierarchy
+        if (this.ref == null) {
+            this.ref = ref;
+        }
+        return this;
+    }
+
+    public static JsonpMappingException from(Throwable cause, Object ref, String name, JsonParser parser) {
+        return from0(cause, ref, name, parser);
+    }
+
+    public static JsonpMappingException from(Throwable cause, int index, JsonParser parser) {
+        return from0(cause, null, index, parser);
+    }
+
+    private static JsonpMappingException from0(Throwable cause, Object ref, Object pathItem, JsonParser parser) {
+        JsonpMappingException jme;
+
+        if (cause instanceof JsonpMappingException) {
+            jme = (JsonpMappingException)cause;
+        } else {
+            jme = new JsonpMappingException(cause, parser.getLocation());
+        }
+
+        return jme.prepend0(ref, pathItem);
+    }
+}
+

--- a/java-client/src/main/java/co/elastic/clients/json/NamedDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/NamedDeserializer.java
@@ -21,7 +21,6 @@ package co.elastic.clients.json;
 
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParser.Event;
-import jakarta.json.stream.JsonParsingException;
 
 import java.util.EnumSet;
 
@@ -60,7 +59,7 @@ public class NamedDeserializer<T> implements JsonpDeserializer<T> {
     public T deserialize(JsonParser parser, JsonpMapper mapper) {
         JsonpDeserializer<T> deserializer = mapper.attribute(name);
         if (deserializer == null) {
-            throw new JsonParsingException("Missing deserializer for generic type: " + name, parser.getLocation());
+            throw new JsonpMappingException("Missing deserializer for generic type: " + name, parser.getLocation());
         }
         return deserializer.deserialize(parser, mapper);
     }
@@ -69,7 +68,7 @@ public class NamedDeserializer<T> implements JsonpDeserializer<T> {
     public T deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
         JsonpDeserializer<T> deserializer = mapper.attribute(name);
         if (deserializer == null) {
-            throw new JsonParsingException("Missing deserializer for generic type: " + name, parser.getLocation());
+            throw new JsonpMappingException("Missing deserializer for generic type: " + name, parser.getLocation());
         }
         return deserializer.deserialize(parser, mapper, event);
     }

--- a/java-client/src/main/java/co/elastic/clients/json/UnionDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/UnionDeserializer.java
@@ -23,7 +23,6 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParser.Event;
-import jakarta.json.stream.JsonParsingException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -102,7 +101,7 @@ public class UnionDeserializer<Union, Kind, Member> implements JsonpDeserializer
                     exception = ex;
                 }
             }
-            throw new JsonParsingException("Couldn't find a suitable union member deserializer", exception, parser.getLocation());
+            throw JsonpMappingException.from(exception, null, null, parser);
         }
     }
 
@@ -286,7 +285,7 @@ public class UnionDeserializer<Union, Kind, Member> implements JsonpDeserializer
         }
 
         if (member == null) {
-            throw new JsonParsingException("Cannot determine what union member to deserialize", parser.getLocation());
+            throw new JsonpMappingException("Cannot determine what union member to deserialize", parser.getLocation());
         }
 
         return member.deserialize(parser, mapper, event, buildFn);

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/containers/SomeUnionTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/containers/SomeUnionTest.java
@@ -79,7 +79,6 @@ public class SomeUnionTest extends ModelTestCase {
             SomeUnion c = SomeUnion._DESERIALIZER.deserialize(parser, new JsonbJsonpMapper());
         });
 
-        assertEquals("Property 'type' not found", e.getMessage());
+        assertTrue(e.getMessage().contains("Property 'type' not found"));
     }
-
 }

--- a/java-client/src/test/java/co/elastic/clients/json/JsonpMappingExceptionTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpMappingExceptionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+public class JsonpMappingExceptionTest extends ModelTestCase {
+
+    @Test
+    public void testObjectAndArrayPath() {
+
+        String json = "{" +
+            "  \"took\" : 9," +
+            "  \"timed_out\" : false," +
+            "  \"_shards\" : {" +
+            "    \"total\" : 1," +
+            "    \"successful\" : 1," +
+            "    \"skipped\" : 0," +
+            "    \"failed\" : 0" +
+            "  }," +
+            "  \"hits\" : {" +
+            "    \"total\" : {" +
+            "      \"value\" : 1," +
+            "      \"relation\" : \"eq\"" +
+            "    }," +
+            "    \"max_score\" : 1.0," +
+            "    \"hits\" : [" +
+            "      {" +
+            "        \"_index\" : \"test\"," +
+            "        \"_id\" : \"8aSerXUBs1w7Wkuj31zd\"," +
+            "        \"_score\" : \"1.0\"," +
+            "        \"_source\" : {" +
+            "          \"foo\" : \"bar\"" +
+            "        }" +
+            "      }," +
+            "      {" +
+            "        \"_index\" : \"test\"," +
+            "        \"_id\" : \"8aSerXUBs1w7Wkuj31zd\"," +
+            "        \"_score\" : \"abc\"," + // <====== error here
+            "        \"_source\" : {" +
+            "          \"foo\" : \"bar\"" +
+            "        }" +
+            "      }" +
+            "    ]" +
+            "  }" +
+            "}";
+
+        JsonpMappingException e = assertThrows(JsonpMappingException.class, () -> {
+            // withJson() will read values of the generic parameter type as JsonData
+            SearchResponse<JsonData> r = SearchResponse.searchResponseOf(b -> b
+                .withJson(new StringReader(json))
+            );
+        });
+
+        assertTrue(e.getMessage().contains("Error deserializing co.elastic.clients.elasticsearch.core.search.Hit"));
+        assertTrue(e.getMessage().contains("java.lang.NumberFormatException"));
+
+        // Also checks array index in path
+        assertEquals("hits.hits[1]._score", e.path());
+    }
+
+    @Test
+    public void testLookAhead() {
+
+        String json =
+            "{" +
+            "  \"properties\": { " +
+            "    \"foo-bar\": {" +
+            "        \"type\": \"text\"," +
+            "        \"baz\": false" +
+            "    }" +
+            "  }" +
+            "}";
+
+        // Error deserializing co.elastic.clients.elasticsearch._types.mapping.TextProperty:
+        // Unknown field 'baz' (JSON path: properties['foo-bar'].baz) (in object at line no=1, column no=36, offset=35)
+
+        JsonpMappingException e = assertThrows(JsonpMappingException.class, () -> {
+            fromJson(json, TypeMapping.class);
+        });
+
+        // Check escaping of non identifier path elements and path from map elements
+        assertEquals("properties['foo-bar'].baz", e.path());
+
+        String msg = e.getMessage();
+        assertTrue(msg.contains("Unknown field 'baz'"));
+        // Check look ahead position (see JsonpUtils.lookAheadFieldValue)
+        assertTrue(msg.contains("(in object at line no="));
+    }
+}


### PR DESCRIPTION
Adds a new `JsonpMappingException` that is thrown by the JSON mapping framework instead of a raw `JsonParsingException`. It provides detailed information on the context where the error happened: object class, JSON path and location in the input.

Example error message: `Error deserializing co.elastic.clients.elasticsearch.core.search.Hit: java.lang.NumberFormatException: For input string: "abc" (JSON path: hits.hits[1]._score) (line no=1, column no=491, offset=490)`