### PR TITLE
[DOCS] Add 7.17.3 to conditional attributes

### DIFF
--- a/docs/_releases.asciidoc
+++ b/docs/_releases.asciidoc
@@ -1,8 +1,9 @@
 // Versions for the 7.1.x releases
 :v7_17_0_released:
 :v7_17_1_released:
+:v7_17_2_released:
 
 // Handle version bump in the docs build
-ifeval::["{version}" == "7.17.2"]
-:v7_17_2_released:
+ifeval::["{version}" == "7.17.3"]
+:v7_17_3_released:
 endif::[]


### PR DESCRIPTION
This PR addresses the following documentation build errors:

> 11:24:06 INFO:build_docs:ERROR building Java Client version 7.17
> ...
> 11:24:06 INFO:build_docs:
11:24:06 INFO:build_docs:asciidoctor: WARNING: invalid reference: loading-json
11:24:06 INFO:build_docs:
11:24:06 INFO:build_docs:Child exited with 255 at lib/ES/Util.pm line 666.