### PR TITLE
Add support for plugin-defined custom components in union types

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/SortOptions.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/SortOptions.java
@@ -58,9 +58,6 @@ public class SortOptions implements TaggedUnion<SortOptions.Kind, Object>, Jsonp
 
 	/**
 	 * {@link SortOptions} variant kinds.
-	 */
-	/**
-	 * {@link SortOptions} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#_types.SortOptions">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Transform.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/Transform.java
@@ -55,9 +55,6 @@ public class Transform implements TaggedUnion<Transform.Kind, Object>, JsonpSeri
 
 	/**
 	 * {@link Transform} variant kinds.
-	 */
-	/**
-	 * {@link Transform} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#_types.TransformContainer">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregate.java
@@ -24,6 +24,7 @@
 package co.elastic.clients.elasticsearch._types.aggregations;
 
 import co.elastic.clients.json.ExternallyTaggedUnion;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -34,9 +35,10 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import co.elastic.clients.util.ObjectBuilderBase;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import jakarta.json.stream.JsonGenerator;
+import java.lang.Object;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -52,11 +54,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 
-public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>, JsonpSerializable {
+public class Aggregate implements OpenTaggedUnion<Aggregate.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link Aggregate} variant kinds.
-	 */
 	/**
 	 * {@link Aggregate} variant kinds.
 	 * 
@@ -198,6 +197,9 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 
 		WeightedAvg("weighted_avg"),
 
+		/** A custom {@code Aggregate} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -213,7 +215,7 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 	}
 
 	private final Kind _kind;
-	private final AggregateVariant _value;
+	private final Object _value;
 
 	@Override
 	public final Kind _kind() {
@@ -221,7 +223,7 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 	}
 
 	@Override
-	public final AggregateVariant _get() {
+	public final Object _get() {
 		return _value;
 	}
 
@@ -229,6 +231,7 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 
 		this._kind = ApiTypeHelper.requireNonNull(value._aggregateKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -236,11 +239,22 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
 	public static Aggregate of(Function<Builder, ObjectBuilder<Aggregate>> fn) {
 		return fn.apply(new Builder()).build();
+	}
+
+	/**
+	 * Build a custom plugin-defined {@code Aggregate}, given its kind and some JSON
+	 * data
+	 */
+	public Aggregate(String kind, JsonData value) {
+		this._kind = Kind._Custom;
+		this._value = value;
+		this._customKind = kind;
 	}
 
 	/**
@@ -1379,6 +1393,35 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 		return TaggedUnionUtils.get(this, Kind.WeightedAvg);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code Aggregate} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
@@ -1393,7 +1436,8 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 
 	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<Aggregate> {
 		private Kind _kind;
-		private AggregateVariant _value;
+		private Object _value;
+		private String _customKind;
 
 		public ObjectBuilder<Aggregate> adjacencyMatrix(AdjacencyMatrixAggregate v) {
 			this._kind = Kind.AdjacencyMatrix;
@@ -2109,6 +2153,22 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 			return this.weightedAvg(fn.apply(new WeightedAvgAggregate.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code Aggregate} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code Aggregate}. It is converted
+		 *            internally to {@link JsonData}.
+		 */
+		public ObjectBuilder<Aggregate> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public Aggregate build() {
 			_checkSingleUse();
 			return new Aggregate(this);
@@ -2187,7 +2247,7 @@ public class Aggregate implements TaggedUnion<Aggregate.Kind, AggregateVariant>,
 		deserializers.put("variable_width_histogram", VariableWidthHistogramAggregate._DESERIALIZER);
 		deserializers.put("weighted_avg", WeightedAvgAggregate._DESERIALIZER);
 
-		_TYPED_KEYS_DESERIALIZER = new ExternallyTaggedUnion.Deserializer<>(deserializers,
-				(name, value) -> new Aggregate(value)).typedKeys();
+		_TYPED_KEYS_DESERIALIZER = new ExternallyTaggedUnion.Deserializer<>(deserializers, Aggregate::new,
+				Aggregate::new).typedKeys();
 	}
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregation.java
@@ -35,7 +35,7 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
@@ -55,11 +55,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, JsonpSerializable {
+public class Aggregation implements OpenTaggedUnion<Aggregation.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link Aggregation} variant kinds.
-	 */
 	/**
 	 * {@link Aggregation} variant kinds.
 	 * 
@@ -215,6 +212,9 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 
 		VariableWidthHistogram("variable_width_histogram"),
 
+		/** A custom {@code Aggregation} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -250,6 +250,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 
 		this._kind = ApiTypeHelper.requireNonNull(value._aggregationKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 		this.aggregations = null;
 		this.meta = null;
@@ -260,6 +261,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 		this.aggregations = ApiTypeHelper.unmodifiable(builder.aggregations);
 		this.meta = ApiTypeHelper.unmodifiable(builder.meta);
@@ -1544,6 +1546,35 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 		return TaggedUnionUtils.get(this, Kind.VariableWidthHistogram);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code Aggregation} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
@@ -1573,7 +1604,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 
 		}
 
-		generator.writeKey(_kind.jsonValue());
+		generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
 		if (_value instanceof JsonpSerializable) {
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
@@ -1590,6 +1621,7 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> {
 		private Kind _kind;
 		private Object _value;
+		private String _customKind;
 
 		@Nullable
 		private Map<String, Aggregation> aggregations;
@@ -2438,6 +2470,22 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 			return this.variableWidthHistogram(fn.apply(new VariableWidthHistogramAggregation.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code Aggregation} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code Aggregation}. It is converted
+		 *            internally to {@link JsonData}.
+		 */
+		public ContainerBuilder _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return new ContainerBuilder();
+		}
+
 		protected Aggregation build() {
 			_checkSingleUse();
 			return new Aggregation(this);
@@ -2588,6 +2636,11 @@ public class Aggregation implements TaggedUnion<Aggregation.Kind, Object>, Jsonp
 		op.add(Builder::weightedAvg, WeightedAverageAggregation._DESERIALIZER, "weighted_avg");
 		op.add(Builder::variableWidthHistogram, VariableWidthHistogramAggregation._DESERIALIZER,
 				"variable_width_histogram");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/InferenceConfig.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/InferenceConfig.java
@@ -57,9 +57,6 @@ public class InferenceConfig implements TaggedUnion<InferenceConfig.Kind, Object
 
 	/**
 	 * {@link InferenceConfig} variant kinds.
-	 */
-	/**
-	 * {@link InferenceConfig} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_types.aggregations.InferenceConfigContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/MovingAverageAggregation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/MovingAverageAggregation.java
@@ -57,9 +57,6 @@ public class MovingAverageAggregation
 
 	/**
 	 * {@link MovingAverageAggregation} variant kinds.
-	 */
-	/**
-	 * {@link MovingAverageAggregation} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_types.aggregations.MovingAverageAggregation">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Analyzer.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Analyzer.java
@@ -23,6 +23,7 @@
 
 package co.elastic.clients.elasticsearch._types.analysis;
 
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -33,10 +34,11 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
+import java.lang.Object;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -49,11 +51,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, JsonpSerializable {
+public class Analyzer implements OpenTaggedUnion<Analyzer.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link Analyzer} variant kinds.
-	 */
 	/**
 	 * {@link Analyzer} variant kinds.
 	 * 
@@ -90,6 +89,9 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 
 		Whitespace("whitespace"),
 
+		/** A custom {@code Analyzer} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -105,7 +107,7 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 	}
 
 	private final Kind _kind;
-	private final AnalyzerVariant _value;
+	private final Object _value;
 
 	@Override
 	public final Kind _kind() {
@@ -113,7 +115,7 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 	}
 
 	@Override
-	public final AnalyzerVariant _get() {
+	public final Object _get() {
 		return _value;
 	}
 
@@ -121,6 +123,7 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 
 		this._kind = ApiTypeHelper.requireNonNull(value._analyzerKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -128,11 +131,22 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
 	public static Analyzer of(Function<Builder, ObjectBuilder<Analyzer>> fn) {
 		return fn.apply(new Builder()).build();
+	}
+
+	/**
+	 * Build a custom plugin-defined {@code Analyzer}, given its kind and some JSON
+	 * data
+	 */
+	public Analyzer(String kind, JsonData value) {
+		this._kind = Kind._Custom;
+		this._value = value;
+		this._customKind = kind;
 	}
 
 	/**
@@ -373,6 +387,35 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 		return TaggedUnionUtils.get(this, Kind.Whitespace);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code Analyzer} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
@@ -387,7 +430,8 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Analyzer> {
 		private Kind _kind;
-		private AnalyzerVariant _value;
+		private Object _value;
+		private String _customKind;
 
 		@Override
 		protected Builder self() {
@@ -539,6 +583,22 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 			return this.whitespace(fn.apply(new WhitespaceAnalyzer.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code Analyzer} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code Analyzer}. It is converted
+		 *            internally to {@link JsonData}.
+		 */
+		public ObjectBuilder<Analyzer> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public Analyzer build() {
 			_checkSingleUse();
 			return new Analyzer(this);
@@ -562,6 +622,11 @@ public class Analyzer implements TaggedUnion<Analyzer.Kind, AnalyzerVariant>, Js
 		op.add(Builder::standard, StandardAnalyzer._DESERIALIZER, "standard");
 		op.add(Builder::stop, StopAnalyzer._DESERIALIZER, "stop");
 		op.add(Builder::whitespace, WhitespaceAnalyzer._DESERIALIZER, "whitespace");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 		op.setTypeProperty("type", null);
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/CharFilterDefinition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/CharFilterDefinition.java
@@ -23,6 +23,7 @@
 
 package co.elastic.clients.elasticsearch._types.analysis;
 
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -33,10 +34,11 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
+import java.lang.Object;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -50,14 +52,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class CharFilterDefinition
-		implements
-			TaggedUnion<CharFilterDefinition.Kind, CharFilterDefinitionVariant>,
-			JsonpSerializable {
+public class CharFilterDefinition implements OpenTaggedUnion<CharFilterDefinition.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link CharFilterDefinition} variant kinds.
-	 */
 	/**
 	 * {@link CharFilterDefinition} variant kinds.
 	 * 
@@ -77,6 +73,9 @@ public class CharFilterDefinition
 
 		PatternReplace("pattern_replace"),
 
+		/** A custom {@code CharFilterDefinition} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -92,7 +91,7 @@ public class CharFilterDefinition
 	}
 
 	private final Kind _kind;
-	private final CharFilterDefinitionVariant _value;
+	private final Object _value;
 
 	@Override
 	public final Kind _kind() {
@@ -100,7 +99,7 @@ public class CharFilterDefinition
 	}
 
 	@Override
-	public final CharFilterDefinitionVariant _get() {
+	public final Object _get() {
 		return _value;
 	}
 
@@ -108,6 +107,7 @@ public class CharFilterDefinition
 
 		this._kind = ApiTypeHelper.requireNonNull(value._charFilterDefinitionKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -115,11 +115,22 @@ public class CharFilterDefinition
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
 	public static CharFilterDefinition of(Function<Builder, ObjectBuilder<CharFilterDefinition>> fn) {
 		return fn.apply(new Builder()).build();
+	}
+
+	/**
+	 * Build a custom plugin-defined {@code CharFilterDefinition}, given its kind
+	 * and some JSON data
+	 */
+	public CharFilterDefinition(String kind, JsonData value) {
+		this._kind = Kind._Custom;
+		this._value = value;
+		this._customKind = kind;
 	}
 
 	/**
@@ -209,6 +220,35 @@ public class CharFilterDefinition
 		return TaggedUnionUtils.get(this, Kind.PatternReplace);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code CharFilterDefinition} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
@@ -225,7 +265,8 @@ public class CharFilterDefinition
 			implements
 				ObjectBuilder<CharFilterDefinition> {
 		private Kind _kind;
-		private CharFilterDefinitionVariant _value;
+		private Object _value;
+		private String _customKind;
 
 		@Override
 		protected Builder self() {
@@ -286,6 +327,22 @@ public class CharFilterDefinition
 			return this.patternReplace(fn.apply(new PatternReplaceCharFilter.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code CharFilterDefinition} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code CharFilterDefinition}. It is
+		 *            converted internally to {@link JsonData}.
+		 */
+		public ObjectBuilder<CharFilterDefinition> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public CharFilterDefinition build() {
 			_checkSingleUse();
 			return new CharFilterDefinition(this);
@@ -301,6 +358,11 @@ public class CharFilterDefinition
 				"kuromoji_iteration_mark");
 		op.add(Builder::mapping, MappingCharFilter._DESERIALIZER, "mapping");
 		op.add(Builder::patternReplace, PatternReplaceCharFilter._DESERIALIZER, "pattern_replace");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 		op.setTypeProperty("type", null);
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Normalizer.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/Normalizer.java
@@ -56,9 +56,6 @@ public class Normalizer implements TaggedUnion<Normalizer.Kind, NormalizerVarian
 
 	/**
 	 * {@link Normalizer} variant kinds.
-	 */
-	/**
-	 * {@link Normalizer} variant kinds.
 	 * 
 	 * @see <a href="../../doc-files/api-spec.html#_types.analysis.Normalizer">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenFilterDefinition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenFilterDefinition.java
@@ -23,6 +23,7 @@
 
 package co.elastic.clients.elasticsearch._types.analysis;
 
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -33,10 +34,11 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
+import java.lang.Object;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -50,14 +52,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class TokenFilterDefinition
-		implements
-			TaggedUnion<TokenFilterDefinition.Kind, TokenFilterDefinitionVariant>,
-			JsonpSerializable {
+public class TokenFilterDefinition implements OpenTaggedUnion<TokenFilterDefinition.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link TokenFilterDefinition} variant kinds.
-	 */
 	/**
 	 * {@link TokenFilterDefinition} variant kinds.
 	 * 
@@ -163,6 +159,9 @@ public class TokenFilterDefinition
 
 		WordDelimiter("word_delimiter"),
 
+		/** A custom {@code TokenFilterDefinition} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -178,7 +177,7 @@ public class TokenFilterDefinition
 	}
 
 	private final Kind _kind;
-	private final TokenFilterDefinitionVariant _value;
+	private final Object _value;
 
 	@Override
 	public final Kind _kind() {
@@ -186,7 +185,7 @@ public class TokenFilterDefinition
 	}
 
 	@Override
-	public final TokenFilterDefinitionVariant _get() {
+	public final Object _get() {
 		return _value;
 	}
 
@@ -194,6 +193,7 @@ public class TokenFilterDefinition
 
 		this._kind = ApiTypeHelper.requireNonNull(value._tokenFilterDefinitionKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -201,11 +201,22 @@ public class TokenFilterDefinition
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
 	public static TokenFilterDefinition of(Function<Builder, ObjectBuilder<TokenFilterDefinition>> fn) {
 		return fn.apply(new Builder()).build();
+	}
+
+	/**
+	 * Build a custom plugin-defined {@code TokenFilterDefinition}, given its kind
+	 * and some JSON data
+	 */
+	public TokenFilterDefinition(String kind, JsonData value) {
+		this._kind = Kind._Custom;
+		this._value = value;
+		this._customKind = kind;
 	}
 
 	/**
@@ -1037,6 +1048,35 @@ public class TokenFilterDefinition
 		return TaggedUnionUtils.get(this, Kind.WordDelimiter);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code TokenFilterDefinition} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
@@ -1053,7 +1093,8 @@ public class TokenFilterDefinition
 			implements
 				ObjectBuilder<TokenFilterDefinition> {
 		private Kind _kind;
-		private TokenFilterDefinitionVariant _value;
+		private Object _value;
+		private String _customKind;
 
 		@Override
 		protected Builder self() {
@@ -1587,6 +1628,22 @@ public class TokenFilterDefinition
 			return this.wordDelimiter(fn.apply(new WordDelimiterTokenFilter.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code TokenFilterDefinition} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code TokenFilterDefinition}. It is
+		 *            converted internally to {@link JsonData}.
+		 */
+		public ObjectBuilder<TokenFilterDefinition> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public TokenFilterDefinition build() {
 			_checkSingleUse();
 			return new TokenFilterDefinition(this);
@@ -1646,6 +1703,11 @@ public class TokenFilterDefinition
 		op.add(Builder::uppercase, UppercaseTokenFilter._DESERIALIZER, "uppercase");
 		op.add(Builder::wordDelimiterGraph, WordDelimiterGraphTokenFilter._DESERIALIZER, "word_delimiter_graph");
 		op.add(Builder::wordDelimiter, WordDelimiterTokenFilter._DESERIALIZER, "word_delimiter");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 		op.setTypeProperty("type", null);
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenizerDefinition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/analysis/TokenizerDefinition.java
@@ -23,6 +23,7 @@
 
 package co.elastic.clients.elasticsearch._types.analysis;
 
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -33,10 +34,11 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
+import java.lang.Object;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -50,14 +52,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class TokenizerDefinition
-		implements
-			TaggedUnion<TokenizerDefinition.Kind, TokenizerDefinitionVariant>,
-			JsonpSerializable {
+public class TokenizerDefinition implements OpenTaggedUnion<TokenizerDefinition.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link TokenizerDefinition} variant kinds.
-	 */
 	/**
 	 * {@link TokenizerDefinition} variant kinds.
 	 * 
@@ -95,6 +91,9 @@ public class TokenizerDefinition
 
 		Whitespace("whitespace"),
 
+		/** A custom {@code TokenizerDefinition} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -110,7 +109,7 @@ public class TokenizerDefinition
 	}
 
 	private final Kind _kind;
-	private final TokenizerDefinitionVariant _value;
+	private final Object _value;
 
 	@Override
 	public final Kind _kind() {
@@ -118,7 +117,7 @@ public class TokenizerDefinition
 	}
 
 	@Override
-	public final TokenizerDefinitionVariant _get() {
+	public final Object _get() {
 		return _value;
 	}
 
@@ -126,6 +125,7 @@ public class TokenizerDefinition
 
 		this._kind = ApiTypeHelper.requireNonNull(value._tokenizerDefinitionKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -133,11 +133,22 @@ public class TokenizerDefinition
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
 	public static TokenizerDefinition of(Function<Builder, ObjectBuilder<TokenizerDefinition>> fn) {
 		return fn.apply(new Builder()).build();
+	}
+
+	/**
+	 * Build a custom plugin-defined {@code TokenizerDefinition}, given its kind and
+	 * some JSON data
+	 */
+	public TokenizerDefinition(String kind, JsonData value) {
+		this._kind = Kind._Custom;
+		this._value = value;
+		this._customKind = kind;
 	}
 
 	/**
@@ -379,6 +390,35 @@ public class TokenizerDefinition
 		return TaggedUnionUtils.get(this, Kind.Whitespace);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code TokenizerDefinition} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
@@ -395,7 +435,8 @@ public class TokenizerDefinition
 			implements
 				ObjectBuilder<TokenizerDefinition> {
 		private Kind _kind;
-		private TokenizerDefinitionVariant _value;
+		private Object _value;
+		private String _customKind;
 
 		@Override
 		protected Builder self() {
@@ -555,6 +596,22 @@ public class TokenizerDefinition
 			return this.whitespace(fn.apply(new WhitespaceTokenizer.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code TokenizerDefinition} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code TokenizerDefinition}. It is
+		 *            converted internally to {@link JsonData}.
+		 */
+		public ObjectBuilder<TokenizerDefinition> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public TokenizerDefinition build() {
 			_checkSingleUse();
 			return new TokenizerDefinition(this);
@@ -578,6 +635,11 @@ public class TokenizerDefinition
 		op.add(Builder::standard, StandardTokenizer._DESERIALIZER, "standard");
 		op.add(Builder::uaxUrlEmail, UaxEmailUrlTokenizer._DESERIALIZER, "uax_url_email");
 		op.add(Builder::whitespace, WhitespaceTokenizer._DESERIALIZER, "whitespace");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 		op.setTypeProperty("type", null);
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/mapping/Property.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/mapping/Property.java
@@ -23,6 +23,7 @@
 
 package co.elastic.clients.elasticsearch._types.mapping;
 
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -33,10 +34,11 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
+import java.lang.Object;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -49,11 +51,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, JsonpSerializable {
+public class Property implements OpenTaggedUnion<Property.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link Property} variant kinds.
-	 */
 	/**
 	 * {@link Property} variant kinds.
 	 * 
@@ -154,6 +153,9 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 
 		Wildcard("wildcard"),
 
+		/** A custom {@code Property} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -169,7 +171,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 	}
 
 	private final Kind _kind;
-	private final PropertyVariant _value;
+	private final Object _value;
 
 	@Override
 	public final Kind _kind() {
@@ -177,7 +179,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 	}
 
 	@Override
-	public final PropertyVariant _get() {
+	public final Object _get() {
 		return _value;
 	}
 
@@ -185,6 +187,7 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 
 		this._kind = ApiTypeHelper.requireNonNull(value._propertyKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -192,11 +195,22 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
 	public static Property of(Function<Builder, ObjectBuilder<Property>> fn) {
 		return fn.apply(new Builder()).build();
+	}
+
+	/**
+	 * Build a custom plugin-defined {@code Property}, given its kind and some JSON
+	 * data
+	 */
+	public Property(String kind, JsonData value) {
+		this._kind = Kind._Custom;
+		this._value = value;
+		this._customKind = kind;
 	}
 
 	/**
@@ -986,6 +1000,35 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 		return TaggedUnionUtils.get(this, Kind.Wildcard);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code Property} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
@@ -1000,7 +1043,8 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Property> {
 		private Kind _kind;
-		private PropertyVariant _value;
+		private Object _value;
+		private String _customKind;
 
 		@Override
 		protected Builder self() {
@@ -1499,6 +1543,22 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 			return this.wildcard(fn.apply(new WildcardProperty.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code Property} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code Property}. It is converted
+		 *            internally to {@link JsonData}.
+		 */
+		public ObjectBuilder<Property> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public Property build() {
 			_checkSingleUse();
 			return new Property(this);
@@ -1554,6 +1614,11 @@ public class Property implements TaggedUnion<Property.Kind, PropertyVariant>, Js
 		op.add(Builder::unsignedLong, UnsignedLongNumberProperty._DESERIALIZER, "unsigned_long");
 		op.add(Builder::version, VersionProperty._DESERIALIZER, "version");
 		op.add(Builder::wildcard, WildcardProperty._DESERIALIZER, "wildcard");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 		op.setTypeProperty("type", "object");
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/FunctionScore.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/FunctionScore.java
@@ -56,9 +56,6 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
 
 	/**
 	 * {@link FunctionScore} variant kinds.
-	 */
-	/**
-	 * {@link FunctionScore} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_types.query_dsl.FunctionScoreContainer">API
@@ -120,6 +117,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
 		if (value != null) {
 			this._kind = ApiTypeHelper.requireNonNull(value._functionScoreKind(), this, "<variant kind>");
 			this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+
 		} else {
 			this._kind = null;
 			this._value = null;
@@ -135,6 +133,7 @@ public class FunctionScore implements TaggedUnion<FunctionScore.Kind, Object>, J
 		if (builder._value != null) {
 			this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 			this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+
 		} else {
 			this._kind = null;
 			this._value = null;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Intervals.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Intervals.java
@@ -55,9 +55,6 @@ public class Intervals implements TaggedUnion<Intervals.Kind, Object>, Intervals
 
 	/**
 	 * {@link Intervals} variant kinds.
-	 */
-	/**
-	 * {@link Intervals} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_types.query_dsl.IntervalsContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsFilter.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsFilter.java
@@ -56,9 +56,6 @@ public class IntervalsFilter implements TaggedUnion<IntervalsFilter.Kind, Object
 
 	/**
 	 * {@link IntervalsFilter} variant kinds.
-	 */
-	/**
-	 * {@link IntervalsFilter} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_types.query_dsl.IntervalsFilter">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/IntervalsQuery.java
@@ -59,9 +59,6 @@ public class IntervalsQuery extends QueryBase
 
 	/**
 	 * {@link IntervalsQuery} variant kinds.
-	 */
-	/**
-	 * {@link IntervalsQuery} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_types.query_dsl.IntervalsQuery">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/PinnedQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/PinnedQuery.java
@@ -59,9 +59,6 @@ public class PinnedQuery extends QueryBase
 
 	/**
 	 * {@link PinnedQuery} variant kinds.
-	 */
-	/**
-	 * {@link PinnedQuery} variant kinds.
 	 * 
 	 * @see <a href="../../doc-files/api-spec.html#_types.query_dsl.PinnedQuery">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
@@ -25,6 +25,7 @@ package co.elastic.clients.elasticsearch._types.query_dsl;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.AggregationVariant;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -35,7 +36,7 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
@@ -56,11 +57,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVariant, JsonpSerializable {
+public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVariant, JsonpSerializable {
 
-	/**
-	 * {@link Query} variant kinds.
-	 */
 	/**
 	 * {@link Query} variant kinds.
 	 * 
@@ -180,6 +178,9 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 
 		Type("type"),
 
+		/** A custom {@code Query} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -219,6 +220,7 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 
 		this._kind = ApiTypeHelper.requireNonNull(value._queryKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -226,6 +228,7 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
@@ -1176,13 +1179,42 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 		return TaggedUnionUtils.get(this, Kind.Type);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code Query} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
 		generator.writeStartObject();
 
-		generator.writeKey(_kind.jsonValue());
+		generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
 		if (_value instanceof JsonpSerializable) {
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
@@ -1199,6 +1231,7 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Query> {
 		private Kind _kind;
 		private Object _value;
+		private String _customKind;
 
 		@Override
 		protected Builder self() {
@@ -1771,6 +1804,22 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 			return this.type(fn.apply(new TypeQuery.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code Query} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code Query}. It is converted internally
+		 *            to {@link JsonData}.
+		 */
+		public ObjectBuilder<Query> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public Query build() {
 			_checkSingleUse();
 			return new Query(this);
@@ -1835,6 +1884,11 @@ public class Query implements TaggedUnion<Query.Kind, Object>, AggregationVarian
 		op.add(Builder::wildcard, WildcardQuery._DESERIALIZER, "wildcard");
 		op.add(Builder::wrapper, WrapperQuery._DESERIALIZER, "wrapper");
 		op.add(Builder::type, TypeQuery._DESERIALIZER, "type");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
@@ -54,9 +54,6 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, Object>, JsonpSeri
 
 	/**
 	 * {@link SpanQuery} variant kinds.
-	 */
-	/**
-	 * {@link SpanQuery} variant kinds.
 	 * 
 	 * @see <a href="../../doc-files/api-spec.html#_types.query_dsl.SpanQuery">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/PutAutoscalingPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/PutAutoscalingPolicyRequest.java
@@ -166,8 +166,8 @@ public class PutAutoscalingPolicyRequest extends RequestBase implements JsonpSer
 
 		JsonpDeserializer<AutoscalingPolicy> valueDeserializer = AutoscalingPolicy._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().policy(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.policy(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AliasesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AliasesResponse.java
@@ -160,8 +160,8 @@ public class AliasesResponse implements JsonpSerializable {
 		JsonpDeserializer<List<AliasesRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(AliasesRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AllocationResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AllocationResponse.java
@@ -162,8 +162,8 @@ public class AllocationResponse implements JsonpSerializable {
 		JsonpDeserializer<List<AllocationRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(AllocationRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ComponentTemplatesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ComponentTemplatesResponse.java
@@ -163,8 +163,8 @@ public class ComponentTemplatesResponse implements JsonpSerializable {
 		JsonpDeserializer<List<ComponentTemplate>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(ComponentTemplate._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CountResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CountResponse.java
@@ -160,8 +160,8 @@ public class CountResponse implements JsonpSerializable {
 		JsonpDeserializer<List<CountRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(CountRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/FielddataResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/FielddataResponse.java
@@ -160,8 +160,8 @@ public class FielddataResponse implements JsonpSerializable {
 		JsonpDeserializer<List<FielddataRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(FielddataRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HealthResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HealthResponse.java
@@ -160,8 +160,8 @@ public class HealthResponse implements JsonpSerializable {
 		JsonpDeserializer<List<HealthRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(HealthRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HelpResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HelpResponse.java
@@ -160,8 +160,8 @@ public class HelpResponse implements JsonpSerializable {
 		JsonpDeserializer<List<HelpRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(HelpRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/IndicesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/IndicesResponse.java
@@ -160,8 +160,8 @@ public class IndicesResponse implements JsonpSerializable {
 		JsonpDeserializer<List<IndicesRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(IndicesRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MasterResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MasterResponse.java
@@ -160,8 +160,8 @@ public class MasterResponse implements JsonpSerializable {
 		JsonpDeserializer<List<MasterRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(MasterRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDataFrameAnalyticsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDataFrameAnalyticsResponse.java
@@ -164,8 +164,8 @@ public class MlDataFrameAnalyticsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<DataFrameAnalyticsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(DataFrameAnalyticsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDatafeedsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDatafeedsResponse.java
@@ -162,8 +162,8 @@ public class MlDatafeedsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<DatafeedsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(DatafeedsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlJobsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlJobsResponse.java
@@ -160,8 +160,8 @@ public class MlJobsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<JobsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(JobsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlTrainedModelsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlTrainedModelsResponse.java
@@ -162,8 +162,8 @@ public class MlTrainedModelsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<TrainedModelsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(TrainedModelsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodeattrsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodeattrsResponse.java
@@ -160,8 +160,8 @@ public class NodeattrsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<NodeAttributesRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(NodeAttributesRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodesResponse.java
@@ -160,8 +160,8 @@ public class NodesResponse implements JsonpSerializable {
 		JsonpDeserializer<List<NodesRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(NodesRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PendingTasksResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PendingTasksResponse.java
@@ -162,8 +162,8 @@ public class PendingTasksResponse implements JsonpSerializable {
 		JsonpDeserializer<List<PendingTasksRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(PendingTasksRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PluginsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PluginsResponse.java
@@ -160,8 +160,8 @@ public class PluginsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<PluginsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(PluginsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RecoveryResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RecoveryResponse.java
@@ -160,8 +160,8 @@ public class RecoveryResponse implements JsonpSerializable {
 		JsonpDeserializer<List<RecoveryRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(RecoveryRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RepositoriesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RepositoriesResponse.java
@@ -162,8 +162,8 @@ public class RepositoriesResponse implements JsonpSerializable {
 		JsonpDeserializer<List<RepositoriesRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(RepositoriesRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SegmentsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SegmentsResponse.java
@@ -160,8 +160,8 @@ public class SegmentsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<SegmentsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(SegmentsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ShardsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ShardsResponse.java
@@ -160,8 +160,8 @@ public class ShardsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<ShardsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(ShardsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SnapshotsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SnapshotsResponse.java
@@ -160,8 +160,8 @@ public class SnapshotsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<SnapshotsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(SnapshotsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TasksResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TasksResponse.java
@@ -160,8 +160,8 @@ public class TasksResponse implements JsonpSerializable {
 		JsonpDeserializer<List<TasksRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(TasksRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TemplatesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TemplatesResponse.java
@@ -160,8 +160,8 @@ public class TemplatesResponse implements JsonpSerializable {
 		JsonpDeserializer<List<TemplatesRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(TemplatesRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ThreadPoolResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ThreadPoolResponse.java
@@ -162,8 +162,8 @@ public class ThreadPoolResponse implements JsonpSerializable {
 		JsonpDeserializer<List<ThreadPoolRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(ThreadPoolRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TransformsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TransformsResponse.java
@@ -162,8 +162,8 @@ public class TransformsResponse implements JsonpSerializable {
 		JsonpDeserializer<List<TransformsRecord>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(TransformsRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RemoteInfoResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RemoteInfoResponse.java
@@ -173,8 +173,8 @@ public class RemoteInfoResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, ClusterRemoteInfo>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(ClusterRemoteInfo._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/StateResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/StateResponse.java
@@ -131,8 +131,8 @@ public class StateResponse implements JsonpSerializable {
 
 		JsonpDeserializer<JsonData> valueDeserializer = JsonData._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/remote_info/ClusterRemoteInfo.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/remote_info/ClusterRemoteInfo.java
@@ -57,9 +57,6 @@ public class ClusterRemoteInfo
 
 	/**
 	 * {@link ClusterRemoteInfo} variant kinds.
-	 */
-	/**
-	 * {@link ClusterRemoteInfo} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#cluster.remote_info.ClusterRemoteInfo">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
@@ -445,8 +445,9 @@ public class CreateRequest<TDocument> extends RequestBase implements JsonpSerial
 
 		JsonpDeserializer<TDocument> valueDeserializer = tDocumentDeserializer;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper) -> new Builder<TDocument>()
-				.document(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
+				(parser, mapper, event) -> new Builder<TDocument>()
+						.document(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetSourceResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetSourceResponse.java
@@ -160,8 +160,9 @@ public class GetSourceResponse<TDocument> implements JsonpSerializable {
 
 		JsonpDeserializer<TDocument> valueDeserializer = tDocumentDeserializer;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper) -> new Builder<TDocument>()
-				.valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
+				(parser, mapper, event) -> new Builder<TDocument>()
+						.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
@@ -563,8 +563,9 @@ public class IndexRequest<TDocument> extends RequestBase implements JsonpSeriali
 
 		JsonpDeserializer<TDocument> valueDeserializer = tDocumentDeserializer;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper) -> new Builder<TDocument>()
-				.document(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
+				(parser, mapper, event) -> new Builder<TDocument>()
+						.document(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/bulk/BulkOperation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/bulk/BulkOperation.java
@@ -56,9 +56,6 @@ public class BulkOperation implements TaggedUnion<BulkOperation.Kind, Object>, N
 
 	/**
 	 * {@link BulkOperation} variant kinds.
-	 */
-	/**
-	 * {@link BulkOperation} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_global.bulk.OperationContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/FieldSuggester.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/FieldSuggester.java
@@ -23,6 +23,7 @@
 
 package co.elastic.clients.elasticsearch.core.search;
 
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -33,7 +34,7 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
@@ -52,11 +53,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>, JsonpSerializable {
+public class FieldSuggester implements OpenTaggedUnion<FieldSuggester.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link FieldSuggester} variant kinds.
-	 */
 	/**
 	 * {@link FieldSuggester} variant kinds.
 	 * 
@@ -71,6 +69,9 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 		Phrase("phrase"),
 
 		Term("term"),
+
+		/** A custom {@code FieldSuggester} defined by a plugin */
+		_Custom(null)
 
 		;
 
@@ -112,6 +113,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 
 		this._kind = ApiTypeHelper.requireNonNull(value._fieldSuggesterKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 		this.prefix = null;
 		this.regex = null;
@@ -123,6 +125,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 		this.prefix = builder.prefix;
 		this.regex = builder.regex;
@@ -209,6 +212,35 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 		return TaggedUnionUtils.get(this, Kind.Term);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code FieldSuggester} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
@@ -231,7 +263,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 
 		}
 
-		generator.writeKey(_kind.jsonValue());
+		generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
 		if (_value instanceof JsonpSerializable) {
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
@@ -248,6 +280,7 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> {
 		private Kind _kind;
 		private Object _value;
+		private String _customKind;
 
 		@Nullable
 		private String prefix;
@@ -317,6 +350,22 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 			return this.term(fn.apply(new TermSuggester.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code FieldSuggester} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code FieldSuggester}. It is converted
+		 *            internally to {@link JsonData}.
+		 */
+		public ContainerBuilder _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return new ContainerBuilder();
+		}
+
 		protected FieldSuggester build() {
 			_checkSingleUse();
 			return new FieldSuggester(this);
@@ -362,6 +411,11 @@ public class FieldSuggester implements TaggedUnion<FieldSuggester.Kind, Object>,
 		op.add(Builder::prefix, JsonpDeserializer.stringDeserializer(), "prefix");
 		op.add(Builder::regex, JsonpDeserializer.stringDeserializer(), "regex");
 		op.add(Builder::text, JsonpDeserializer.stringDeserializer(), "text");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SmoothingModel.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/SmoothingModel.java
@@ -55,9 +55,6 @@ public class SmoothingModel implements TaggedUnion<SmoothingModel.Kind, Object>,
 
 	/**
 	 * {@link SmoothingModel} variant kinds.
-	 */
-	/**
-	 * {@link SmoothingModel} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_global.search._types.SmoothingModelContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Suggestion.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Suggestion.java
@@ -57,9 +57,6 @@ public class Suggestion<TDocument> implements TaggedUnion<Suggestion.Kind, Sugge
 
 	/**
 	 * {@link Suggestion} variant kinds.
-	 */
-	/**
-	 * {@link Suggestion} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#_global.search._types.Suggest">API
@@ -238,7 +235,7 @@ public class Suggestion<TDocument> implements TaggedUnion<Suggestion.Kind, Sugge
 		deserializers.put("term", TermSuggest._DESERIALIZER);
 
 		return new ExternallyTaggedUnion.Deserializer<Suggestion<TDocument>, SuggestionVariant>(deserializers,
-				(name, value) -> new Suggestion<>(value)).typedKeys();
+				Suggestion::new).typedKeys();
 	};
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetLifecycleResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetLifecycleResponse.java
@@ -172,8 +172,8 @@ public class GetLifecycleResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Lifecycle>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(Lifecycle._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/explain_lifecycle/LifecycleExplain.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/explain_lifecycle/LifecycleExplain.java
@@ -57,9 +57,6 @@ public class LifecycleExplain
 
 	/**
 	 * {@link LifecycleExplain} variant kinds.
-	 */
-	/**
-	 * {@link LifecycleExplain} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#ilm.explain_lifecycle.LifecycleExplain">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DiskUsageResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DiskUsageResponse.java
@@ -131,8 +131,8 @@ public class DiskUsageResponse implements JsonpSerializable {
 
 		JsonpDeserializer<JsonData> valueDeserializer = JsonData._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetAliasResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetAliasResponse.java
@@ -170,8 +170,8 @@ public class GetAliasResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, IndexAliases>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(IndexAliases._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetFieldMappingResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetFieldMappingResponse.java
@@ -174,8 +174,8 @@ public class GetFieldMappingResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, TypeFieldMappings>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(TypeFieldMappings._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexResponse.java
@@ -169,8 +169,8 @@ public class GetIndexResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, IndexState>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(IndexState._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndicesSettingsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndicesSettingsResponse.java
@@ -171,8 +171,8 @@ public class GetIndicesSettingsResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, IndexState>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(IndexState._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetMappingResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetMappingResponse.java
@@ -173,8 +173,8 @@ public class GetMappingResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, IndexMappingRecord>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(IndexMappingRecord._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetTemplateResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetTemplateResponse.java
@@ -171,8 +171,8 @@ public class GetTemplateResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, TemplateMapping>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(TemplateMapping._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PromoteDataStreamResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PromoteDataStreamResponse.java
@@ -134,8 +134,8 @@ public class PromoteDataStreamResponse implements JsonpSerializable {
 
 		JsonpDeserializer<JsonData> valueDeserializer = JsonData._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndicesSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndicesSettingsRequest.java
@@ -418,8 +418,8 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 
 		JsonpDeserializer<IndexSettings> valueDeserializer = IndexSettings._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().settings(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.settings(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RecoveryResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RecoveryResponse.java
@@ -170,8 +170,8 @@ public class RecoveryResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, RecoveryStatus>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(RecoveryStatus._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateTemplateRequest.java
@@ -248,8 +248,8 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 
 		JsonpDeserializer<IndexTemplate> valueDeserializer = IndexTemplate._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().template(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.template(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/modify_data_stream/Action.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/modify_data_stream/Action.java
@@ -55,9 +55,6 @@ public class Action implements TaggedUnion<Action.Kind, Object>, JsonpSerializab
 
 	/**
 	 * {@link Action} variant kinds.
-	 */
-	/**
-	 * {@link Action} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#indices.modify_data_stream.Action">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/update_aliases/Action.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/update_aliases/Action.java
@@ -55,9 +55,6 @@ public class Action implements TaggedUnion<Action.Kind, Object>, JsonpSerializab
 
 	/**
 	 * {@link Action} variant kinds.
-	 */
-	/**
-	 * {@link Action} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#indices.update_aliases.Action">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GetPipelineResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GetPipelineResponse.java
@@ -171,8 +171,8 @@ public class GetPipelineResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Pipeline>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(Pipeline._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/InferenceConfig.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/InferenceConfig.java
@@ -54,9 +54,6 @@ public class InferenceConfig implements TaggedUnion<InferenceConfig.Kind, Object
 
 	/**
 	 * {@link InferenceConfig} variant kinds.
-	 */
-	/**
-	 * {@link InferenceConfig} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#ingest._types.InferenceConfig">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/Processor.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/Processor.java
@@ -24,6 +24,7 @@
 package co.elastic.clients.elasticsearch.ingest;
 
 import co.elastic.clients.elasticsearch._types.Script;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonEnum;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -34,7 +35,7 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.TaggedUnion;
+import co.elastic.clients.util.OpenTaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
@@ -52,11 +53,8 @@ import javax.annotation.Nullable;
  *      specification</a>
  */
 @JsonpDeserializable
-public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSerializable {
+public class Processor implements OpenTaggedUnion<Processor.Kind, Object>, JsonpSerializable {
 
-	/**
-	 * {@link Processor} variant kinds.
-	 */
 	/**
 	 * {@link Processor} variant kinds.
 	 * 
@@ -134,6 +132,9 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 
 		Inference("inference"),
 
+		/** A custom {@code Processor} defined by a plugin */
+		_Custom(null)
+
 		;
 
 		private final String jsonValue;
@@ -165,6 +166,7 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 
 		this._kind = ApiTypeHelper.requireNonNull(value._processorKind(), this, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(value, this, "<variant value>");
+		this._customKind = null;
 
 	}
 
@@ -172,6 +174,7 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 
 		this._kind = ApiTypeHelper.requireNonNull(builder._kind, builder, "<variant kind>");
 		this._value = ApiTypeHelper.requireNonNull(builder._value, builder, "<variant value>");
+		this._customKind = builder._customKind;
 
 	}
 
@@ -759,13 +762,42 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 		return TaggedUnionUtils.get(this, Kind.Inference);
 	}
 
+	@Nullable
+	private final String _customKind;
+
+	/**
+	 * Is this a custom {@code Processor} defined by a plugin?
+	 */
+	public boolean _isCustom() {
+		return _kind == Kind._Custom;
+	}
+
+	/**
+	 * Get the actual kind when {@code _kind()} equals {@link Kind#_Custom}
+	 * (plugin-defined variant).
+	 */
+	@Nullable
+	public final String _customKind() {
+		return _customKind;
+	}
+
+	/**
+	 * Get the custom plugin-defined variant value.
+	 *
+	 * @throws IllegalStateException
+	 *             if the current variant is not {@link Kind#_Custom}.
+	 */
+	public JsonData _custom() {
+		return TaggedUnionUtils.get(this, Kind._Custom);
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public void serialize(JsonGenerator generator, JsonpMapper mapper) {
 
 		generator.writeStartObject();
 
-		generator.writeKey(_kind.jsonValue());
+		generator.writeKey(_kind == Kind._Custom ? _customKind : _kind.jsonValue());
 		if (_value instanceof JsonpSerializable) {
 			((JsonpSerializable) _value).serialize(generator, mapper);
 		}
@@ -782,6 +814,7 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<Processor> {
 		private Kind _kind;
 		private Object _value;
+		private String _customKind;
 
 		@Override
 		protected Builder self() {
@@ -1140,6 +1173,22 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 			return this.inference(fn.apply(new InferenceProcessor.Builder()).build());
 		}
 
+		/**
+		 * Define this {@code Processor} as a plugin-defined variant.
+		 *
+		 * @param name
+		 *            the plugin-defined identifier
+		 * @param data
+		 *            the data for this custom {@code Processor}. It is converted
+		 *            internally to {@link JsonData}.
+		 */
+		public ObjectBuilder<Processor> _custom(String name, Object data) {
+			this._kind = Kind._Custom;
+			this._customKind = name;
+			this._value = JsonData.of(data);
+			return this;
+		}
+
 		public Processor build() {
 			_checkSingleUse();
 			return new Processor(this);
@@ -1183,6 +1232,11 @@ public class Processor implements TaggedUnion<Processor.Kind, Object>, JsonpSeri
 		op.add(Builder::drop, DropProcessor._DESERIALIZER, "drop");
 		op.add(Builder::circle, CircleProcessor._DESERIALIZER, "circle");
 		op.add(Builder::inference, InferenceProcessor._DESERIALIZER, "inference");
+
+		op.setUnknownFieldHandler((builder, name, parser, mapper) -> {
+			JsonpUtils.ensureCustomVariantsAllowed(parser, mapper);
+			builder._custom(name, JsonData._DESERIALIZER.deserialize(parser, mapper));
+		});
 
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/GetPipelineResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/GetPipelineResponse.java
@@ -171,8 +171,8 @@ public class GetPipelineResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Pipeline>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(Pipeline._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/PutPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/PutPipelineRequest.java
@@ -166,8 +166,8 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 
 		JsonpDeserializer<Pipeline> valueDeserializer = Pipeline._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().pipeline(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.pipeline(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysis.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysis.java
@@ -55,9 +55,6 @@ public class DataframeAnalysis implements TaggedUnion<DataframeAnalysis.Kind, Ob
 
 	/**
 	 * {@link DataframeAnalysis} variant kinds.
-	 */
-	/**
-	 * {@link DataframeAnalysis} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#ml._types.DataframeAnalysisContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysisFeatureProcessor.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalysisFeatureProcessor.java
@@ -58,9 +58,6 @@ public class DataframeAnalysisFeatureProcessor
 
 	/**
 	 * {@link DataframeAnalysisFeatureProcessor} variant kinds.
-	 */
-	/**
-	 * {@link DataframeAnalysisFeatureProcessor} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#ml._types.DataframeAnalysisFeatureProcessor">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalyticsStats.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeAnalyticsStats.java
@@ -55,9 +55,6 @@ public class DataframeAnalyticsStats implements TaggedUnion<DataframeAnalyticsSt
 
 	/**
 	 * {@link DataframeAnalyticsStats} variant kinds.
-	 */
-	/**
-	 * {@link DataframeAnalyticsStats} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#ml._types.DataframeAnalyticsStatsContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeEvaluation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DataframeEvaluation.java
@@ -55,9 +55,6 @@ public class DataframeEvaluation implements TaggedUnion<DataframeEvaluation.Kind
 
 	/**
 	 * {@link DataframeEvaluation} variant kinds.
-	 */
-	/**
-	 * {@link DataframeEvaluation} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#ml._types.DataframeEvaluationContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigCreate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigCreate.java
@@ -56,9 +56,6 @@ public class InferenceConfigCreate implements TaggedUnion<InferenceConfigCreate.
 
 	/**
 	 * {@link InferenceConfigCreate} variant kinds.
-	 */
-	/**
-	 * {@link InferenceConfigCreate} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#ml._types.InferenceConfigCreateContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigUpdate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferenceConfigUpdate.java
@@ -55,9 +55,6 @@ public class InferenceConfigUpdate implements TaggedUnion<InferenceConfigUpdate.
 
 	/**
 	 * {@link InferenceConfigUpdate} variant kinds.
-	 */
-	/**
-	 * {@link InferenceConfigUpdate} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#ml._types.InferenceConfigUpdateContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostDataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostDataRequest.java
@@ -271,8 +271,8 @@ public class PostDataRequest<TData> extends RequestBase implements JsonpSerializ
 
 		JsonpDeserializer<List<TData>> valueDeserializer = JsonpDeserializer.arrayDeserializer(tDataDeserializer);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder<TData>().data(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder<TData>()
+				.data(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/TokenizationConfig.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/TokenizationConfig.java
@@ -56,9 +56,6 @@ public class TokenizationConfig implements TaggedUnion<TokenizationConfig.Kind, 
 
 	/**
 	 * {@link TokenizationConfig} variant kinds.
-	 */
-	/**
-	 * {@link TokenizationConfig} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#ml._types.TokenizationConfigContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateDetectorRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateDetectorRequest.java
@@ -139,8 +139,8 @@ public class ValidateDetectorRequest extends RequestBase implements JsonpSeriali
 
 		JsonpDeserializer<Detector> valueDeserializer = Detector._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().detector(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.detector(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/put_trained_model/Preprocessor.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/put_trained_model/Preprocessor.java
@@ -55,9 +55,6 @@ public class Preprocessor implements TaggedUnion<Preprocessor.Kind, Object>, Jso
 
 	/**
 	 * {@link Preprocessor} variant kinds.
-	 */
-	/**
-	 * {@link Preprocessor} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../../doc-files/api-spec.html#ml.put_trained_model.Preprocessor">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupCapsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupCapsResponse.java
@@ -173,8 +173,8 @@ public class GetRollupCapsResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, RollupCapabilities>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(RollupCapabilities._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupIndexCapsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupIndexCapsResponse.java
@@ -174,8 +174,8 @@ public class GetRollupIndexCapsResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, IndexCapabilities>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(IndexCapabilities._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupRequest.java
@@ -180,8 +180,8 @@ public class RollupRequest extends RequestBase implements JsonpSerializable {
 
 		JsonpDeserializer<JsonData> valueDeserializer = JsonData._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().config(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.config(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupResponse.java
@@ -131,8 +131,8 @@ public class RollupResponse implements JsonpSerializable {
 
 		JsonpDeserializer<JsonData> valueDeserializer = JsonData._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/ClearCacheResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/ClearCacheResponse.java
@@ -134,8 +134,8 @@ public class ClearCacheResponse implements JsonpSerializable {
 
 		JsonpDeserializer<JsonData> valueDeserializer = JsonData._DESERIALIZER;
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeletePrivilegesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeletePrivilegesResponse.java
@@ -173,8 +173,8 @@ public class DeletePrivilegesResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Map<String, FoundStatus>>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(JsonpDeserializer.stringMapDeserializer(FoundStatus._DESERIALIZER));
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/FieldRule.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/FieldRule.java
@@ -57,9 +57,6 @@ public class FieldRule implements TaggedUnion<FieldRule.Kind, Object>, RoleMappi
 
 	/**
 	 * {@link FieldRule} variant kinds.
-	 */
-	/**
-	 * {@link FieldRule} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#security._types.FieldRule">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetPrivilegesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetPrivilegesResponse.java
@@ -173,8 +173,8 @@ public class GetPrivilegesResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Map<String, Actions>>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(JsonpDeserializer.stringMapDeserializer(Actions._DESERIALIZER));
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleMappingResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleMappingResponse.java
@@ -172,8 +172,8 @@ public class GetRoleMappingResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, RoleMapping>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(RoleMapping._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleResponse.java
@@ -170,8 +170,8 @@ public class GetRoleResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Role>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(Role._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceAccountsResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceAccountsResponse.java
@@ -174,8 +174,8 @@ public class GetServiceAccountsResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, RoleDescriptorWrapper>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(RoleDescriptorWrapper._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserProfileResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserProfileResponse.java
@@ -173,8 +173,8 @@ public class GetUserProfileResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, UserProfileWithMetadata>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(UserProfileWithMetadata._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserResponse.java
@@ -169,8 +169,8 @@ public class GetUserResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, User>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(User._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesRequest.java
@@ -205,8 +205,8 @@ public class PutPrivilegesRequest extends RequestBase implements JsonpSerializab
 		JsonpDeserializer<Map<String, Map<String, Actions>>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(JsonpDeserializer.stringMapDeserializer(Actions._DESERIALIZER));
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().privileges(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.privileges(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesResponse.java
@@ -172,8 +172,8 @@ public class PutPrivilegesResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Map<String, CreatedStatus>>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(JsonpDeserializer.stringMapDeserializer(CreatedStatus._DESERIALIZER));
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/RoleMappingRule.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/RoleMappingRule.java
@@ -59,9 +59,6 @@ public class RoleMappingRule
 
 	/**
 	 * {@link RoleMappingRule} variant kinds.
-	 */
-	/**
-	 * {@link RoleMappingRule} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#security._types.RoleMappingRule">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetLifecycleResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetLifecycleResponse.java
@@ -172,8 +172,8 @@ public class GetLifecycleResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, SnapshotLifecycle>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(SnapshotLifecycle._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetRepositoryResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetRepositoryResponse.java
@@ -172,8 +172,8 @@ public class GetRepositoryResponse implements JsonpSerializable {
 		JsonpDeserializer<Map<String, Repository>> valueDeserializer = JsonpDeserializer
 				.stringMapDeserializer(Repository._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().result(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.result(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ssl/CertificatesResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ssl/CertificatesResponse.java
@@ -163,8 +163,8 @@ public class CertificatesResponse implements JsonpSerializable {
 		JsonpDeserializer<List<CertificateInformation>> valueDeserializer = JsonpDeserializer
 				.arrayDeserializer(CertificateInformation._DESERIALIZER);
 
-		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(),
-				(parser, mapper) -> new Builder().valueBody(valueDeserializer.deserialize(parser, mapper)).build());
+		return JsonpDeserializer.of(valueDeserializer.acceptedEvents(), (parser, mapper, event) -> new Builder()
+				.valueBody(valueDeserializer.deserialize(parser, mapper, event)).build());
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PivotGroupBy.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PivotGroupBy.java
@@ -59,9 +59,6 @@ public class PivotGroupBy implements TaggedUnion<PivotGroupBy.Kind, Object>, Jso
 
 	/**
 	 * {@link PivotGroupBy} variant kinds.
-	 */
-	/**
-	 * {@link PivotGroupBy} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#transform._types.PivotGroupByContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/RetentionPolicy.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/RetentionPolicy.java
@@ -55,9 +55,6 @@ public class RetentionPolicy implements TaggedUnion<RetentionPolicy.Kind, Object
 
 	/**
 	 * {@link RetentionPolicy} variant kinds.
-	 */
-	/**
-	 * {@link RetentionPolicy} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#transform._types.RetentionPolicyContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/Sync.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/Sync.java
@@ -54,9 +54,6 @@ public class Sync implements TaggedUnion<Sync.Kind, Object>, JsonpSerializable {
 
 	/**
 	 * {@link Sync} variant kinds.
-	 */
-	/**
-	 * {@link Sync} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#transform._types.SyncContainer">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Condition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Condition.java
@@ -55,9 +55,6 @@ public class Condition implements TaggedUnion<Condition.Kind, Object>, JsonpSeri
 
 	/**
 	 * {@link Condition} variant kinds.
-	 */
-	/**
-	 * {@link Condition} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#watcher._types.ConditionContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/EmailAttachment.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/EmailAttachment.java
@@ -55,9 +55,6 @@ public class EmailAttachment implements TaggedUnion<EmailAttachment.Kind, Object
 
 	/**
 	 * {@link EmailAttachment} variant kinds.
-	 */
-	/**
-	 * {@link EmailAttachment} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#watcher._types.EmailAttachmentContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Input.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Input.java
@@ -57,9 +57,6 @@ public class Input implements TaggedUnion<Input.Kind, Object>, JsonpSerializable
 
 	/**
 	 * {@link Input} variant kinds.
-	 */
-	/**
-	 * {@link Input} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#watcher._types.InputContainer">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Schedule.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Schedule.java
@@ -58,9 +58,6 @@ public class Schedule implements TaggedUnion<Schedule.Kind, Object>, TriggerVari
 
 	/**
 	 * {@link Schedule} variant kinds.
-	 */
-	/**
-	 * {@link Schedule} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#watcher._types.ScheduleContainer">API

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Trigger.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/Trigger.java
@@ -54,9 +54,6 @@ public class Trigger implements TaggedUnion<Trigger.Kind, Object>, JsonpSerializ
 
 	/**
 	 * {@link Trigger} variant kinds.
-	 */
-	/**
-	 * {@link Trigger} variant kinds.
 	 * 
 	 * @see <a href="../doc-files/api-spec.html#watcher._types.TriggerContainer">API
 	 *      specification</a>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/TriggerEvent.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/TriggerEvent.java
@@ -55,9 +55,6 @@ public class TriggerEvent implements TaggedUnion<TriggerEvent.Kind, Object>, Jso
 
 	/**
 	 * {@link TriggerEvent} variant kinds.
-	 */
-	/**
-	 * {@link TriggerEvent} variant kinds.
 	 * 
 	 * @see <a href=
 	 *      "../doc-files/api-spec.html#watcher._types.TriggerEventContainer">API

--- a/java-client/src/main/java/co/elastic/clients/json/JsonEnum.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonEnum.java
@@ -65,7 +65,10 @@ public interface JsonEnum extends JsonpSerializable {
             // Use the same size calculation as in java.lang.Enum.enumConstantDirectory
             this.lookupTable = new HashMap<>((int)(values.length / 0.75f) + 1);
             for (T member : values) {
-                this.lookupTable.put(member.jsonValue(), member);
+                String jsonValue = member.jsonValue();
+                if (jsonValue != null) { // _Custom enum members have a null jsonValue
+                    this.lookupTable.put(jsonValue, member);
+                }
                 String[] aliases = member.aliases();
                 if (aliases != null) {
                     for (String alias: aliases) {

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpMapperFeatures.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpMapperFeatures.java
@@ -24,6 +24,15 @@ package co.elastic.clients.json;
  */
 public class JsonpMapperFeatures {
 
+    /**
+     *
+     */
     public static final String SERIALIZE_TYPED_KEYS = JsonpMapperFeatures.class.getName() + ":SERIALIZE_TYPED_KEYS";
+
+    /**
+     * Disables custom variants in union types (false by default). Used in tests to avoid interpreting wrong variant kinds as a custom
+     * extension.
+     */
+    public static final String FORBID_CUSTOM_VARIANTS = JsonpMapperFeatures.class.getName() + ":FORBID_CUSTOM_VARIANTS";
 
 }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
@@ -105,6 +105,12 @@ public class JsonpUtils {
         }
     }
 
+    public static void ensureCustomVariantsAllowed(JsonParser parser, JsonpMapper mapper) {
+        if (mapper.attribute(JsonpMapperFeatures.FORBID_CUSTOM_VARIANTS, false)) {
+            throw new JsonpMappingException("Json mapper configuration forbids custom variants", parser.getLocation());
+        }
+    }
+
     /**
      * Skip the value at the next position of the parser.
      */

--- a/java-client/src/main/java/co/elastic/clients/json/ObjectDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/ObjectDeserializer.java
@@ -192,7 +192,7 @@ public class ObjectDeserializer<ObjectType> implements JsonpDeserializer<ObjectT
 
                 FieldDeserializer<ObjectType> fieldDeserializer = fieldDeserializers.get(variant);
                 if (fieldDeserializer == null) {
-                    parseUnknownField(parser, mapper, variant, value);
+                    parseUnknownField(innerParser, mapper, variant, value);
                 } else {
                     fieldDeserializer.deserialize(innerParser, mapper, variant, value);
                 }

--- a/java-client/src/main/java/co/elastic/clients/util/OpenTaggedUnion.java
+++ b/java-client/src/main/java/co/elastic/clients/util/OpenTaggedUnion.java
@@ -19,24 +19,18 @@
 
 package co.elastic.clients.util;
 
+import javax.annotation.Nullable;
+
 /**
- * Base interface for tagged union types (also known as sum types or variants).
- * <p>
- * It provides access to the current variant kind and its value.
+ * A union that is open, i.e. non-exhaustive, where new variants can be defined on the server using extension plugins.
  *
- * @param <Tag> the tag type that defines the possible variants (an enum).
- * @param <BaseType> the closest common ancestor type to all variant values.
- *
- * @see <a href="https://en.wikipedia.org/wiki/Tagged_union">Tagged Union on Wikipedia</a>
+ * @see TaggedUnion
  */
-public interface TaggedUnion<Tag extends Enum<?>, BaseType> {
+public interface OpenTaggedUnion<Tag extends Enum<?>, BaseType> extends TaggedUnion<Tag, BaseType> {
 
     /**
-     * Get the of the kind of variant held by this object.
-     *
-     * @return the variant kind
+     * Get the actual kind when {@code _kind()} equals {@code _Custom} (plugin-defined variant).
      */
-    Tag _kind();
-
-    BaseType _get();
+    @Nullable
+    String _customKind();
 }

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpDeserializerTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpDeserializerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.elasticsearch.json;
+
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+import co.elastic.clients.json.JsonpDeserializer;
+import jakarta.json.stream.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.util.List;
+
+public class JsonpDeserializerTest extends ModelTestCase {
+
+    @Test
+    public void testNullStringInArray() {
+        JsonpDeserializer<List<String>> deser = JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer());
+
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader("[\"a\", null, \"b\"]"));
+        List<String> list = deser.deserialize(parser, mapper);
+
+        assertEquals("a", list.get(0));
+        assertNull(list.get(1));
+        assertEquals("b", list.get(2));
+    }
+}


### PR DESCRIPTION
Add support for custom variants in types representing components that can be extended with plugins in Elasticsearch, such as queries, aggregations, property mapping, etc. These types now have an additional `_custom` variant that accepts a name (the plugin-defined extension identifier) and an arbitrary value.

Fixes #252.

Doc for this feature is added in PR #371