### PR TITLE
Handle enums that have true/false values as booleans

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Refresh.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Refresh.java
@@ -26,6 +26,8 @@ package co.elastic.clients.elasticsearch._types;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import jakarta.json.stream.JsonGenerator;
 
 /**
  *
@@ -52,5 +54,17 @@ public enum Refresh implements JsonEnum {
 		return this.jsonValue;
 	}
 
-	public static final JsonEnum.Deserializer<Refresh> _DESERIALIZER = new JsonEnum.Deserializer<>(Refresh.values());
+	@Override
+	public void serialize(JsonGenerator generator, JsonpMapper params) {
+		if (this == Refresh.True) {
+			generator.write(true);
+		} else if (this == Refresh.False) {
+			generator.write(false);
+		} else {
+			generator.write(jsonValue());
+		}
+	}
+
+	public static final JsonEnum.Deserializer<Refresh> _DESERIALIZER = new JsonEnum.Deserializer.AllowingBooleans<>(
+			Refresh.values());
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/mapping/DynamicMapping.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/mapping/DynamicMapping.java
@@ -26,6 +26,8 @@ package co.elastic.clients.elasticsearch._types.mapping;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import jakarta.json.stream.JsonGenerator;
 
 /**
  *
@@ -55,6 +57,17 @@ public enum DynamicMapping implements JsonEnum {
 		return this.jsonValue;
 	}
 
-	public static final JsonEnum.Deserializer<DynamicMapping> _DESERIALIZER = new JsonEnum.Deserializer<>(
+	@Override
+	public void serialize(JsonGenerator generator, JsonpMapper params) {
+		if (this == DynamicMapping.True) {
+			generator.write(true);
+		} else if (this == DynamicMapping.False) {
+			generator.write(false);
+		} else {
+			generator.write(jsonValue());
+		}
+	}
+
+	public static final JsonEnum.Deserializer<DynamicMapping> _DESERIALIZER = new JsonEnum.Deserializer.AllowingBooleans<>(
 			DynamicMapping.values());
 }

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/EnumTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/EnumTest.java
@@ -20,13 +20,13 @@
 package co.elastic.clients.elasticsearch.model;
 
 import co.elastic.clients.elasticsearch._types.Bytes;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.mapping.GeoOrientation;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 
-public class EnumTest extends Assert {
+public class EnumTest extends ModelTestCase {
 
     @Test
     public void testSimpleEnum() {
@@ -42,5 +42,15 @@ public class EnumTest extends Assert {
         Arrays.asList("right", "RIGHT", "counterclockwise", "ccw").forEach(alias -> {
             assertEquals(GeoOrientation.Right, GeoOrientation._DESERIALIZER.parse(alias));
         });
+    }
+
+    @Test
+    public void testBooleanEnum() {
+        // Quoted value
+        assertEquals(Refresh.WaitFor, checkJsonRoundtrip(Refresh.WaitFor, "\"wait_for\""));
+
+        // Unquoted boolean values
+        assertEquals(Refresh.True, checkJsonRoundtrip(Refresh.True, "true"));
+        assertEquals(Refresh.False, checkJsonRoundtrip(Refresh.False, "false"));
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/EnumTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/EnumTest.java
@@ -52,5 +52,9 @@ public class EnumTest extends ModelTestCase {
         // Unquoted boolean values
         assertEquals(Refresh.True, checkJsonRoundtrip(Refresh.True, "true"));
         assertEquals(Refresh.False, checkJsonRoundtrip(Refresh.False, "false"));
+
+        // true/false as strings
+        assertEquals(Refresh.True, fromJson("\"true\"", Refresh.class));
+        assertEquals(Refresh.False, fromJson("\"false\"", Refresh.class));
     }
 }


### PR DESCRIPTION
Add a specific JSON (de)serialization for enums that have `true` and `false` values. These used to be boolean properties that evolved into enums to handle more than two states.

Elasticsearch accepts their JSON boolean representation in requests and some tools/products expect them to be serialized as JSON booleans.

Fixes #139