### PR TITLE
Boolean response endpoints can have a request body

### DIFF
--- a/java-client/src/test/java/co/elastic/clients/transport/endpoints/BooleanEndpointTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/endpoints/BooleanEndpointTest.java
@@ -19,32 +19,16 @@
 
 package co.elastic.clients.transport.endpoints;
 
-import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.elasticsearch.core.ExistsRequest;
+import co.elastic.clients.elasticsearch.logstash.PutPipelineRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-import java.util.function.Function;
+public class BooleanEndpointTest extends Assertions {
 
-public class BooleanEndpoint<RequestT> extends SimpleEndpoint<RequestT, BooleanResponse> {
-
-    public BooleanEndpoint(
-        String id,
-        Function<RequestT, String> method,
-        Function<RequestT, String> requestUrl,
-        Function<RequestT,
-            Map<String, String>> queryParameters,
-        Function<RequestT, Map<String, String>> headers,
-        boolean hasRequestBody,
-        JsonpDeserializer<?> responseParser // always null
-    ) {
-        super(id, method, requestUrl, queryParameters, headers, hasRequestBody, null);
-    }
-
-    @Override
-    public boolean isError(int statusCode) {
-        return statusCode >= 500;
-    }
-
-    public boolean getResult(int statusCode) {
-        return statusCode < 400;
+    @Test
+    public void testHasRequestBody() {
+        assertFalse(ExistsRequest._ENDPOINT.hasRequestBody());
+        assertTrue(PutPipelineRequest._ENDPOINT.hasRequestBody());
     }
 }


### PR DESCRIPTION
Fixes `BooleanEndpoint` that incorrectly assumed that requests do not have a body, while `LogstashClient.putPipeline()` and `SecurityClient.samlCompleteLogout()` do have bodies.

Reported in https://discuss.elastic.co/t/java-client-put-logstash-pipeline/309345
