### PR TITLE
Improve toString()

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/GeoBounds.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/GeoBounds.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -165,6 +166,11 @@ public class GeoBounds implements TaggedUnion<GeoBounds.Kind, Object>, JsonpSeri
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GeoBounds> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/GeoHashPrecision.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/GeoHashPrecision.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -151,6 +152,11 @@ public class GeoHashPrecision implements TaggedUnion<GeoHashPrecision.Kind, Obje
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GeoHashPrecision> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/GeoLocation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/GeoLocation.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -186,6 +187,11 @@ public class GeoLocation implements TaggedUnion<GeoLocation.Kind, Object>, Jsonp
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GeoLocation> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/RequestBase.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/RequestBase.java
@@ -53,7 +53,7 @@ public abstract class RequestBase {
 	@Override
 	public String toString() {
 
-		StringBuilder sb = new StringBuilder();
+		StringBuilder sb = new StringBuilder(this.getClass().getSimpleName()).append(": ");
 
 		try {
 			@SuppressWarnings("unchecked")

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Script.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Script.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -123,6 +124,11 @@ public class Script implements TaggedUnion<Script.Kind, Object>, JsonpSerializab
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Script> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Slices.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Slices.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -144,6 +145,11 @@ public class Slices implements TaggedUnion<Slices.Kind, Object>, JsonpSerializab
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Slices> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/SortOptions.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/SortOptions.java
@@ -225,6 +225,11 @@ public class SortOptions implements TaggedUnion<SortOptions.Kind, Object>, Jsonp
 		}
 	}
 
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
+	}
+
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SortOptions> {
 		private Kind _kind;
 		private Object _value;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Time.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Time.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -153,6 +154,11 @@ public class Time implements TaggedUnion<Time.Kind, Object>, JsonpSerializable {
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Time> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Transform.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Transform.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -190,6 +191,11 @@ public class Transform implements TaggedUnion<Transform.Kind, Object>, JsonpSeri
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Transform> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/WaitForActiveShards.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/WaitForActiveShards.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -144,6 +145,11 @@ public class WaitForActiveShards implements TaggedUnion<WaitForActiveShards.Kind
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<WaitForActiveShards> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregate.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
@@ -1383,6 +1384,11 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Aggregate> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregation.java
@@ -30,6 +30,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -1579,6 +1580,11 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Buckets.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Buckets.java
@@ -158,6 +158,11 @@ public class Buckets<TBucket> implements TaggedUnion<Buckets.Kind, Object>, Json
 
 	}
 
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
+	}
+
 	public static class Builder<TBucket> extends ObjectBuilderBase implements ObjectBuilder<Buckets<TBucket>> {
 		private Kind _kind;
 		private Object _value;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/BucketsPath.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/BucketsPath.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -174,6 +175,11 @@ public class BucketsPath implements TaggedUnion<BucketsPath.Kind, Object>, Jsonp
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<BucketsPath> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/CategorizeTextAnalyzer.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/CategorizeTextAnalyzer.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -133,6 +134,11 @@ public class CategorizeTextAnalyzer implements TaggedUnion<CategorizeTextAnalyze
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CategorizeTextAnalyzer> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/FieldDateMath.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/FieldDateMath.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -152,6 +153,11 @@ public class FieldDateMath implements TaggedUnion<FieldDateMath.Kind, Object>, J
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FieldDateMath> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/InferenceConfig.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/InferenceConfig.java
@@ -30,6 +30,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -162,6 +163,11 @@ public class InferenceConfig implements TaggedUnion<InferenceConfig.Kind, Object
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<InferenceConfig> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/MovingAverageAggregation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/MovingAverageAggregation.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -211,6 +212,11 @@ public class MovingAverageAggregation
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Percentiles.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Percentiles.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -150,6 +151,11 @@ public class Percentiles implements TaggedUnion<Percentiles.Kind, Object>, Jsonp
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Percentiles> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/TermsExclude.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/TermsExclude.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -156,6 +157,11 @@ public class TermsExclude implements TaggedUnion<TermsExclude.Kind, Object>, Jso
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TermsExclude> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/TermsInclude.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/TermsInclude.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -160,6 +161,11 @@ public class TermsInclude implements TaggedUnion<TermsInclude.Kind, Object>, Jso
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TermsInclude> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Analyzer.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Analyzer.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -377,6 +378,11 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Analyzer> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/CharFilter.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/CharFilter.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -132,6 +133,11 @@ public class CharFilter implements TaggedUnion<CharFilter.Kind, Object>, JsonpSe
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CharFilter> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/CharFilterDefinition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/CharFilterDefinition.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -213,6 +214,11 @@ public class CharFilterDefinition
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Normalizer.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Normalizer.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -152,6 +153,11 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Normalizer> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenFilter.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenFilter.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -132,6 +133,11 @@ public class TokenFilter implements TaggedUnion<TokenFilter.Kind, Object>, Jsonp
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TokenFilter> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenFilterDefinition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenFilterDefinition.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -1041,6 +1042,11 @@ public class TokenFilterDefinition
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Tokenizer.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Tokenizer.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -132,6 +133,11 @@ public class Tokenizer implements TaggedUnion<Tokenizer.Kind, Object>, JsonpSeri
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Tokenizer> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenizerDefinition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenizerDefinition.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -383,6 +384,11 @@ public class TokenizerDefinition
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/mapping/Property.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/mapping/Property.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -990,6 +991,11 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Property> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/FunctionScore.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/FunctionScore.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -294,6 +295,11 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<FunctionScore> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Intervals.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Intervals.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -244,6 +245,11 @@ public class Intervals implements TaggedUnion<Intervals.Kind, Object>, Intervals
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Intervals> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsFilter.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsFilter.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -296,6 +297,11 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Object
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<IntervalsFilter> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsQuery.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -258,6 +259,11 @@ public class IntervalsQuery extends QueryBase
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends QueryBase.AbstractBuilder<Builder> implements ObjectBuilder<IntervalsQuery> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Like.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Like.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -137,6 +138,11 @@ public class Like implements TaggedUnion<Like.Kind, Object>, JsonpSerializable {
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Like> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/PinnedQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/PinnedQuery.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -201,6 +202,11 @@ public class PinnedQuery extends QueryBase
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends QueryBase.AbstractBuilder<Builder> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
@@ -30,6 +30,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -1188,6 +1189,11 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Query> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SimpleQueryStringFlags.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SimpleQueryStringFlags.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -150,6 +151,11 @@ public class SimpleQueryStringFlags implements TaggedUnion<SimpleQueryStringFlag
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SimpleQueryStringFlags> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -312,6 +313,11 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, Object>, JsonpSeri
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SpanQuery> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/TermsQueryField.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/TermsQueryField.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -139,6 +140,11 @@ public class TermsQueryField implements TaggedUnion<TermsQueryField.Kind, Object
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TermsQueryField> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/remote_info/ClusterRemoteInfo.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/remote_info/ClusterRemoteInfo.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -154,6 +155,11 @@ public class ClusterRemoteInfo
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ClusterRemoteInfo> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/bulk/BulkOperation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/bulk/BulkOperation.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.NdJsonpSerializable;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -204,6 +205,11 @@ public class BulkOperation implements TaggedUnion<BulkOperation.Kind, Object>, N
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<BulkOperation> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/mget/MultiGetResponseItem.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/mget/MultiGetResponseItem.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.JsonpSerializer;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -132,6 +133,11 @@ public class MultiGetResponseItem<TDocument>
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder<TDocument> extends ObjectBuilderBase

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/msearch/MultiSearchResponseItem.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/msearch/MultiSearchResponseItem.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.JsonpSerializer;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -132,6 +133,11 @@ public class MultiSearchResponseItem<TDocument>
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder<TDocument> extends ObjectBuilderBase

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Context.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Context.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -140,6 +141,11 @@ public class Context implements TaggedUnion<Context.Kind, Object>, JsonpSerializ
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Context> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/FieldSuggester.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/FieldSuggester.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -237,6 +238,11 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SmoothingModel.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SmoothingModel.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -180,6 +181,11 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Object>,
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SmoothingModel> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SourceConfig.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SourceConfig.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -135,6 +136,11 @@ public class SourceConfig implements TaggedUnion<SourceConfig.Kind, Object>, Jso
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SourceConfig> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SourceConfigParam.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SourceConfigParam.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -160,6 +161,11 @@ public class SourceConfigParam implements TaggedUnion<SourceConfigParam.Kind, Ob
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SourceConfigParam> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Suggestion.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Suggestion.java
@@ -30,6 +30,7 @@ import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.JsonpSerializer;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
@@ -176,6 +177,11 @@ public class Suggestion<TDocument> implements TaggedUnion<Suggestion.Kind, Sugge
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder<TDocument> extends ObjectBuilderBase implements ObjectBuilder<Suggestion<TDocument>> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/TrackHits.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/TrackHits.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -154,6 +155,11 @@ public class TrackHits implements TaggedUnion<TrackHits.Kind, Object>, JsonpSeri
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TrackHits> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/explain_lifecycle/LifecycleExplain.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/explain_lifecycle/LifecycleExplain.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -154,6 +155,11 @@ public class LifecycleExplain
 
 		mapper.serialize(_value, generator);
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<LifecycleExplain> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/modify_data_stream/Action.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/modify_data_stream/Action.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -162,6 +163,11 @@ public class Action implements TaggedUnion<Action.Kind, Object>, JsonpSerializab
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Action> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/update_aliases/Action.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/update_aliases/Action.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -179,6 +180,11 @@ public class Action implements TaggedUnion<Action.Kind, Object>, JsonpSerializab
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Action> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/InferenceConfig.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/InferenceConfig.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -158,6 +159,11 @@ public class InferenceConfig implements TaggedUnion<InferenceConfig.Kind, Object
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<InferenceConfig> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/Processor.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/Processor.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -771,6 +772,11 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Processor> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/CategorizationAnalyzer.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/CategorizationAnalyzer.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -133,6 +134,11 @@ public class CategorizationAnalyzer implements TaggedUnion<CategorizationAnalyze
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CategorizationAnalyzer> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysis.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysis.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -180,6 +181,11 @@ public class DataframeAnalysis implements TaggedUnion<DataframeAnalysis.Kind, Ob
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<DataframeAnalysis> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysisFeatureProcessor.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysisFeatureProcessor.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -226,6 +227,11 @@ public class DataframeAnalysisFeatureProcessor
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalyticsStats.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalyticsStats.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -182,6 +183,11 @@ public class DataframeAnalyticsStats implements TaggedUnion<DataframeAnalyticsSt
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeEvaluation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeEvaluation.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -180,6 +181,11 @@ public class DataframeEvaluation implements TaggedUnion<DataframeEvaluation.Kind
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigCreate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigCreate.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -297,6 +298,11 @@ public class InferenceConfigCreate implements TaggedUnion<InferenceConfigCreate.
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigUpdate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigUpdate.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -296,6 +297,11 @@ public class InferenceConfigUpdate implements TaggedUnion<InferenceConfigUpdate.
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/TokenizationConfig.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/TokenizationConfig.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -180,6 +181,11 @@ public class TokenizationConfig implements TaggedUnion<TokenizationConfig.Kind, 
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/put_trained_model/Preprocessor.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/put_trained_model/Preprocessor.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -182,6 +183,11 @@ public class Preprocessor implements TaggedUnion<Preprocessor.Kind, Object>, Jso
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Preprocessor> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodeReloadResult.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodeReloadResult.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -124,6 +125,11 @@ public class NodeReloadResult implements TaggedUnion<NodeReloadResult.Kind, Obje
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NodeReloadResult> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/FieldRule.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/FieldRule.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -255,6 +256,11 @@ public class FieldRule implements TaggedUnion<FieldRule.Kind, Object>, RoleMappi
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<FieldRule> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/RoleMappingRule.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/RoleMappingRule.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -230,6 +231,11 @@ public class RoleMappingRule
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<RoleMappingRule> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/TaskInfos.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/TaskInfos.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -150,6 +151,11 @@ public class TaskInfos implements TaggedUnion<TaskInfos.Kind, Object>, JsonpSeri
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TaskInfos> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PivotGroupBy.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PivotGroupBy.java
@@ -32,6 +32,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -202,6 +203,11 @@ public class PivotGroupBy implements TaggedUnion<PivotGroupBy.Kind, Object>, Jso
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PivotGroupBy> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/RetentionPolicy.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/RetentionPolicy.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -141,6 +142,11 @@ public class RetentionPolicy implements TaggedUnion<RetentionPolicy.Kind, Object
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<RetentionPolicy> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/Sync.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/Sync.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -139,6 +140,11 @@ public class Sync implements TaggedUnion<Sync.Kind, Object>, JsonpSerializable {
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Sync> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Condition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Condition.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -217,6 +218,11 @@ public class Condition implements TaggedUnion<Condition.Kind, Object>, JsonpSeri
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Condition> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/EmailAttachment.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/EmailAttachment.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -179,6 +180,11 @@ public class EmailAttachment implements TaggedUnion<EmailAttachment.Kind, Object
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<EmailAttachment> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Input.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Input.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -212,6 +213,11 @@ public class Input implements TaggedUnion<Input.Kind, Object>, JsonpSerializable
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Input> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Schedule.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Schedule.java
@@ -29,6 +29,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -300,6 +301,11 @@ public class Schedule implements TaggedUnion<Schedule.Kind, Object>, TriggerVari
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Schedule> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/TimeOfDay.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/TimeOfDay.java
@@ -27,6 +27,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.json.UnionDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -132,6 +133,11 @@ public class TimeOfDay implements TaggedUnion<TimeOfDay.Kind, Object>, JsonpSeri
 			}
 		}
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TimeOfDay> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Trigger.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Trigger.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -139,6 +140,11 @@ public class Trigger implements TaggedUnion<Trigger.Kind, Object>, JsonpSerializ
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Trigger> {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/TriggerEvent.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/TriggerEvent.java
@@ -28,6 +28,7 @@ import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpSerializable;
+import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
@@ -141,6 +142,11 @@ public class TriggerEvent implements TaggedUnion<TriggerEvent.Kind, Object>, Jso
 
 		generator.writeEnd();
 
+	}
+
+	@Override
+	public String toString() {
+		return JsonpUtils.toString(this);
 	}
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<TriggerEvent> {

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpUtilsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpUtilsTest.java
@@ -73,7 +73,7 @@ public class JsonpUtilsTest extends Assert {
             .index("idx")
             .id("id1")
         );
-        assertEquals("{\"_index\":\"idx\",\"_id\":\"id1\",\"_source\":\"Some user data\"}", hit.toString());
+        assertEquals("Hit: {\"_index\":\"idx\",\"_id\":\"id1\",\"_source\":\"Some user data\"}", hit.toString());
     }
 
     private static class SomeUserData {
@@ -102,7 +102,8 @@ public class JsonpUtilsTest extends Assert {
 
         String toString = hit.toString();
 
-        assertEquals(10003, toString.length());
+        assertEquals(10000 + "Hit: ".length() + "...".length(), toString.length());
+        assertTrue(toString.startsWith("Hit: "));
         assertTrue(toString.endsWith("..."));
     }
 

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/EndpointTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/EndpointTest.java
@@ -78,16 +78,16 @@ public class EndpointTest extends Assert {
     @Test
     public void testRequestToString() {
         // Simple path, no parameters, no body
-        assertEquals("GET /", InfoRequest._INSTANCE.toString());
+        assertEquals("InfoRequest: GET /", InfoRequest._INSTANCE.toString());
 
         // Complex path, parameters, no body
         assertEquals(
-            "HEAD /idx/_doc/id1?preference=foo&refresh=true",
+            "ExistsRequest: HEAD /idx/_doc/id1?preference=foo&refresh=true",
             ExistsRequest.of(b -> b.index("idx").id("id1").preference("foo").refresh(true)).toString()
         );
 
         assertEquals(
-            "POST /idx/_search?typed_keys=true {\"size\":10}",
+            "SearchRequest: POST /idx/_search?typed_keys=true {\"size\":10}",
             SearchRequest.of(s -> s.index("idx").size(10)).toString()
         );
     }

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/spec_issues/SpecIssuesTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/spec_issues/SpecIssuesTest.java
@@ -19,11 +19,14 @@
 
 package co.elastic.clients.elasticsearch.spec_issues;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.ElasticsearchTestServer;
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
 import co.elastic.clients.elasticsearch.cluster.ClusterStatsResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.indices.GetFieldMappingRequest;
+import co.elastic.clients.elasticsearch.indices.GetFieldMappingResponse;
 import co.elastic.clients.elasticsearch.model.ModelTestCase;
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -38,6 +41,17 @@ import java.io.InputStream;
  * Depending on the feedback provided, this may involve either loading a JSON file or sending requests to an ES server.
  */
 public class SpecIssuesTest extends ModelTestCase {
+
+    @Test
+    public void i066_multiFieldMapping() throws Exception {
+        ElasticsearchClient client = ElasticsearchTestServer.global().client();
+
+        GetFieldMappingRequest gfmRequest =  new GetFieldMappingRequest.Builder()
+            .index("*")
+            .fields("*")
+            .build();
+        GetFieldMappingResponse gfmResponse = client.indices().getFieldMapping(gfmRequest);
+    }
 
     @Test
     public void i0107_rangeBucketKey() {


### PR DESCRIPTION
Improve the `toString()` method on API objects:
* the class name is prepended to the JSON representation of the class, to allow identifying it, and also avoir misuse of `toString()` as a way to serialize objects to JSON
* add static setter and getter in replacement of the (now deprecated) `JsonpUtils.MAX_TO_STRING_LENGTH`
* implement `toString()` for tagged unions (i.e. variant) objects