### PR TITLE
Fix NPEs and race condition in deserializers

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/BuildFunctionDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/BuildFunctionDeserializer.java
@@ -45,12 +45,12 @@ public class BuildFunctionDeserializer<B, T> extends DelegatingDeserializer<T, B
     @Override
     public T deserialize(JsonParser parser, JsonpMapper mapper) {
         B builder = builderDeserializer.deserialize(parser, mapper);
-        return build.apply(builder);
+        return builder == null ? null : build.apply(builder);
     }
 
     @Override
     public T deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
         B builder = builderDeserializer.deserialize(parser, mapper, event);
-        return build.apply(builder);
+        return builder == null ? null : build.apply(builder);
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializerBase.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializerBase.java
@@ -295,11 +295,13 @@ public abstract class JsonpDeserializerBase<V> implements JsonpDeserializer<V> {
         public EnumSet<Event> acceptedEvents() {
             // Accepted events is computed lazily
             // no need for double-checked lock, we don't care about computing it several times
-            if (acceptedEvents == null) {
-                acceptedEvents = EnumSet.of(Event.START_ARRAY);
-                acceptedEvents.addAll(itemDeserializer.acceptedEvents());
+            EnumSet<Event> events = acceptedEvents;
+            if (events == null) {
+                events = EnumSet.of(Event.START_ARRAY);
+                events.addAll(itemDeserializer.acceptedEvents());
+                acceptedEvents = events;
             }
-            return acceptedEvents;
+            return events;
         }
 
         @Override

--- a/java-client/src/main/java/co/elastic/clients/json/LazyDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/LazyDeserializer.java
@@ -29,12 +29,12 @@ import java.util.function.Supplier;
  * @see JsonpDeserializable
  * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-12.html#jls-12.4">Initialization of Classes and Interfaces</a>
  */
-class LazyDeserializer<T> extends DelegatingDeserializer.SameType<T> {
+public class LazyDeserializer<T> extends DelegatingDeserializer.SameType<T> {
 
     private final Supplier<JsonpDeserializer<T>> ctor;
     private volatile JsonpDeserializer<T> deserializer = null;
 
-    LazyDeserializer(Supplier<JsonpDeserializer<T>> ctor) {
+    public LazyDeserializer(Supplier<JsonpDeserializer<T>> ctor) {
         this.ctor = ctor;
     }
 

--- a/java-client/src/main/java/co/elastic/clients/json/ObjectBuilderDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/ObjectBuilderDeserializer.java
@@ -77,12 +77,12 @@ public class ObjectBuilderDeserializer<T, B extends ObjectBuilder<T>> extends De
     @Override
     public T deserialize(JsonParser parser, JsonpMapper mapper) {
         ObjectBuilder<T> builder = builderDeserializer.deserialize(parser, mapper);
-        return builder.build();
+        return builder == null ? null : builder.build();
     }
 
     @Override
     public T deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
         ObjectBuilder<T> builder = builderDeserializer.deserialize(parser, mapper, event);
-        return builder.build();
+        return builder == null ? null : builder.build();
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/json/ObjectDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/ObjectDeserializer.java
@@ -44,6 +44,8 @@ public class ObjectDeserializer<ObjectType> implements JsonpDeserializer<ObjectT
             this.name = name;
         }
 
+        public abstract EnumSet<Event> acceptedEvents();
+
         public abstract void deserialize(JsonParser parser, JsonpMapper mapper, String fieldName, ObjectType object);
 
         public abstract void deserialize(JsonParser parser, JsonpMapper mapper, String fieldName, ObjectType object, Event event);
@@ -65,6 +67,11 @@ public class ObjectDeserializer<ObjectType> implements JsonpDeserializer<ObjectT
 
         public String name() {
             return this.name;
+        }
+
+        @Override
+        public EnumSet<Event> acceptedEvents() {
+            return deserializer.acceptedEvents();
         }
 
         public void deserialize(JsonParser parser, JsonpMapper mapper, String fieldName, ObjectType object) {
@@ -89,6 +96,11 @@ public class ObjectDeserializer<ObjectType> implements JsonpDeserializer<ObjectT
         @Override
         public void deserialize(JsonParser parser, JsonpMapper mapper, String fieldName, Object object, Event event) {
             JsonpUtils.skipValue(parser, event);
+        }
+
+        @Override
+        public EnumSet<Event> acceptedEvents() {
+            return EnumSet.allOf(Event.class);
         }
     };
 
@@ -242,6 +254,8 @@ public class ObjectDeserializer<ObjectType> implements JsonpDeserializer<ObjectT
             throw new NoSuchElementException("No deserializer was setup for '" + name + "'");
         }
 
+        //acceptedEvents = EnumSet.copyOf(acceptedEvents);
+        //acceptedEvents.addAll(shortcutProperty.acceptedEvents());
         acceptedEvents = EventSetObjectAndString;
     }
 

--- a/java-client/src/test/java/co/elastic/clients/json/JsonpDeserializerBaseTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpDeserializerBaseTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+import jakarta.json.stream.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class JsonpDeserializerBaseTest extends ModelTestCase {
+
+    @Test
+    public void testArrayDeserializer() {
+
+        JsonpDeserializer<List<Integer>> deser =
+            JsonpDeserializer.arrayDeserializer(JsonpDeserializer.integerDeserializer());
+
+        assertFalse(deser.nativeEvents().contains(JsonParser.Event.VALUE_NUMBER));
+        assertTrue(deser.acceptedEvents().contains(JsonParser.Event.VALUE_NUMBER));
+
+        List<Integer> values = fromJson("[ 42, 43 ]", deser);
+        assertEquals(2, values.size());
+        assertEquals(42, values.get(0));
+        assertEquals(43, values.get(1));
+
+        // Single value representation
+        values = fromJson("42", deser);
+        assertEquals(1, values.size());
+        assertEquals(42, values.get(0));
+
+    }
+}

--- a/java-client/src/test/java/co/elastic/clients/json/ObjectBuilderDeserializerTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/ObjectBuilderDeserializerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import co.elastic.clients.elasticsearch._types.mapping.TextProperty;
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+import co.elastic.clients.elasticsearch.transform.UpdateTransformRequest;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+public class ObjectBuilderDeserializerTest extends ModelTestCase {
+
+    @Test
+    public void testNullObjectValue() {
+        // Should also accept null for optional values
+        String json = "{ \"index_prefixes\": null }";
+        fromJson(json, TextProperty.class);
+    }
+
+    @Test
+    public void testNullObjectValueInFunctionBuilder() {
+        String json = "{\n" +
+            "        \"retention_policy\": null\n" +
+            "      }";
+
+        UpdateTransformRequest.Builder builder = new UpdateTransformRequest.Builder();
+        builder.transformId("foo");
+        builder.withJson(new StringReader(json));
+        builder.build();
+    }
+
+}


### PR DESCRIPTION
This fixes two issues in deserializers:
* in a few APIs, Elasticsearch sends `null` for missing optional fields instead of omitting the field altogether. This can cause NullPointerExceptions in ObjectDeserializers.
* A race condition in `JsonpDeserializerBase.ArrayDeserializer` can cause it's accepted JSON events to be initialized with an incomplete value.
  Fixes #402