### PR TITLE
Limit the size of toString() to a configurable limit

### DIFF
--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpUtilsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpUtilsTest.java
@@ -84,6 +84,29 @@ public class JsonpUtilsTest extends Assert {
     }
 
     @Test
+    public void testLargeObjectToString() {
+        // Build a large string
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1001; i++) {
+            sb.append("0123456789");
+        }
+
+        String text = sb.toString();
+        assertEquals(10010, text.length());
+
+        Hit<String> hit = Hit.of(h -> h
+            .source(text)
+            .index("idx")
+            .id("id1")
+        );
+
+        String toString = hit.toString();
+
+        assertEquals(10003, toString.length());
+        assertTrue(toString.endsWith("..."));
+    }
+
+    @Test
     public void testSerializeDoubleOrNull() {
         // ---- Double values
         assertEquals("{\"a\":null}", orNullHelper(g -> JsonpUtils.serializeDoubleOrNull(g, Double.NaN, Double.NaN)));


### PR DESCRIPTION
Follow-up to #269.

Elasticsearch API objects can be quite large. In order to avoid using too much memory when calling `toString()` on API objects (and filling up the logs if they end up there), the resulting string is limited, with a default limit of 10k characters. This limit can be changed globally.