### PR TITLE
Fix RestClientOptions building to not lose builtin headers

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/ApiClient.java
+++ b/java-client/src/main/java/co/elastic/clients/ApiClient.java
@@ -26,6 +26,7 @@ import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapperBase;
 
 import javax.annotation.Nullable;
+import java.util.function.Function;
 
 public abstract class ApiClient<T extends Transport, Self extends ApiClient<T, Self>> {
 
@@ -53,14 +54,26 @@ public abstract class ApiClient<T extends Transport, Self extends ApiClient<T, S
     public abstract Self withTransportOptions(@Nullable TransportOptions transportOptions);
 
     /**
+     * Creates a new client with additional request options
+     *
+     * @param fn a lambda expression that takes the current options as input
+     */
+    public Self withTransportOptions(Function<TransportOptions.Builder, TransportOptions.Builder> fn) {
+        return withTransportOptions(fn.apply(_transportOptions().toBuilder()).build());
+    }
+
+    /**
      * Get the transport used by this client to handle communication with the server.
      */
     public T _transport() {
         return this.transport;
     }
 
+    /**
+     * Get the transport options used for this client. If the client has no custom options, falls back to the transport's options.
+     */
     public TransportOptions _transportOptions() {
-        return this.transportOptions;
+        return this.transportOptions == null ? transport.options() : transportOptions;
     }
 
     /**

--- a/java-client/src/main/java/co/elastic/clients/util/VisibleForTesting.java
+++ b/java-client/src/main/java/co/elastic/clients/util/VisibleForTesting.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a program element that exists, or is more widely visible than otherwise necessary, only
+ * for use in test code.
+ *
+ * <p><b>Do not use this interface</b> for public or protected declarations: it is a fig leaf for
+ * bad design, and it does not prevent anyone from using the declaration---and experience has shown
+ * that they will.
+ *
+ * <p>Borrowed from <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/annotations/VisibleForTesting.java">
+ *    Guava</a>.
+ */
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+public @interface VisibleForTesting {
+}

--- a/java-client/src/test/java/co/elastic/clients/transport/RequestOptionsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/RequestOptionsTest.java
@@ -101,6 +101,15 @@ public class RequestOptionsTest extends Assertions {
     }
 
     @Test
+    public void testNonNullClientOptions() {
+        final RestClientTransport trsp = new RestClientTransport(restClient, new JsonbJsonpMapper());
+        final ElasticsearchClient client = new ElasticsearchClient(trsp);
+
+        assertNotNull(client._transportOptions());
+        assertSame(trsp.options(), client._transportOptions());
+    }
+
+    @Test
     public void testDefaultHeaders() throws IOException {
         final RestClientTransport trsp = new RestClientTransport(restClient, new JsonbJsonpMapper());
         final ElasticsearchClient client = new ElasticsearchClient(trsp);
@@ -111,7 +120,7 @@ public class RequestOptionsTest extends Assertions {
         assertTrue(props.getProperty("header-x-elastic-client-meta").contains("es="));
         assertTrue(props.getProperty("header-x-elastic-client-meta").contains("hl=2"));
         assertEquals(
-            "application/vnd.elasticsearch+json; compatible-with=" + String.valueOf(Version.VERSION.major()),
+            "application/vnd.elasticsearch+json; compatible-with=" + Version.VERSION.major(),
             props.getProperty("header-accept")
         );
     }
@@ -120,10 +129,9 @@ public class RequestOptionsTest extends Assertions {
     public void testClientHeader() throws IOException {
         final RestClientTransport trsp = new RestClientTransport(restClient, new JsonbJsonpMapper());
         final ElasticsearchClient client = new ElasticsearchClient(trsp)
-            .withTransportOptions(trsp.options().with(
-                b -> b.addHeader("X-Foo", "Bar")
-                    .addHeader("uSer-agEnt", "MegaClient/1.2.3")
-                )
+            .withTransportOptions(b -> b
+                .addHeader("X-Foo", "Bar")
+                .addHeader("uSer-agEnt", "MegaClient/1.2.3")
             );
 
         Properties props = getProps(client);

--- a/java-client/src/test/java/co/elastic/clients/transport/rest_client/RestClientOptionsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/rest_client/RestClientOptionsTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.rest_client;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.SimpleJsonpMapper;
+import co.elastic.clients.transport.Version;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class RestClientOptionsTest extends Assertions {
+
+    /** Collected headers by test name */
+    private static Map<String, Headers> collectedHeaders;
+    private static final AtomicInteger testCounter = new AtomicInteger();
+    private static HttpServer httpServer;
+
+    private static final String MIME_TYPE = "application/vnd.elasticsearch+json; compatible-with=" + Version.VERSION.major();
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        collectedHeaders = new ConcurrentHashMap<>();
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+
+        // Register a handler on the core.exists("capture-handler/{name}") endpoint that will capture request headers.
+        httpServer.createContext("/capture-headers/_doc/", exchange -> {
+            String testName = exchange.getRequestURI().getPath().substring("/capture-headers/_doc/".length());
+            collectedHeaders.put(testName, exchange.getRequestHeaders());
+
+            // Reply with an empty 200 response
+            exchange.getResponseHeaders().set("X-Elastic-Product", "Elasticsearch");
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+
+        httpServer.start();
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        httpServer.stop(0);
+        httpServer = null;
+        collectedHeaders = null;
+    }
+
+    /**
+     * Make a server call, capture request headers and check their consistency.
+     *
+     * @return the name of the entry in <code>collectedHeaders</code> for further inspection.
+     */
+    private String checkHeaders(ElasticsearchClient esClient) throws IOException {
+        String testName = "test-" + testCounter.incrementAndGet();
+        BooleanResponse exists = esClient.exists(r -> r.index("capture-headers").id(testName));
+        assertTrue(exists.value());
+
+        Headers headers = collectedHeaders.get(testName);
+        assertNotNull(headers, "No headers collected for test " + testName);
+
+        assertNotNull(headers.get("X-elastic-client-meta"), "Missing client meta header");
+        assertEquals(RestClientOptions.CLIENT_META_VALUE, headers.get("X-elastic-client-meta").get(0));
+        assertNotNull(headers.get("Accept"), "Missing 'Accept' header");
+        assertEquals(MIME_TYPE, headers.get("Accept").get(0));
+
+        for (Map.Entry<String, List<String>> entry: headers.entrySet()) {
+            System.out.println(entry.getKey() + " " + entry.getValue());
+        }
+
+        return testName;
+    }
+
+    private void checkUserAgent(String testName, String value) {
+        Headers headers = collectedHeaders.get(testName);
+        assertNotNull(headers, "No headers collected for test " + testName);
+        assertNotNull(headers.get("User-Agent"), "Missing 'User-Agent' header");
+        assertEquals(value, headers.get("User-Agent").get(0));
+    }
+
+    @Test
+    void testNoRequestOptions() throws Exception {
+        RestClient llrc = RestClient.builder(
+            new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
+        ).build();
+
+        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper());
+        ElasticsearchClient esClient = new ElasticsearchClient(transport);
+
+        String id = checkHeaders(esClient);
+        checkUserAgent(id, RestClientOptions.USER_AGENT_VALUE);
+    }
+
+    @Test
+    void testTransportRequestOptions() throws Exception {
+        RestClient llrc = RestClient.builder(
+            new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
+        ).build();
+
+        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper(),
+            new RestClientOptions.Builder(RequestOptions.DEFAULT.toBuilder()).build()
+        );
+        ElasticsearchClient esClient = new ElasticsearchClient(transport);
+
+        String id = checkHeaders(esClient);
+        checkUserAgent(id, RestClientOptions.USER_AGENT_VALUE);
+    }
+
+    @Test
+    void testClientRequestOptions() throws Exception {
+        RestClient llrc = RestClient.builder(
+            new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
+        ).build();
+
+        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper());
+        ElasticsearchClient esClient = new ElasticsearchClient(transport).withTransportOptions(
+            new RestClientOptions.Builder(RequestOptions.DEFAULT.toBuilder()).build()
+        );
+
+        String id = checkHeaders(esClient);
+        checkUserAgent(id, RestClientOptions.USER_AGENT_VALUE);
+    }
+
+    @Test
+    void testLambdaOptionsBuilder() throws Exception {
+        RestClient llrc = RestClient.builder(
+            new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
+        ).build();
+
+        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper());
+        ElasticsearchClient esClient = new ElasticsearchClient(transport)
+            .withTransportOptions(o -> o
+                .addHeader("Foo", "bar")
+                .addHeader("x-elastic-client-meta", "foo-bar-client")
+            );
+
+        String id = checkHeaders(esClient);
+        checkUserAgent(id, RestClientOptions.USER_AGENT_VALUE);
+    }
+
+    @Test
+    void testRequestOptionsOverridingBuiltin() throws Exception {
+        RequestOptions options = RequestOptions.DEFAULT.toBuilder()
+            .addHeader("user-agent", "FooBarAgent/1.0")
+            .addHeader("x-elastic-client-meta", "foo-bar-client")
+            .build();
+
+        RestClient llrc = RestClient.builder(
+            new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
+        ).build();
+
+        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper(), new RestClientOptions(options));
+        ElasticsearchClient esClient = new ElasticsearchClient(transport);
+        // Should not override client meta
+        String id = checkHeaders(esClient);
+        // overriding user-agent is ok
+        checkUserAgent(id, "FooBarAgent/1.0");
+    }
+}


### PR DESCRIPTION
This fixes `RestClientOptions` to ensure that built-in headers (`Accept` and the `X-elastic-client-meta` telemetry header) are always present, even when instantiating the transport with custom `RequestOptions`.

Also ensures `ElasticsearchClient._transportOptions()` is never `null` by falling back to the transport's options.

Fixes #377.
