### PR TITLE
Builder classes extend the parent builder even if this parent has no properties

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/RequestBase.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/RequestBase.java
@@ -50,6 +50,13 @@ public abstract class RequestBase {
 	public RequestBase() {
 	}
 
+	protected abstract static class AbstractBuilder<BuilderT extends AbstractBuilder<BuilderT>>
+			extends
+				WithJsonObjectBuilderBase<BuilderT> {
+		protected abstract BuilderT self();
+
+	}
+
 	@Override
 	public String toString() {
 
@@ -82,13 +89,6 @@ public abstract class RequestBase {
 		}
 
 		return sb.toString();
-	}
-
-	protected abstract static class AbstractBuilder<BuilderT extends AbstractBuilder<BuilderT>>
-			extends
-				WithJsonObjectBuilderBase<BuilderT> {
-		protected abstract BuilderT self();
-
 	}
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionLogarithm.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionLogarithm.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.util.Objects;
@@ -96,7 +95,7 @@ public class RankFeatureFunctionLogarithm extends RankFeatureFunction implements
 	 * Builder for {@link RankFeatureFunctionLogarithm}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RankFeatureFunction.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<RankFeatureFunctionLogarithm> {
 		private Float scalingFactor;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionSaturation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionSaturation.java
@@ -31,7 +31,6 @@ import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.util.Objects;
@@ -101,7 +100,7 @@ public class RankFeatureFunctionSaturation extends RankFeatureFunction implement
 	 * Builder for {@link RankFeatureFunctionSaturation}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RankFeatureFunction.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<RankFeatureFunctionSaturation> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionSigmoid.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionSigmoid.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.util.Objects;
@@ -109,7 +108,7 @@ public class RankFeatureFunctionSigmoid extends RankFeatureFunction implements J
 	 * Builder for {@link RankFeatureFunctionSigmoid}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RankFeatureFunction.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<RankFeatureFunctionSigmoid> {
 		private Float pivot;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/AsyncSearchStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/AsyncSearchStatusRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class AsyncSearchStatusRequest extends RequestBase {
 	 * Builder for {@link AsyncSearchStatusRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<AsyncSearchStatusRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<AsyncSearchStatusRequest> {
 		private String id;
 
 		/**
@@ -91,6 +92,11 @@ public class AsyncSearchStatusRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/DeleteAsyncSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/DeleteAsyncSearchRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class DeleteAsyncSearchRequest extends RequestBase {
 	 * Builder for {@link DeleteAsyncSearchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteAsyncSearchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteAsyncSearchRequest> {
 		private String id;
 
 		/**
@@ -91,6 +92,11 @@ public class DeleteAsyncSearchRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/GetAsyncSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/GetAsyncSearchRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -112,7 +111,9 @@ public class GetAsyncSearchRequest extends RequestBase {
 	 * Builder for {@link GetAsyncSearchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetAsyncSearchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetAsyncSearchRequest> {
 		private String id;
 
 		@Nullable
@@ -169,6 +170,11 @@ public class GetAsyncSearchRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletionTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.waitForCompletionTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/SubmitRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/SubmitRequest.java
@@ -55,7 +55,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -1129,7 +1128,7 @@ public class SubmitRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link SubmitRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SubmitRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<SubmitRequest> {
 		@Nullable
 		private SourceConfig source;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/DeleteAutoscalingPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/DeleteAutoscalingPolicyRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -83,7 +82,9 @@ public class DeleteAutoscalingPolicyRequest extends RequestBase {
 	 * Builder for {@link DeleteAutoscalingPolicyRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteAutoscalingPolicyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteAutoscalingPolicyRequest> {
 		private String name;
 
 		/**
@@ -93,6 +94,11 @@ public class DeleteAutoscalingPolicyRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/GetAutoscalingPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/GetAutoscalingPolicyRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class GetAutoscalingPolicyRequest extends RequestBase {
 	 * Builder for {@link GetAutoscalingPolicyRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetAutoscalingPolicyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetAutoscalingPolicyRequest> {
 		private String name;
 
 		/**
@@ -92,6 +93,11 @@ public class GetAutoscalingPolicyRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/PutAutoscalingPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/PutAutoscalingPolicyRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
@@ -103,7 +102,7 @@ public class PutAutoscalingPolicyRequest extends RequestBase implements JsonpSer
 	 * Builder for {@link PutAutoscalingPolicyRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutAutoscalingPolicyRequest> {
 		private String name;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AliasesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AliasesRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -97,7 +96,9 @@ public class AliasesRequest extends CatRequestBase {
 	 * Builder for {@link AliasesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<AliasesRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<AliasesRequest> {
 		@Nullable
 		private List<ExpandWildcard> expandWildcards;
 
@@ -151,6 +152,11 @@ public class AliasesRequest extends CatRequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AllocationRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AllocationRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -98,7 +97,9 @@ public class AllocationRequest extends CatRequestBase {
 	 * Builder for {@link AllocationRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<AllocationRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<AllocationRequest> {
 		@Nullable
 		private Bytes bytes;
 
@@ -136,6 +137,11 @@ public class AllocationRequest extends CatRequestBase {
 		 */
 		public final Builder nodeId(String value, String... values) {
 			this.nodeId = _listAdd(this.nodeId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CatRequestBase.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CatRequestBase.java
@@ -47,7 +47,7 @@ public abstract class CatRequestBase extends RequestBase {
 
 	protected abstract static class AbstractBuilder<BuilderT extends AbstractBuilder<BuilderT>>
 			extends
-				WithJsonObjectBuilderBase<BuilderT> {
+				RequestBase.AbstractBuilder<BuilderT> {
 		protected abstract BuilderT self();
 
 	}

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ComponentTemplatesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ComponentTemplatesRequest.java
@@ -31,7 +31,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -81,7 +80,9 @@ public class ComponentTemplatesRequest extends CatRequestBase {
 	 * Builder for {@link ComponentTemplatesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ComponentTemplatesRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ComponentTemplatesRequest> {
 		@Nullable
 		private String name;
 
@@ -92,6 +93,11 @@ public class ComponentTemplatesRequest extends CatRequestBase {
 		 */
 		public final Builder name(@Nullable String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CountRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -83,7 +82,7 @@ public class CountRequest extends CatRequestBase {
 	 * Builder for {@link CountRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CountRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder> implements ObjectBuilder<CountRequest> {
 		@Nullable
 		private List<String> index;
 
@@ -108,6 +107,11 @@ public class CountRequest extends CatRequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/FielddataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/FielddataRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -98,7 +97,9 @@ public class FielddataRequest extends CatRequestBase {
 	 * Builder for {@link FielddataRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FielddataRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<FielddataRequest> {
 		@Nullable
 		private Bytes bytes;
 
@@ -136,6 +137,11 @@ public class FielddataRequest extends CatRequestBase {
 		 */
 		public final Builder fields(String value, String... values) {
 			this.fields = _listAdd(this.fields, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HealthRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HealthRequest.java
@@ -31,7 +31,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -81,7 +80,9 @@ public class HealthRequest extends CatRequestBase {
 	 * Builder for {@link HealthRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<HealthRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<HealthRequest> {
 		@Nullable
 		private Boolean ts;
 
@@ -92,6 +93,11 @@ public class HealthRequest extends CatRequestBase {
 		 */
 		public final Builder ts(@Nullable Boolean value) {
 			this.ts = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/IndicesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/IndicesRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -158,7 +157,9 @@ public class IndicesRequest extends CatRequestBase {
 	 * Builder for {@link IndicesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndicesRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<IndicesRequest> {
 		@Nullable
 		private Bytes bytes;
 
@@ -266,6 +267,11 @@ public class IndicesRequest extends CatRequestBase {
 		 */
 		public final Builder pri(@Nullable Boolean value) {
 			this.pri = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDataFrameAnalyticsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -161,7 +160,9 @@ public class MlDataFrameAnalyticsRequest extends CatRequestBase {
 	 * Builder for {@link MlDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MlDataFrameAnalyticsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<MlDataFrameAnalyticsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -278,6 +279,11 @@ public class MlDataFrameAnalyticsRequest extends CatRequestBase {
 		 */
 		public final Builder time(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.time(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDatafeedsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDatafeedsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -158,7 +157,9 @@ public class MlDatafeedsRequest extends CatRequestBase {
 	 * Builder for {@link MlDatafeedsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MlDatafeedsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<MlDatafeedsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -262,6 +263,11 @@ public class MlDatafeedsRequest extends CatRequestBase {
 		 */
 		public final Builder time(@Nullable TimeUnit value) {
 			this.time = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlJobsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlJobsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -173,7 +172,9 @@ public class MlJobsRequest extends CatRequestBase {
 	 * Builder for {@link MlJobsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MlJobsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<MlJobsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -290,6 +291,11 @@ public class MlJobsRequest extends CatRequestBase {
 		 */
 		public final Builder time(@Nullable TimeUnit value) {
 			this.time = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlTrainedModelsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlTrainedModelsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -173,7 +172,9 @@ public class MlTrainedModelsRequest extends CatRequestBase {
 	 * Builder for {@link MlTrainedModelsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MlTrainedModelsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<MlTrainedModelsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -292,6 +293,11 @@ public class MlTrainedModelsRequest extends CatRequestBase {
 		 */
 		public final Builder size(@Nullable Integer value) {
 			this.size = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodesRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -96,7 +95,7 @@ public class NodesRequest extends CatRequestBase {
 	 * Builder for {@link NodesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NodesRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder> implements ObjectBuilder<NodesRequest> {
 		@Nullable
 		private Bytes bytes;
 
@@ -120,6 +119,11 @@ public class NodesRequest extends CatRequestBase {
 		 */
 		public final Builder fullId(@Nullable Boolean value) {
 			this.fullId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RecoveryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RecoveryRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -128,7 +127,9 @@ public class RecoveryRequest extends CatRequestBase {
 	 * Builder for {@link RecoveryRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RecoveryRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<RecoveryRequest> {
 		@Nullable
 		private Boolean activeOnly;
 
@@ -195,6 +196,11 @@ public class RecoveryRequest extends CatRequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SegmentsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SegmentsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -97,7 +96,9 @@ public class SegmentsRequest extends CatRequestBase {
 	 * Builder for {@link SegmentsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SegmentsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SegmentsRequest> {
 		@Nullable
 		private Bytes bytes;
 
@@ -135,6 +136,11 @@ public class SegmentsRequest extends CatRequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ShardsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ShardsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -97,7 +96,9 @@ public class ShardsRequest extends CatRequestBase {
 	 * Builder for {@link ShardsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ShardsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ShardsRequest> {
 		@Nullable
 		private Bytes bytes;
 
@@ -135,6 +136,11 @@ public class ShardsRequest extends CatRequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SnapshotsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SnapshotsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -97,7 +96,9 @@ public class SnapshotsRequest extends CatRequestBase {
 	 * Builder for {@link SnapshotsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SnapshotsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SnapshotsRequest> {
 		@Nullable
 		private Boolean ignoreUnavailable;
 
@@ -135,6 +136,11 @@ public class SnapshotsRequest extends CatRequestBase {
 		 */
 		public final Builder repository(String value, String... values) {
 			this.repository = _listAdd(this.repository, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TasksRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TasksRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -122,7 +121,7 @@ public class TasksRequest extends CatRequestBase {
 	 * Builder for {@link TasksRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TasksRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder> implements ObjectBuilder<TasksRequest> {
 		@Nullable
 		private List<String> actions;
 
@@ -196,6 +195,11 @@ public class TasksRequest extends CatRequestBase {
 		 */
 		public final Builder parentTask(@Nullable Long value) {
 			this.parentTask = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TemplatesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TemplatesRequest.java
@@ -31,7 +31,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -81,7 +80,9 @@ public class TemplatesRequest extends CatRequestBase {
 	 * Builder for {@link TemplatesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TemplatesRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<TemplatesRequest> {
 		@Nullable
 		private String name;
 
@@ -92,6 +93,11 @@ public class TemplatesRequest extends CatRequestBase {
 		 */
 		public final Builder name(@Nullable String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ThreadPoolRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ThreadPoolRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class ThreadPoolRequest extends CatRequestBase {
 	 * Builder for {@link ThreadPoolRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ThreadPoolRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ThreadPoolRequest> {
 		@Nullable
 		private List<String> threadPoolPatterns;
 
@@ -139,6 +140,11 @@ public class ThreadPoolRequest extends CatRequestBase {
 		 */
 		public final Builder time(@Nullable TimeUnit value) {
 			this.time = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TransformsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TransformsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -174,7 +173,9 @@ public class TransformsRequest extends CatRequestBase {
 	 * Builder for {@link TransformsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<TransformsRequest> {
+	public static class Builder extends CatRequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<TransformsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -295,6 +296,11 @@ public class TransformsRequest extends CatRequestBase {
 		 */
 		public final Builder transformId(@Nullable String value) {
 			this.transformId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/DeleteAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/DeleteAutoFollowPatternRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class DeleteAutoFollowPatternRequest extends RequestBase {
 	 * Builder for {@link DeleteAutoFollowPatternRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteAutoFollowPatternRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteAutoFollowPatternRequest> {
 		private String name;
 
 		/**
@@ -92,6 +93,11 @@ public class DeleteAutoFollowPatternRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowInfoRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -84,7 +83,9 @@ public class FollowInfoRequest extends RequestBase {
 	 * Builder for {@link FollowInfoRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FollowInfoRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<FollowInfoRequest> {
 		private List<String> index;
 
 		/**
@@ -110,6 +111,11 @@ public class FollowInfoRequest extends RequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -322,7 +321,7 @@ public class FollowRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link FollowRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<FollowRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<FollowRequest> {
 		private String index;
 
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowStatsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -84,7 +83,9 @@ public class FollowStatsRequest extends RequestBase {
 	 * Builder for {@link FollowStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FollowStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<FollowStatsRequest> {
 		private List<String> index;
 
 		/**
@@ -110,6 +111,11 @@ public class FollowStatsRequest extends RequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ForgetFollowerRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ForgetFollowerRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -165,7 +164,7 @@ public class ForgetFollowerRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link ForgetFollowerRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ForgetFollowerRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/GetAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/GetAutoFollowPatternRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -84,7 +83,9 @@ public class GetAutoFollowPatternRequest extends RequestBase {
 	 * Builder for {@link GetAutoFollowPatternRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetAutoFollowPatternRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetAutoFollowPatternRequest> {
 		@Nullable
 		private String name;
 
@@ -96,6 +97,11 @@ public class GetAutoFollowPatternRequest extends RequestBase {
 		 */
 		public final Builder name(@Nullable String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseAutoFollowPatternRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class PauseAutoFollowPatternRequest extends RequestBase {
 	 * Builder for {@link PauseAutoFollowPatternRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PauseAutoFollowPatternRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PauseAutoFollowPatternRequest> {
 		private String name;
 
 		/**
@@ -93,6 +94,11 @@ public class PauseAutoFollowPatternRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseFollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseFollowRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class PauseFollowRequest extends RequestBase {
 	 * Builder for {@link PauseFollowRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PauseFollowRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PauseFollowRequest> {
 		private String index;
 
 		/**
@@ -93,6 +94,11 @@ public class PauseFollowRequest extends RequestBase {
 		 */
 		public final Builder index(String value) {
 			this.index = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PutAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PutAutoFollowPatternRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -415,7 +414,7 @@ public class PutAutoFollowPatternRequest extends RequestBase implements JsonpSer
 	 * Builder for {@link PutAutoFollowPatternRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutAutoFollowPatternRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeAutoFollowPatternRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -83,7 +82,9 @@ public class ResumeAutoFollowPatternRequest extends RequestBase {
 	 * Builder for {@link ResumeAutoFollowPatternRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ResumeAutoFollowPatternRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ResumeAutoFollowPatternRequest> {
 		private String name;
 
 		/**
@@ -94,6 +95,11 @@ public class ResumeAutoFollowPatternRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeFollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeFollowRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -268,7 +267,7 @@ public class ResumeFollowRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link ResumeFollowRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ResumeFollowRequest> {
 		private String index;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/UnfollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/UnfollowRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,7 @@ public class UnfollowRequest extends RequestBase {
 	 * Builder for {@link UnfollowRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<UnfollowRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<UnfollowRequest> {
 		private String index;
 
 		/**
@@ -93,6 +92,11 @@ public class UnfollowRequest extends RequestBase {
 		 */
 		public final Builder index(String value) {
 			this.index = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/AllocationExplainRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/AllocationExplainRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -192,7 +191,7 @@ public class AllocationExplainRequest extends RequestBase implements JsonpSerial
 	 * Builder for {@link AllocationExplainRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<AllocationExplainRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ClusterStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ClusterStatsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -117,7 +116,9 @@ public class ClusterStatsRequest extends RequestBase {
 	 * Builder for {@link ClusterStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClusterStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClusterStatsRequest> {
 		@Nullable
 		private Boolean flatSettings;
 
@@ -186,6 +187,11 @@ public class ClusterStatsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteComponentTemplateRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -115,7 +114,9 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 	 * Builder for {@link DeleteComponentTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteComponentTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteComponentTemplateRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -186,6 +187,11 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteVotingConfigExclusionsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteVotingConfigExclusionsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.endpoints.BooleanEndpoint;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -91,7 +90,7 @@ public class DeleteVotingConfigExclusionsRequest extends RequestBase {
 	 * Builder for {@link DeleteVotingConfigExclusionsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<DeleteVotingConfigExclusionsRequest> {
 		@Nullable
@@ -109,6 +108,11 @@ public class DeleteVotingConfigExclusionsRequest extends RequestBase {
 		 */
 		public final Builder waitForRemoval(@Nullable Boolean value) {
 			this.waitForRemoval = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ExistsComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ExistsComponentTemplateRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -120,7 +119,9 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 	 * Builder for {@link ExistsComponentTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsComponentTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExistsComponentTemplateRequest> {
 		@Nullable
 		private Boolean local;
 
@@ -184,6 +185,11 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetClusterSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetClusterSettingsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -125,7 +124,9 @@ public class GetClusterSettingsRequest extends RequestBase {
 	 * Builder for {@link GetClusterSettingsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetClusterSettingsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetClusterSettingsRequest> {
 		@Nullable
 		private Boolean flatSettings;
 
@@ -194,6 +195,11 @@ public class GetClusterSettingsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetComponentTemplateRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -126,7 +125,9 @@ public class GetComponentTemplateRequest extends RequestBase {
 	 * Builder for {@link GetComponentTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetComponentTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetComponentTemplateRequest> {
 		@Nullable
 		private Boolean flatSettings;
 
@@ -184,6 +185,11 @@ public class GetComponentTemplateRequest extends RequestBase {
 		 */
 		public final Builder name(@Nullable String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/HealthRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/HealthRequest.java
@@ -39,7 +39,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -267,7 +266,7 @@ public class HealthRequest extends RequestBase {
 	 * Builder for {@link HealthRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<HealthRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<HealthRequest> {
 		@Nullable
 		private List<ExpandWildcard> expandWildcards;
 
@@ -500,6 +499,11 @@ public class HealthRequest extends RequestBase {
 		 */
 		public final Builder waitForStatus(@Nullable HealthStatus value) {
 			this.waitForStatus = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PendingTasksRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PendingTasksRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class PendingTasksRequest extends RequestBase {
 	 * Builder for {@link PendingTasksRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PendingTasksRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PendingTasksRequest> {
 		@Nullable
 		private Boolean local;
 
@@ -134,6 +135,11 @@ public class PendingTasksRequest extends RequestBase {
 		 */
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PostVotingConfigExclusionsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PostVotingConfigExclusionsRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -119,7 +118,9 @@ public class PostVotingConfigExclusionsRequest extends RequestBase {
 	 * Builder for {@link PostVotingConfigExclusionsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PostVotingConfigExclusionsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PostVotingConfigExclusionsRequest> {
 		@Nullable
 		private List<String> nodeIds;
 
@@ -204,6 +205,11 @@ public class PostVotingConfigExclusionsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutClusterSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutClusterSettingsRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -172,7 +171,7 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 	 * Builder for {@link PutClusterSettingsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutClusterSettingsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutComponentTemplateRequest.java
@@ -41,7 +41,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -241,7 +240,7 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 	 * Builder for {@link PutComponentTemplateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutComponentTemplateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RerouteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RerouteRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -199,7 +198,7 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link RerouteRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<RerouteRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RerouteRequest> {
 		@Nullable
 		private List<Command> commands;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/StateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/StateRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -216,7 +215,7 @@ public class StateRequest extends RequestBase {
 	 * Builder for {@link StateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<StateRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -414,6 +413,11 @@ public class StateRequest extends RequestBase {
 		 */
 		public final Builder waitForTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.waitForTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/BulkRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/BulkRequest.java
@@ -41,7 +41,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -255,7 +254,7 @@ public class BulkRequest extends RequestBase implements NdJsonpSerializable, Jso
 	 * Builder for {@link BulkRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<BulkRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<BulkRequest> {
 		@Nullable
 		private SourceConfigParam source;
 
@@ -488,6 +487,11 @@ public class BulkRequest extends RequestBase implements NdJsonpSerializable, Jso
 		 */
 		public final Builder operations(Function<BulkOperation.Builder, ObjectBuilder<BulkOperation>> fn) {
 			return operations(fn.apply(new BulkOperation.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClearScrollRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClearScrollRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -105,7 +104,7 @@ public class ClearScrollRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link ClearScrollRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ClearScrollRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClosePointInTimeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClosePointInTimeRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -97,7 +96,7 @@ public class ClosePointInTimeRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link ClosePointInTimeRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ClosePointInTimeRequest> {
 		private String id;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -327,7 +326,7 @@ public class CountRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link CountRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<CountRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<CountRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
@@ -43,7 +43,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.Long;
@@ -236,7 +235,7 @@ public class CreateRequest<TDocument> extends RequestBase implements JsonpSerial
 	 * Builder for {@link CreateRequest}.
 	 */
 
-	public static class Builder<TDocument> extends WithJsonObjectBuilderBase<Builder<TDocument>>
+	public static class Builder<TDocument> extends RequestBase.AbstractBuilder<Builder<TDocument>>
 			implements
 				ObjectBuilder<CreateRequest<TDocument>> {
 		private String id;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRequest.java
@@ -44,7 +44,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Float;
@@ -567,7 +566,7 @@ public class DeleteByQueryRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link DeleteByQueryRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<DeleteByQueryRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRethrottleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRethrottleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.lang.String;
@@ -100,7 +99,9 @@ public class DeleteByQueryRethrottleRequest extends RequestBase {
 	 * Builder for {@link DeleteByQueryRethrottleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteByQueryRethrottleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteByQueryRethrottleRequest> {
 		@Nullable
 		private Float requestsPerSecond;
 
@@ -124,6 +125,11 @@ public class DeleteByQueryRethrottleRequest extends RequestBase {
 		 */
 		public final Builder taskId(String value) {
 			this.taskId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -219,7 +218,7 @@ public class DeleteRequest extends RequestBase {
 	 * Builder for {@link DeleteRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<DeleteRequest> {
 		private String id;
 
 		@Nullable
@@ -378,6 +377,11 @@ public class DeleteRequest extends RequestBase {
 		public final Builder waitForActiveShards(
 				Function<WaitForActiveShards.Builder, ObjectBuilder<WaitForActiveShards>> fn) {
 			return this.waitForActiveShards(fn.apply(new WaitForActiveShards.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteScriptRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteScriptRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -110,7 +109,9 @@ public class DeleteScriptRequest extends RequestBase {
 	 * Builder for {@link DeleteScriptRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteScriptRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteScriptRequest> {
 		private String id;
 
 		@Nullable
@@ -165,6 +166,11 @@ public class DeleteScriptRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -237,7 +236,7 @@ public class ExistsRequest extends RequestBase {
 	 * Builder for {@link ExistsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ExistsRequest> {
 		@Nullable
 		private SourceConfigParam source;
 
@@ -443,6 +442,11 @@ public class ExistsRequest extends RequestBase {
 		 */
 		public final Builder versionType(@Nullable VersionType value) {
 			this.versionType = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsSourceRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsSourceRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -225,7 +224,9 @@ public class ExistsSourceRequest extends RequestBase {
 	 * Builder for {@link ExistsSourceRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsSourceRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExistsSourceRequest> {
 		@Nullable
 		private SourceConfigParam source;
 
@@ -404,6 +405,11 @@ public class ExistsSourceRequest extends RequestBase {
 		 */
 		public final Builder versionType(@Nullable VersionType value) {
 			this.versionType = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExplainRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExplainRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -298,7 +297,7 @@ public class ExplainRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link ExplainRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ExplainRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ExplainRequest> {
 		@Nullable
 		private SourceConfigParam source;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/FieldCapsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/FieldCapsRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -256,7 +255,9 @@ public class FieldCapsRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link FieldCapsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<FieldCapsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<FieldCapsRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -237,7 +236,7 @@ public class GetRequest extends RequestBase {
 	 * Builder for {@link GetRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetRequest> {
 		@Nullable
 		private SourceConfigParam source;
 
@@ -445,6 +444,11 @@ public class GetRequest extends RequestBase {
 		 */
 		public final Builder versionType(@Nullable VersionType value) {
 			this.versionType = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -96,7 +95,9 @@ public class GetScriptRequest extends RequestBase {
 	 * Builder for {@link GetScriptRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetScriptRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetScriptRequest> {
 		private String id;
 
 		@Nullable
@@ -129,6 +130,11 @@ public class GetScriptRequest extends RequestBase {
 		 */
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
@@ -44,7 +44,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.Boolean;
@@ -297,7 +296,7 @@ public class IndexRequest<TDocument> extends RequestBase implements JsonpSeriali
 	 * Builder for {@link IndexRequest}.
 	 */
 
-	public static class Builder<TDocument> extends WithJsonObjectBuilderBase<Builder<TDocument>>
+	public static class Builder<TDocument> extends RequestBase.AbstractBuilder<Builder<TDocument>>
 			implements
 				ObjectBuilder<IndexRequest<TDocument>> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/KnnSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/KnnSearchRequest.java
@@ -39,7 +39,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -249,7 +248,9 @@ public class KnnSearchRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link KnnSearchRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<KnnSearchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<KnnSearchRequest> {
 		@Nullable
 		private SourceConfig source;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MgetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MgetRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -268,7 +267,7 @@ public class MgetRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link MgetRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<MgetRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<MgetRequest> {
 		@Nullable
 		private SourceConfigParam source;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchRequest.java
@@ -39,7 +39,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -271,7 +270,7 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 	 * Builder for {@link MsearchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MsearchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<MsearchRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -488,6 +487,11 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 		 */
 		public final Builder searches(Function<RequestItem.Builder, ObjectBuilder<RequestItem>> fn) {
 			return searches(fn.apply(new RequestItem.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchTemplateRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -163,7 +162,9 @@ public class MsearchTemplateRequest extends RequestBase implements NdJsonpSerial
 	 * Builder for {@link MsearchTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MsearchTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<MsearchTemplateRequest> {
 		@Nullable
 		private Boolean ccsMinimizeRoundtrips;
 
@@ -261,6 +262,11 @@ public class MsearchTemplateRequest extends RequestBase implements NdJsonpSerial
 		 */
 		public final Builder searchTemplates(Function<RequestItem.Builder, ObjectBuilder<RequestItem>> fn) {
 			return searchTemplates(fn.apply(new RequestItem.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MtermvectorsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MtermvectorsRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -312,7 +311,7 @@ public class MtermvectorsRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link MtermvectorsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<MtermvectorsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/OpenPointInTimeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/OpenPointInTimeRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -121,7 +120,9 @@ public class OpenPointInTimeRequest extends RequestBase {
 	 * Builder for {@link OpenPointInTimeRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<OpenPointInTimeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<OpenPointInTimeRequest> {
 		@Nullable
 		private Boolean ignoreUnavailable;
 
@@ -183,6 +184,11 @@ public class OpenPointInTimeRequest extends RequestBase {
 		 */
 		public final Builder keepAlive(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.keepAlive(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/PutScriptRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/PutScriptRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -153,7 +152,9 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutScriptRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutScriptRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PutScriptRequest> {
 		@Nullable
 		private String context;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RankEvalRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RankEvalRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -210,7 +209,7 @@ public class RankEvalRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link RankEvalRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<RankEvalRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RankEvalRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRequest.java
@@ -42,7 +42,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Float;
@@ -305,7 +304,7 @@ public class ReindexRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link ReindexRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ReindexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ReindexRequest> {
 		@Nullable
 		private Conflicts conflicts;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRethrottleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRethrottleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.lang.String;
@@ -98,7 +97,9 @@ public class ReindexRethrottleRequest extends RequestBase {
 	 * Builder for {@link ReindexRethrottleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ReindexRethrottleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ReindexRethrottleRequest> {
 		@Nullable
 		private Float requestsPerSecond;
 
@@ -122,6 +123,11 @@ public class ReindexRethrottleRequest extends RequestBase {
 		 */
 		public final Builder taskId(String value) {
 			this.taskId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RenderSearchTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RenderSearchTemplateRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -156,7 +155,7 @@ public class RenderSearchTemplateRequest extends RequestBase implements JsonpSer
 	 * Builder for {@link RenderSearchTemplateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<RenderSearchTemplateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScriptsPainlessExecuteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScriptsPainlessExecuteRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -137,7 +136,7 @@ public class ScriptsPainlessExecuteRequest extends RequestBase implements JsonpS
 	 * Builder for {@link ScriptsPainlessExecuteRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ScriptsPainlessExecuteRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScrollRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScrollRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -118,7 +117,7 @@ public class ScrollRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link ScrollRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ScrollRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ScrollRequest> {
 		@Nullable
 		private Time scroll;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchRequest.java
@@ -55,7 +55,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -1102,7 +1101,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link SearchRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SearchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<SearchRequest> {
 		@Nullable
 		private SourceConfig source;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchShardsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchShardsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -175,7 +174,9 @@ public class SearchShardsRequest extends RequestBase {
 	 * Builder for {@link SearchShardsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SearchShardsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SearchShardsRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -301,6 +302,11 @@ public class SearchShardsRequest extends RequestBase {
 		 */
 		public final Builder routing(@Nullable String value) {
 			this.routing = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchTemplateRequest.java
@@ -39,7 +39,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -333,7 +332,7 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link SearchTemplateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SearchTemplateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermsEnumRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermsEnumRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -236,7 +235,9 @@ public class TermsEnumRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link TermsEnumRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<TermsEnumRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<TermsEnumRequest> {
 		@Nullable
 		private Boolean caseInsensitive;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermvectorsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermvectorsRequest.java
@@ -40,7 +40,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -337,7 +336,7 @@ public class TermvectorsRequest<TDocument> extends RequestBase implements JsonpS
 	 * Builder for {@link TermvectorsRequest}.
 	 */
 
-	public static class Builder<TDocument> extends WithJsonObjectBuilderBase<Builder<TDocument>>
+	public static class Builder<TDocument> extends RequestBase.AbstractBuilder<Builder<TDocument>>
 			implements
 				ObjectBuilder<TermvectorsRequest<TDocument>> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRequest.java
@@ -45,7 +45,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Float;
@@ -604,7 +603,7 @@ public class UpdateByQueryRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link UpdateByQueryRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateByQueryRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRethrottleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRethrottleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.lang.String;
@@ -100,7 +99,9 @@ public class UpdateByQueryRethrottleRequest extends RequestBase {
 	 * Builder for {@link UpdateByQueryRethrottleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<UpdateByQueryRethrottleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<UpdateByQueryRethrottleRequest> {
 		@Nullable
 		private Float requestsPerSecond;
 
@@ -124,6 +125,11 @@ public class UpdateByQueryRethrottleRequest extends RequestBase {
 		 */
 		public final Builder taskId(String value) {
 			this.taskId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateRequest.java
@@ -43,7 +43,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -402,7 +401,7 @@ public class UpdateRequest<TDocument, TPartialDocument> extends RequestBase impl
 
 	public static class Builder<TDocument, TPartialDocument>
 			extends
-				WithJsonObjectBuilderBase<Builder<TDocument, TPartialDocument>>
+				RequestBase.AbstractBuilder<Builder<TDocument, TPartialDocument>>
 			implements
 				ObjectBuilder<UpdateRequest<TDocument, TPartialDocument>> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/DeleteDanglingIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/DeleteDanglingIndexRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -124,7 +123,9 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 	 * Builder for {@link DeleteDanglingIndexRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteDanglingIndexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteDanglingIndexRequest> {
 		private Boolean acceptDataLoss;
 
 		private String indexUuid;
@@ -191,6 +192,11 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/ImportDanglingIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/ImportDanglingIndexRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -124,7 +123,9 @@ public class ImportDanglingIndexRequest extends RequestBase {
 	 * Builder for {@link ImportDanglingIndexRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ImportDanglingIndexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ImportDanglingIndexRequest> {
 		private Boolean acceptDataLoss;
 
 		private String indexUuid;
@@ -191,6 +192,11 @@ public class ImportDanglingIndexRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/DeletePolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/DeletePolicyRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,9 @@ public class DeletePolicyRequest extends RequestBase {
 	 * Builder for {@link DeletePolicyRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeletePolicyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeletePolicyRequest> {
 		private String name;
 
 		/**
@@ -90,6 +91,11 @@ public class DeletePolicyRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/ExecutePolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/ExecutePolicyRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -96,7 +95,9 @@ public class ExecutePolicyRequest extends RequestBase {
 	 * Builder for {@link ExecutePolicyRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExecutePolicyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExecutePolicyRequest> {
 		private String name;
 
 		@Nullable
@@ -119,6 +120,11 @@ public class ExecutePolicyRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/GetPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/GetPolicyRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class GetPolicyRequest extends RequestBase {
 	 * Builder for {@link GetPolicyRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetPolicyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetPolicyRequest> {
 		@Nullable
 		private List<String> name;
 
@@ -107,6 +108,11 @@ public class GetPolicyRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/PutPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/PutPolicyRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -147,7 +146,9 @@ public class PutPolicyRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutPolicyRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutPolicyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PutPolicyRequest> {
 		@Nullable
 		private EnrichPolicy geoMatch;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlDeleteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlDeleteRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class EqlDeleteRequest extends RequestBase {
 	 * Builder for {@link EqlDeleteRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<EqlDeleteRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<EqlDeleteRequest> {
 		private String id;
 
 		/**
@@ -91,6 +92,11 @@ public class EqlDeleteRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlGetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlGetRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -113,7 +112,7 @@ public class EqlGetRequest extends RequestBase {
 	 * Builder for {@link EqlGetRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<EqlGetRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<EqlGetRequest> {
 		private String id;
 
 		@Nullable
@@ -172,6 +171,11 @@ public class EqlGetRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletionTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.waitForCompletionTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlSearchRequest.java
@@ -41,7 +41,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Number;
@@ -405,7 +404,9 @@ public class EqlSearchRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link EqlSearchRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<EqlSearchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<EqlSearchRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/GetEqlStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/GetEqlStatusRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class GetEqlStatusRequest extends RequestBase {
 	 * Builder for {@link GetEqlStatusRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetEqlStatusRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetEqlStatusRequest> {
 		private String id;
 
 		/**
@@ -91,6 +92,11 @@ public class GetEqlStatusRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/fleet/FleetSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/fleet/FleetSearchRequest.java
@@ -54,7 +54,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -1040,7 +1039,7 @@ public class FleetSearchRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link FleetSearchRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<FleetSearchRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/graph/ExploreRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/graph/ExploreRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -202,7 +201,7 @@ public class ExploreRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link ExploreRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ExploreRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ExploreRequest> {
 		@Nullable
 		private Hop connections;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/DeleteLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/DeleteLifecycleRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -114,7 +113,9 @@ public class DeleteLifecycleRequest extends RequestBase {
 	 * Builder for {@link DeleteLifecycleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteLifecycleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteLifecycleRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -173,6 +174,11 @@ public class DeleteLifecycleRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/ExplainLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/ExplainLifecycleRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -148,7 +147,9 @@ public class ExplainLifecycleRequest extends RequestBase {
 	 * Builder for {@link ExplainLifecycleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExplainLifecycleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExplainLifecycleRequest> {
 		private String index;
 
 		@Nullable
@@ -237,6 +238,11 @@ public class ExplainLifecycleRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetLifecycleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -113,7 +112,9 @@ public class GetLifecycleRequest extends RequestBase {
 	 * Builder for {@link GetLifecycleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetLifecycleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetLifecycleRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -173,6 +174,11 @@ public class GetLifecycleRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MigrateToDataTiersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MigrateToDataTiersRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -140,7 +139,7 @@ public class MigrateToDataTiersRequest extends RequestBase implements JsonpSeria
 	 * Builder for {@link MigrateToDataTiersRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<MigrateToDataTiersRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MoveToStepRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MoveToStepRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -131,7 +130,9 @@ public class MoveToStepRequest extends RequestBase implements JsonpSerializable 
 	 * Builder for {@link MoveToStepRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<MoveToStepRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<MoveToStepRequest> {
 		@Nullable
 		private StepKey currentStep;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/PutLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/PutLifecycleRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -146,7 +145,7 @@ public class PutLifecycleRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link PutLifecycleRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutLifecycleRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RemovePolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RemovePolicyRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,9 @@ public class RemovePolicyRequest extends RequestBase {
 	 * Builder for {@link RemovePolicyRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RemovePolicyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<RemovePolicyRequest> {
 		private String index;
 
 		/**
@@ -90,6 +91,11 @@ public class RemovePolicyRequest extends RequestBase {
 		 */
 		public final Builder index(String value) {
 			this.index = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RetryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RetryRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,7 @@ public class RetryRequest extends RequestBase {
 	 * Builder for {@link RetryRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RetryRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RetryRequest> {
 		private String index;
 
 		/**
@@ -92,6 +91,11 @@ public class RetryRequest extends RequestBase {
 		 */
 		public final Builder index(String value) {
 			this.index = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StartIlmRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StartIlmRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.util.HashMap;
 import java.util.Map;
@@ -92,7 +91,7 @@ public class StartIlmRequest extends RequestBase {
 	 * Builder for {@link StartIlmRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StartIlmRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<StartIlmRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -127,6 +126,11 @@ public class StartIlmRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StopIlmRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StopIlmRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.util.HashMap;
 import java.util.Map;
@@ -93,7 +92,7 @@ public class StopIlmRequest extends RequestBase {
 	 * Builder for {@link StopIlmRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StopIlmRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<StopIlmRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -128,6 +127,11 @@ public class StopIlmRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AddBlockRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AddBlockRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -171,7 +170,7 @@ public class AddBlockRequest extends RequestBase {
 	 * Builder for {@link AddBlockRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<AddBlockRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<AddBlockRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -296,6 +295,11 @@ public class AddBlockRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AnalyzeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AnalyzeRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -269,7 +268,7 @@ public class AnalyzeRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link AnalyzeRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<AnalyzeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<AnalyzeRequest> {
 		@Nullable
 		private String analyzer;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ClearCacheRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ClearCacheRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -184,7 +183,9 @@ public class ClearCacheRequest extends RequestBase {
 	 * Builder for {@link ClearCacheRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClearCacheRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClearCacheRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -335,6 +336,11 @@ public class ClearCacheRequest extends RequestBase {
 		 */
 		public final Builder request(@Nullable Boolean value) {
 			this.request = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloneIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloneIndexRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -197,7 +196,9 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 	 * Builder for {@link CloneIndexRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<CloneIndexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<CloneIndexRequest> {
 		@Nullable
 		private Map<String, Alias> aliases;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloseIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloseIndexRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -173,7 +172,9 @@ public class CloseIndexRequest extends RequestBase {
 	 * Builder for {@link CloseIndexRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CloseIndexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<CloseIndexRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -323,6 +324,11 @@ public class CloseIndexRequest extends RequestBase {
 		public final Builder waitForActiveShards(
 				Function<WaitForActiveShards.Builder, ObjectBuilder<WaitForActiveShards>> fn) {
 			return this.waitForActiveShards(fn.apply(new WaitForActiveShards.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateDataStreamRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class CreateDataStreamRequest extends RequestBase {
 	 * Builder for {@link CreateDataStreamRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CreateDataStreamRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<CreateDataStreamRequest> {
 		private String name;
 
 		/**
@@ -91,6 +92,11 @@ public class CreateDataStreamRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateIndexRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -204,7 +203,7 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link CreateIndexRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<CreateIndexRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DataStreamsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DataStreamsStatsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -98,7 +97,9 @@ public class DataStreamsStatsRequest extends RequestBase {
 	 * Builder for {@link DataStreamsStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DataStreamsStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DataStreamsStatsRequest> {
 		@Nullable
 		private List<ExpandWildcard> expandWildcards;
 
@@ -133,6 +134,11 @@ public class DataStreamsStatsRequest extends RequestBase {
 		 */
 		public final Builder name(@Nullable String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteAliasRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -126,7 +125,9 @@ public class DeleteAliasRequest extends RequestBase {
 	 * Builder for {@link DeleteAliasRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteAliasRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteAliasRequest> {
 		private List<String> index;
 
 		@Nullable
@@ -225,6 +226,11 @@ public class DeleteAliasRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteDataStreamRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class DeleteDataStreamRequest extends RequestBase {
 	 * Builder for {@link DeleteDataStreamRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteDataStreamRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteDataStreamRequest> {
 		@Nullable
 		private List<ExpandWildcard> expandWildcards;
 
@@ -154,6 +155,11 @@ public class DeleteDataStreamRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -157,7 +156,9 @@ public class DeleteIndexRequest extends RequestBase {
 	 * Builder for {@link DeleteIndexRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteIndexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteIndexRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -284,6 +285,11 @@ public class DeleteIndexRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexTemplateRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -119,7 +118,9 @@ public class DeleteIndexTemplateRequest extends RequestBase {
 	 * Builder for {@link DeleteIndexTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteIndexTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteIndexTemplateRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -194,6 +195,11 @@ public class DeleteIndexTemplateRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteTemplateRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -110,7 +109,9 @@ public class DeleteTemplateRequest extends RequestBase {
 	 * Builder for {@link DeleteTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteTemplateRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -165,6 +166,11 @@ public class DeleteTemplateRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DiskUsageRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DiskUsageRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -164,7 +163,9 @@ public class DiskUsageRequest extends RequestBase {
 	 * Builder for {@link DiskUsageRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DiskUsageRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DiskUsageRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -283,6 +284,11 @@ public class DiskUsageRequest extends RequestBase {
 		 */
 		public final Builder runExpensiveTasks(@Nullable Boolean value) {
 			this.runExpensiveTasks = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsAliasRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -158,7 +157,9 @@ public class ExistsAliasRequest extends RequestBase {
 	 * Builder for {@link ExistsAliasRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsAliasRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExistsAliasRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -281,6 +282,11 @@ public class ExistsAliasRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsIndexTemplateRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -101,7 +100,9 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 	 * Builder for {@link ExistsIndexTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsIndexTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExistsIndexTemplateRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -136,6 +137,11 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -172,7 +171,7 @@ public class ExistsRequest extends RequestBase {
 	 * Builder for {@link ExistsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ExistsRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -292,6 +291,11 @@ public class ExistsRequest extends RequestBase {
 		 */
 		public final Builder local(@Nullable Boolean value) {
 			this.local = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsTemplateRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -130,7 +129,9 @@ public class ExistsTemplateRequest extends RequestBase {
 	 * Builder for {@link ExistsTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExistsTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExistsTemplateRequest> {
 		@Nullable
 		private Boolean flatSettings;
 
@@ -203,6 +204,11 @@ public class ExistsTemplateRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FieldUsageStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FieldUsageStatsRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -195,7 +194,9 @@ public class FieldUsageStatsRequest extends RequestBase {
 	 * Builder for {@link FieldUsageStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FieldUsageStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<FieldUsageStatsRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -389,6 +390,11 @@ public class FieldUsageStatsRequest extends RequestBase {
 		public final Builder waitForActiveShards(
 				Function<WaitForActiveShards.Builder, ObjectBuilder<WaitForActiveShards>> fn) {
 			return this.waitForActiveShards(fn.apply(new WaitForActiveShards.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FlushRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FlushRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -164,7 +163,7 @@ public class FlushRequest extends RequestBase {
 	 * Builder for {@link FlushRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<FlushRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<FlushRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -281,6 +280,11 @@ public class FlushRequest extends RequestBase {
 		 */
 		public final Builder waitIfOngoing(@Nullable Boolean value) {
 			this.waitIfOngoing = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ForcemergeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ForcemergeRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -188,7 +187,9 @@ public class ForcemergeRequest extends RequestBase {
 	 * Builder for {@link ForcemergeRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ForcemergeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ForcemergeRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -326,6 +327,11 @@ public class ForcemergeRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetAliasRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -156,7 +155,7 @@ public class GetAliasRequest extends RequestBase {
 	 * Builder for {@link GetAliasRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetAliasRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetAliasRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -280,6 +279,11 @@ public class GetAliasRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetDataStreamRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -98,7 +97,9 @@ public class GetDataStreamRequest extends RequestBase {
 	 * Builder for {@link GetDataStreamRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetDataStreamRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetDataStreamRequest> {
 		@Nullable
 		private List<ExpandWildcard> expandWildcards;
 
@@ -154,6 +155,11 @@ public class GetDataStreamRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetFieldMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetFieldMappingRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -171,7 +170,9 @@ public class GetFieldMappingRequest extends RequestBase {
 	 * Builder for {@link GetFieldMappingRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetFieldMappingRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetFieldMappingRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -307,6 +308,11 @@ public class GetFieldMappingRequest extends RequestBase {
 		 */
 		public final Builder local(@Nullable Boolean value) {
 			this.local = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -205,7 +204,7 @@ public class GetIndexRequest extends RequestBase {
 	 * Builder for {@link GetIndexRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetIndexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetIndexRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -384,6 +383,11 @@ public class GetIndexRequest extends RequestBase {
 		 */
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexTemplateRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -130,7 +129,9 @@ public class GetIndexTemplateRequest extends RequestBase {
 	 * Builder for {@link GetIndexTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetIndexTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetIndexTemplateRequest> {
 		@Nullable
 		private Boolean flatSettings;
 
@@ -193,6 +194,11 @@ public class GetIndexTemplateRequest extends RequestBase {
 		 */
 		public final Builder name(@Nullable String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndicesSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndicesSettingsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -200,7 +199,9 @@ public class GetIndicesSettingsRequest extends RequestBase {
 	 * Builder for {@link GetIndicesSettingsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetIndicesSettingsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetIndicesSettingsRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -374,6 +375,11 @@ public class GetIndicesSettingsRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetMappingRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -159,7 +158,9 @@ public class GetMappingRequest extends RequestBase {
 	 * Builder for {@link GetMappingRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetMappingRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetMappingRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -279,6 +280,11 @@ public class GetMappingRequest extends RequestBase {
 		 */
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetTemplateRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -128,7 +127,9 @@ public class GetTemplateRequest extends RequestBase {
 	 * Builder for {@link GetTemplateRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetTemplateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetTemplateRequest> {
 		@Nullable
 		private Boolean flatSettings;
 
@@ -202,6 +203,11 @@ public class GetTemplateRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/IndicesStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/IndicesStatsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -224,7 +223,9 @@ public class IndicesStatsRequest extends RequestBase {
 	 * Builder for {@link IndicesStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<IndicesStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<IndicesStatsRequest> {
 		@Nullable
 		private List<String> completionFields;
 
@@ -480,6 +481,11 @@ public class IndicesStatsRequest extends RequestBase {
 		 */
 		public final Builder metric(String value, String... values) {
 			this.metric = _listAdd(this.metric, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/MigrateToDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/MigrateToDataStreamRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class MigrateToDataStreamRequest extends RequestBase {
 	 * Builder for {@link MigrateToDataStreamRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<MigrateToDataStreamRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<MigrateToDataStreamRequest> {
 		private String name;
 
 		/**
@@ -91,6 +92,11 @@ public class MigrateToDataStreamRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ModifyDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ModifyDataStreamRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.util.Collections;
 import java.util.List;
@@ -108,7 +107,7 @@ public class ModifyDataStreamRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link ModifyDataStreamRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ModifyDataStreamRequest> {
 		private List<Action> actions;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/OpenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/OpenRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -173,7 +172,7 @@ public class OpenRequest extends RequestBase {
 	 * Builder for {@link OpenRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<OpenRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<OpenRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -323,6 +322,11 @@ public class OpenRequest extends RequestBase {
 		public final Builder waitForActiveShards(
 				Function<WaitForActiveShards.Builder, ObjectBuilder<WaitForActiveShards>> fn) {
 			return this.waitForActiveShards(fn.apply(new WaitForActiveShards.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PromoteDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PromoteDataStreamRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class PromoteDataStreamRequest extends RequestBase {
 	 * Builder for {@link PromoteDataStreamRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PromoteDataStreamRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PromoteDataStreamRequest> {
 		private String name;
 
 		/**
@@ -92,6 +93,11 @@ public class PromoteDataStreamRequest extends RequestBase {
 		 */
 		public final Builder name(String value) {
 			this.name = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutAliasRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -229,7 +228,7 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutAliasRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutAliasRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PutAliasRequest> {
 		@Nullable
 		private Query filter;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndexTemplateRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -248,7 +247,7 @@ public class PutIndexTemplateRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link PutIndexTemplateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutIndexTemplateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndicesSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndicesSettingsRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.Boolean;
@@ -209,7 +208,7 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 	 * Builder for {@link PutIndicesSettingsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutIndicesSettingsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutMappingRequest.java
@@ -45,7 +45,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -442,7 +441,9 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 	 * Builder for {@link PutMappingRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutMappingRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PutMappingRequest> {
 		@Nullable
 		private FieldNamesField fieldNames;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutTemplateRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -288,7 +287,7 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link PutTemplateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutTemplateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RecoveryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RecoveryRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -113,7 +112,7 @@ public class RecoveryRequest extends RequestBase {
 	 * Builder for {@link RecoveryRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RecoveryRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RecoveryRequest> {
 		@Nullable
 		private Boolean activeOnly;
 
@@ -166,6 +165,11 @@ public class RecoveryRequest extends RequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RefreshRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RefreshRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -130,7 +129,7 @@ public class RefreshRequest extends RequestBase {
 	 * Builder for {@link RefreshRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<RefreshRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RefreshRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -215,6 +214,11 @@ public class RefreshRequest extends RequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ReloadSearchAnalyzersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ReloadSearchAnalyzersRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -130,7 +129,9 @@ public class ReloadSearchAnalyzersRequest extends RequestBase {
 	 * Builder for {@link ReloadSearchAnalyzersRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ReloadSearchAnalyzersRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ReloadSearchAnalyzersRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -212,6 +213,11 @@ public class ReloadSearchAnalyzersRequest extends RequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ResolveIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ResolveIndexRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -97,7 +96,9 @@ public class ResolveIndexRequest extends RequestBase {
 	 * Builder for {@link ResolveIndexRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ResolveIndexRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ResolveIndexRequest> {
 		@Nullable
 		private List<ExpandWildcard> expandWildcards;
 
@@ -150,6 +151,11 @@ public class ResolveIndexRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RolloverRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RolloverRequest.java
@@ -40,7 +40,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -252,7 +251,7 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link RolloverRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<RolloverRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RolloverRequest> {
 		private String alias;
 
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SegmentsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SegmentsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -144,7 +143,7 @@ public class SegmentsRequest extends RequestBase {
 	 * Builder for {@link SegmentsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SegmentsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<SegmentsRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -242,6 +241,11 @@ public class SegmentsRequest extends RequestBase {
 		 */
 		public final Builder verbose(@Nullable Boolean value) {
 			this.verbose = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShardStoresRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShardStoresRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -142,7 +141,9 @@ public class ShardStoresRequest extends RequestBase {
 	 * Builder for {@link ShardStoresRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ShardStoresRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ShardStoresRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -253,6 +254,11 @@ public class ShardStoresRequest extends RequestBase {
 		 */
 		public final Builder status(ShardStoreStatus value, ShardStoreStatus... values) {
 			this.status = _listAdd(this.status, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShrinkRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShrinkRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -197,7 +196,7 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link ShrinkRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ShrinkRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ShrinkRequest> {
 		@Nullable
 		private Map<String, Alias> aliases;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateIndexTemplateRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -285,7 +284,7 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 	 * Builder for {@link SimulateIndexTemplateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SimulateIndexTemplateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateTemplateRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.Boolean;
@@ -142,7 +141,7 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link SimulateTemplateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SimulateTemplateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SplitRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SplitRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -198,7 +197,7 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link SplitRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SplitRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<SplitRequest> {
 		@Nullable
 		private Map<String, Alias> aliases;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UnfreezeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UnfreezeRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -173,7 +172,7 @@ public class UnfreezeRequest extends RequestBase {
 	 * Builder for {@link UnfreezeRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<UnfreezeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<UnfreezeRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -298,6 +297,11 @@ public class UnfreezeRequest extends RequestBase {
 		 */
 		public final Builder waitForActiveShards(@Nullable String value) {
 			this.waitForActiveShards = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UpdateAliasesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UpdateAliasesRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.util.HashMap;
 import java.util.List;
@@ -135,7 +134,7 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link UpdateAliasesRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateAliasesRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ValidateQueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ValidateQueryRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -295,7 +294,7 @@ public class ValidateQueryRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link ValidateQueryRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ValidateQueryRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/DeletePipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/DeletePipelineRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -110,7 +109,9 @@ public class DeletePipelineRequest extends RequestBase {
 	 * Builder for {@link DeletePipelineRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeletePipelineRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeletePipelineRequest> {
 		private String id;
 
 		@Nullable
@@ -165,6 +166,11 @@ public class DeletePipelineRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GetPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GetPipelineRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -112,7 +111,9 @@ public class GetPipelineRequest extends RequestBase {
 	 * Builder for {@link GetPipelineRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetPipelineRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetPipelineRequest> {
 		@Nullable
 		private String id;
 
@@ -158,6 +159,11 @@ public class GetPipelineRequest extends RequestBase {
 		 */
 		public final Builder summary(@Nullable Boolean value) {
 			this.summary = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/PutPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/PutPipelineRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -259,7 +258,7 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link PutPipelineRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutPipelineRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/SimulateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/SimulateRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -153,7 +152,7 @@ public class SimulateRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link SimulateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SimulateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<SimulateRequest> {
 		@Nullable
 		private List<Document> docs;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetLicenseRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetLicenseRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -108,7 +107,9 @@ public class GetLicenseRequest extends RequestBase {
 	 * Builder for {@link GetLicenseRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetLicenseRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetLicenseRequest> {
 		@Nullable
 		private Boolean acceptEnterprise;
 
@@ -141,6 +142,11 @@ public class GetLicenseRequest extends RequestBase {
 		 */
 		public final Builder local(@Nullable Boolean value) {
 			this.local = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -140,7 +139,7 @@ public class PostRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PostRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PostRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PostRequest> {
 		@Nullable
 		private Boolean acknowledge;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartBasicRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartBasicRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -90,7 +89,9 @@ public class PostStartBasicRequest extends RequestBase {
 	 * Builder for {@link PostStartBasicRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PostStartBasicRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PostStartBasicRequest> {
 		@Nullable
 		private Boolean acknowledge;
 
@@ -101,6 +102,11 @@ public class PostStartBasicRequest extends RequestBase {
 		 */
 		public final Builder acknowledge(@Nullable Boolean value) {
 			this.acknowledge = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartTrialRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartTrialRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -97,7 +96,9 @@ public class PostStartTrialRequest extends RequestBase {
 	 * Builder for {@link PostStartTrialRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PostStartTrialRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PostStartTrialRequest> {
 		@Nullable
 		private Boolean acknowledge;
 
@@ -119,6 +120,11 @@ public class PostStartTrialRequest extends RequestBase {
 		 */
 		public final Builder typeQueryString(@Nullable String value) {
 			this.typeQueryString = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/get/LicenseInformation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/get/LicenseInformation.java
@@ -68,7 +68,8 @@ public class LicenseInformation implements JsonpSerializable {
 
 	private final String issuer;
 
-	private final long maxNodes;
+	@Nullable
+	private final Long maxNodes;
 
 	@Nullable
 	private final Integer maxResourceUnits;
@@ -91,7 +92,7 @@ public class LicenseInformation implements JsonpSerializable {
 		this.issueDateInMillis = ApiTypeHelper.requireNonNull(builder.issueDateInMillis, this, "issueDateInMillis");
 		this.issuedTo = ApiTypeHelper.requireNonNull(builder.issuedTo, this, "issuedTo");
 		this.issuer = ApiTypeHelper.requireNonNull(builder.issuer, this, "issuer");
-		this.maxNodes = ApiTypeHelper.requireNonNull(builder.maxNodes, this, "maxNodes");
+		this.maxNodes = builder.maxNodes;
 		this.maxResourceUnits = builder.maxResourceUnits;
 		this.status = ApiTypeHelper.requireNonNull(builder.status, this, "status");
 		this.type = ApiTypeHelper.requireNonNull(builder.type, this, "type");
@@ -149,9 +150,10 @@ public class LicenseInformation implements JsonpSerializable {
 	}
 
 	/**
-	 * Required - API name: {@code max_nodes}
+	 * API name: {@code max_nodes}
 	 */
-	public final long maxNodes() {
+	@Nullable
+	public final Long maxNodes() {
 		return this.maxNodes;
 	}
 
@@ -224,9 +226,11 @@ public class LicenseInformation implements JsonpSerializable {
 		generator.writeKey("issuer");
 		generator.write(this.issuer);
 
-		generator.writeKey("max_nodes");
-		generator.write(this.maxNodes);
+		if (this.maxNodes != null) {
+			generator.writeKey("max_nodes");
+			generator.write(this.maxNodes);
 
+		}
 		if (this.maxResourceUnits != null) {
 			generator.writeKey("max_resource_units");
 			JsonpUtils.serializeIntOrNull(generator, this.maxResourceUnits, 0);
@@ -271,6 +275,7 @@ public class LicenseInformation implements JsonpSerializable {
 
 		private String issuer;
 
+		@Nullable
 		private Long maxNodes;
 
 		@Nullable
@@ -333,9 +338,9 @@ public class LicenseInformation implements JsonpSerializable {
 		}
 
 		/**
-		 * Required - API name: {@code max_nodes}
+		 * API name: {@code max_nodes}
 		 */
-		public final Builder maxNodes(long value) {
+		public final Builder maxNodes(@Nullable Long value) {
 			this.maxNodes = value;
 			return this;
 		}

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/DeletePipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/DeletePipelineRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -83,7 +82,9 @@ public class DeletePipelineRequest extends RequestBase {
 	 * Builder for {@link DeletePipelineRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeletePipelineRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeletePipelineRequest> {
 		private String id;
 
 		/**
@@ -93,6 +94,11 @@ public class DeletePipelineRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/GetPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/GetPipelineRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class GetPipelineRequest extends RequestBase {
 	 * Builder for {@link GetPipelineRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetPipelineRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetPipelineRequest> {
 		private List<String> id;
 
 		/**
@@ -106,6 +107,11 @@ public class GetPipelineRequest extends RequestBase {
 		 */
 		public final Builder id(String value, String... values) {
 			this.id = _listAdd(this.id, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/PutPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/PutPipelineRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
@@ -103,7 +102,7 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link PutPipelineRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutPipelineRequest> {
 		private String id;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/DeprecationsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/DeprecationsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -84,7 +83,9 @@ public class DeprecationsRequest extends RequestBase {
 	 * Builder for {@link DeprecationsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeprecationsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeprecationsRequest> {
 		@Nullable
 		private String index;
 
@@ -96,6 +97,11 @@ public class DeprecationsRequest extends RequestBase {
 		 */
 		public final Builder index(@Nullable String value) {
 			this.index = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/CloseJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/CloseJobRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -173,7 +172,7 @@ public class CloseJobRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link CloseJobRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<CloseJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<CloseJobRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarEventRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarEventRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -93,7 +92,9 @@ public class DeleteCalendarEventRequest extends RequestBase {
 	 * Builder for {@link DeleteCalendarEventRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteCalendarEventRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteCalendarEventRequest> {
 		private String calendarId;
 
 		private String eventId;
@@ -115,6 +116,11 @@ public class DeleteCalendarEventRequest extends RequestBase {
 		 */
 		public final Builder eventId(String value) {
 			this.eventId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarJobRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -95,7 +94,9 @@ public class DeleteCalendarJobRequest extends RequestBase {
 	 * Builder for {@link DeleteCalendarJobRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteCalendarJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteCalendarJobRequest> {
 		private String calendarId;
 
 		private List<String> jobId;
@@ -133,6 +134,11 @@ public class DeleteCalendarJobRequest extends RequestBase {
 		 */
 		public final Builder jobId(String value, String... values) {
 			this.jobId = _listAdd(this.jobId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,9 @@ public class DeleteCalendarRequest extends RequestBase {
 	 * Builder for {@link DeleteCalendarRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteCalendarRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteCalendarRequest> {
 		private String calendarId;
 
 		/**
@@ -90,6 +91,11 @@ public class DeleteCalendarRequest extends RequestBase {
 		 */
 		public final Builder calendarId(String value) {
 			this.calendarId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDataFrameAnalyticsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -114,7 +113,9 @@ public class DeleteDataFrameAnalyticsRequest extends RequestBase {
 	 * Builder for {@link DeleteDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteDataFrameAnalyticsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteDataFrameAnalyticsRequest> {
 		@Nullable
 		private Boolean force;
 
@@ -161,6 +162,11 @@ public class DeleteDataFrameAnalyticsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDatafeedRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -100,7 +99,9 @@ public class DeleteDatafeedRequest extends RequestBase {
 	 * Builder for {@link DeleteDatafeedRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteDatafeedRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteDatafeedRequest> {
 		private String datafeedId;
 
 		@Nullable
@@ -127,6 +128,11 @@ public class DeleteDatafeedRequest extends RequestBase {
 		 */
 		public final Builder force(@Nullable Boolean value) {
 			this.force = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteExpiredDataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteExpiredDataRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.lang.String;
@@ -146,7 +145,7 @@ public class DeleteExpiredDataRequest extends RequestBase implements JsonpSerial
 	 * Builder for {@link DeleteExpiredDataRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<DeleteExpiredDataRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteFilterRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteFilterRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class DeleteFilterRequest extends RequestBase {
 	 * Builder for {@link DeleteFilterRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteFilterRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteFilterRequest> {
 		private String filterId;
 
 		/**
@@ -92,6 +93,11 @@ public class DeleteFilterRequest extends RequestBase {
 		 */
 		public final Builder filterId(String value) {
 			this.filterId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteForecastRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteForecastRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -134,7 +133,9 @@ public class DeleteForecastRequest extends RequestBase {
 	 * Builder for {@link DeleteForecastRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteForecastRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteForecastRequest> {
 		@Nullable
 		private Boolean allowNoForecasts;
 
@@ -201,6 +202,11 @@ public class DeleteForecastRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteJobRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -119,7 +118,9 @@ public class DeleteJobRequest extends RequestBase {
 	 * Builder for {@link DeleteJobRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteJobRequest> {
 		@Nullable
 		private Boolean force;
 
@@ -157,6 +158,11 @@ public class DeleteJobRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteModelSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteModelSnapshotRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -96,7 +95,9 @@ public class DeleteModelSnapshotRequest extends RequestBase {
 	 * Builder for {@link DeleteModelSnapshotRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteModelSnapshotRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteModelSnapshotRequest> {
 		private String jobId;
 
 		private String snapshotId;
@@ -118,6 +119,11 @@ public class DeleteModelSnapshotRequest extends RequestBase {
 		 */
 		public final Builder snapshotId(String value) {
 			this.snapshotId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelAliasRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -97,7 +96,9 @@ public class DeleteTrainedModelAliasRequest extends RequestBase {
 	 * Builder for {@link DeleteTrainedModelAliasRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteTrainedModelAliasRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteTrainedModelAliasRequest> {
 		private String modelAlias;
 
 		private String modelId;
@@ -119,6 +120,11 @@ public class DeleteTrainedModelAliasRequest extends RequestBase {
 		 */
 		public final Builder modelId(String value) {
 			this.modelId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -98,7 +97,9 @@ public class DeleteTrainedModelRequest extends RequestBase {
 	 * Builder for {@link DeleteTrainedModelRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteTrainedModelRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteTrainedModelRequest> {
 		@Nullable
 		private Boolean force;
 
@@ -122,6 +123,11 @@ public class DeleteTrainedModelRequest extends RequestBase {
 		 */
 		public final Builder modelId(String value) {
 			this.modelId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EstimateModelMemoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EstimateModelMemoryRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -166,7 +165,7 @@ public class EstimateModelMemoryRequest extends RequestBase implements JsonpSeri
 	 * Builder for {@link EstimateModelMemoryRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<EstimateModelMemoryRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EvaluateDataFrameRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EvaluateDataFrameRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -139,7 +138,7 @@ public class EvaluateDataFrameRequest extends RequestBase implements JsonpSerial
 	 * Builder for {@link EvaluateDataFrameRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<EvaluateDataFrameRequest> {
 		private DataframeEvaluation evaluation;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ExplainDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ExplainDataFrameAnalyticsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -280,7 +279,7 @@ public class ExplainDataFrameAnalyticsRequest extends RequestBase implements Jso
 	 * Builder for {@link ExplainDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ExplainDataFrameAnalyticsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/FlushJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/FlushJobRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -196,7 +195,7 @@ public class FlushJobRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link FlushJobRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<FlushJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<FlushJobRequest> {
 		@Nullable
 		private DateTime advanceTime;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ForecastRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ForecastRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -161,7 +160,7 @@ public class ForecastRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link ForecastRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ForecastRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ForecastRequest> {
 		@Nullable
 		private Time duration;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetBucketsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetBucketsRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -294,7 +293,9 @@ public class GetBucketsRequest extends RequestBase implements JsonpSerializable 
 	 * Builder for {@link GetBucketsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<GetBucketsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetBucketsRequest> {
 		@Nullable
 		private Double anomalyScore;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarEventsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarEventsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -158,7 +157,9 @@ public class GetCalendarEventsRequest extends RequestBase {
 	 * Builder for {@link GetCalendarEventsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetCalendarEventsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetCalendarEventsRequest> {
 		private String calendarId;
 
 		@Nullable
@@ -238,6 +239,11 @@ public class GetCalendarEventsRequest extends RequestBase {
 		 */
 		public final Builder start(@Nullable DateTime value) {
 			this.start = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -151,7 +150,7 @@ public class GetCalendarsRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link GetCalendarsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<GetCalendarsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCategoriesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCategoriesRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -175,7 +174,7 @@ public class GetCategoriesRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link GetCategoriesRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<GetCategoriesRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -160,7 +159,9 @@ public class GetDataFrameAnalyticsRequest extends RequestBase {
 	 * Builder for {@link GetDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetDataFrameAnalyticsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetDataFrameAnalyticsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -239,6 +240,11 @@ public class GetDataFrameAnalyticsRequest extends RequestBase {
 		 */
 		public final Builder size(@Nullable Integer value) {
 			this.size = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsStatsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -156,7 +155,9 @@ public class GetDataFrameAnalyticsStatsRequest extends RequestBase {
 	 * Builder for {@link GetDataFrameAnalyticsStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetDataFrameAnalyticsStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetDataFrameAnalyticsStatsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -233,6 +234,11 @@ public class GetDataFrameAnalyticsStatsRequest extends RequestBase {
 		 */
 		public final Builder verbose(@Nullable Boolean value) {
 			this.verbose = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedStatsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -119,7 +118,9 @@ public class GetDatafeedStatsRequest extends RequestBase {
 	 * Builder for {@link GetDatafeedStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetDatafeedStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetDatafeedStatsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -173,6 +174,11 @@ public class GetDatafeedStatsRequest extends RequestBase {
 		 */
 		public final Builder datafeedId(String value, String... values) {
 			this.datafeedId = _listAdd(this.datafeedId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -133,7 +132,9 @@ public class GetDatafeedsRequest extends RequestBase {
 	 * Builder for {@link GetDatafeedsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetDatafeedsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetDatafeedsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -202,6 +203,11 @@ public class GetDatafeedsRequest extends RequestBase {
 		 */
 		public final Builder excludeGenerated(@Nullable Boolean value) {
 			this.excludeGenerated = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetFiltersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetFiltersRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -112,7 +111,9 @@ public class GetFiltersRequest extends RequestBase {
 	 * Builder for {@link GetFiltersRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetFiltersRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetFiltersRequest> {
 		@Nullable
 		private List<String> filterId;
 
@@ -163,6 +164,11 @@ public class GetFiltersRequest extends RequestBase {
 		 */
 		public final Builder size(@Nullable Integer value) {
 			this.size = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetInfluencersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetInfluencersRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -237,7 +236,7 @@ public class GetInfluencersRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link GetInfluencersRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<GetInfluencersRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobStatsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -110,7 +109,9 @@ public class GetJobStatsRequest extends RequestBase {
 	 * Builder for {@link GetJobStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetJobStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetJobStatsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -147,6 +148,11 @@ public class GetJobStatsRequest extends RequestBase {
 		 */
 		public final Builder jobId(@Nullable String value) {
 			this.jobId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -132,7 +131,7 @@ public class GetJobsRequest extends RequestBase {
 	 * Builder for {@link GetJobsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetJobsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetJobsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -200,6 +199,11 @@ public class GetJobsRequest extends RequestBase {
 		 */
 		public final Builder jobId(String value, String... values) {
 			this.jobId = _listAdd(this.jobId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetMemoryStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetMemoryStatsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -133,7 +132,9 @@ public class GetMemoryStatsRequest extends RequestBase {
 	 * Builder for {@link GetMemoryStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetMemoryStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetMemoryStatsRequest> {
 		@Nullable
 		private Boolean human;
 
@@ -209,6 +210,11 @@ public class GetMemoryStatsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotUpgradeStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotUpgradeStatsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -125,7 +124,7 @@ public class GetModelSnapshotUpgradeStatsRequest extends RequestBase {
 	 * Builder for {@link GetModelSnapshotUpgradeStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<GetModelSnapshotUpgradeStatsRequest> {
 		@Nullable
@@ -176,6 +175,11 @@ public class GetModelSnapshotUpgradeStatsRequest extends RequestBase {
 		 */
 		public final Builder snapshotId(String value) {
 			this.snapshotId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotsRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -237,7 +236,7 @@ public class GetModelSnapshotsRequest extends RequestBase implements JsonpSerial
 	 * Builder for {@link GetModelSnapshotsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<GetModelSnapshotsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetOverallBucketsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetOverallBucketsRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -254,7 +253,7 @@ public class GetOverallBucketsRequest extends RequestBase implements JsonpSerial
 	 * Builder for {@link GetOverallBucketsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<GetOverallBucketsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetRecordsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetRecordsRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -267,7 +266,9 @@ public class GetRecordsRequest extends RequestBase implements JsonpSerializable 
 	 * Builder for {@link GetRecordsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<GetRecordsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetRecordsRequest> {
 		@Nullable
 		private Boolean desc;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -195,7 +194,9 @@ public class GetTrainedModelsRequest extends RequestBase {
 	 * Builder for {@link GetTrainedModelsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetTrainedModelsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetTrainedModelsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -310,6 +311,11 @@ public class GetTrainedModelsRequest extends RequestBase {
 		 */
 		public final Builder tags(@Nullable String value) {
 			this.tags = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsStatsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -139,7 +138,9 @@ public class GetTrainedModelsStatsRequest extends RequestBase {
 	 * Builder for {@link GetTrainedModelsStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetTrainedModelsStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetTrainedModelsStatsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -213,6 +214,11 @@ public class GetTrainedModelsStatsRequest extends RequestBase {
 		 */
 		public final Builder size(@Nullable Integer value) {
 			this.size = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferTrainedModelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferTrainedModelRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -166,7 +165,7 @@ public class InferTrainedModelRequest extends RequestBase implements JsonpSerial
 	 * Builder for {@link InferTrainedModelRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<InferTrainedModelRequest> {
 		private List<Map<String, JsonData>> docs;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/OpenJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/OpenJobRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -121,7 +120,7 @@ public class OpenJobRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link OpenJobRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<OpenJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<OpenJobRequest> {
 		private String jobId;
 
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostCalendarEventsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostCalendarEventsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -121,7 +120,7 @@ public class PostCalendarEventsRequest extends RequestBase implements JsonpSeria
 	 * Builder for {@link PostCalendarEventsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PostCalendarEventsRequest> {
 		private String calendarId;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostDataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostDataRequest.java
@@ -40,7 +40,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
@@ -155,7 +154,7 @@ public class PostDataRequest<TData> extends RequestBase implements JsonpSerializ
 	 * Builder for {@link PostDataRequest}.
 	 */
 	@Deprecated
-	public static class Builder<TData> extends WithJsonObjectBuilderBase<Builder<TData>>
+	public static class Builder<TData> extends RequestBase.AbstractBuilder<Builder<TData>>
 			implements
 				ObjectBuilder<PostDataRequest<TData>> {
 		private String jobId;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDataFrameAnalyticsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -121,7 +120,7 @@ public class PreviewDataFrameAnalyticsRequest extends RequestBase implements Jso
 	 * Builder for {@link PreviewDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PreviewDataFrameAnalyticsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDatafeedRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -154,7 +153,7 @@ public class PreviewDatafeedRequest extends RequestBase implements JsonpSerializ
 	 * Builder for {@link PreviewDatafeedRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PreviewDatafeedRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarJobRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -93,7 +92,9 @@ public class PutCalendarJobRequest extends RequestBase {
 	 * Builder for {@link PutCalendarJobRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PutCalendarJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PutCalendarJobRequest> {
 		private String calendarId;
 
 		private String jobId;
@@ -116,6 +117,11 @@ public class PutCalendarJobRequest extends RequestBase {
 		 */
 		public final Builder jobId(String value) {
 			this.jobId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -138,7 +137,7 @@ public class PutCalendarRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link PutCalendarRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutCalendarRequest> {
 		private String calendarId;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDataFrameAnalyticsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -335,7 +334,7 @@ public class PutDataFrameAnalyticsRequest extends RequestBase implements JsonpSe
 	 * Builder for {@link PutDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutDataFrameAnalyticsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDatafeedRequest.java
@@ -42,7 +42,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -505,7 +504,7 @@ public class PutDatafeedRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link PutDatafeedRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutDatafeedRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutFilterRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutFilterRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -142,7 +141,9 @@ public class PutFilterRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutFilterRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutFilterRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PutFilterRequest> {
 		@Nullable
 		private String description;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutJobRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -437,7 +436,7 @@ public class PutJobRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutJobRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PutJobRequest> {
 		@Nullable
 		private Boolean allowLazyOpen;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelAliasRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -123,7 +122,9 @@ public class PutTrainedModelAliasRequest extends RequestBase {
 	 * Builder for {@link PutTrainedModelAliasRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<PutTrainedModelAliasRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<PutTrainedModelAliasRequest> {
 		private String modelAlias;
 
 		private String modelId;
@@ -160,6 +161,11 @@ public class PutTrainedModelAliasRequest extends RequestBase {
 		 */
 		public final Builder reassign(@Nullable Boolean value) {
 			this.reassign = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelDefinitionPartRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelDefinitionPartRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.Long;
@@ -163,7 +162,7 @@ public class PutTrainedModelDefinitionPartRequest extends RequestBase implements
 	 * Builder for {@link PutTrainedModelDefinitionPartRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutTrainedModelDefinitionPartRequest> {
 		private String definition;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -292,7 +291,7 @@ public class PutTrainedModelRequest extends RequestBase implements JsonpSerializ
 	 * Builder for {@link PutTrainedModelRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutTrainedModelRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelVocabularyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelVocabularyRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -146,7 +145,7 @@ public class PutTrainedModelVocabularyRequest extends RequestBase implements Jso
 	 * Builder for {@link PutTrainedModelVocabularyRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutTrainedModelVocabularyRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ResetJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ResetJobRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -99,7 +98,7 @@ public class ResetJobRequest extends RequestBase {
 	 * Builder for {@link ResetJobRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ResetJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ResetJobRequest> {
 		private String jobId;
 
 		@Nullable
@@ -122,6 +121,11 @@ public class ResetJobRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/RevertModelSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/RevertModelSnapshotRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -139,7 +138,7 @@ public class RevertModelSnapshotRequest extends RequestBase implements JsonpSeri
 	 * Builder for {@link RevertModelSnapshotRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<RevertModelSnapshotRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/SetUpgradeModeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/SetUpgradeModeRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -109,7 +108,9 @@ public class SetUpgradeModeRequest extends RequestBase {
 	 * Builder for {@link SetUpgradeModeRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SetUpgradeModeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SetUpgradeModeRequest> {
 		@Nullable
 		private Boolean enabled;
 
@@ -145,6 +146,11 @@ public class SetUpgradeModeRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDataFrameAnalyticsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -111,7 +110,9 @@ public class StartDataFrameAnalyticsRequest extends RequestBase {
 	 * Builder for {@link StartDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StartDataFrameAnalyticsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<StartDataFrameAnalyticsRequest> {
 		private String id;
 
 		@Nullable
@@ -148,6 +149,11 @@ public class StartDataFrameAnalyticsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDatafeedRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.DateTime;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -172,7 +171,7 @@ public class StartDatafeedRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link StartDatafeedRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<StartDatafeedRequest> {
 		private String datafeedId;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartTrainedModelDeploymentRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartTrainedModelDeploymentRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -186,7 +185,9 @@ public class StartTrainedModelDeploymentRequest extends RequestBase {
 	 * Builder for {@link StartTrainedModelDeploymentRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StartTrainedModelDeploymentRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<StartTrainedModelDeploymentRequest> {
 		@Nullable
 		private String cacheSize;
 
@@ -299,6 +300,11 @@ public class StartTrainedModelDeploymentRequest extends RequestBase {
 		 */
 		public final Builder waitFor(@Nullable DeploymentAllocationState value) {
 			this.waitFor = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDataFrameAnalyticsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -141,7 +140,9 @@ public class StopDataFrameAnalyticsRequest extends RequestBase {
 	 * Builder for {@link StopDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StopDataFrameAnalyticsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<StopDataFrameAnalyticsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -215,6 +216,11 @@ public class StopDataFrameAnalyticsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDatafeedRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -160,7 +159,7 @@ public class StopDatafeedRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link StopDatafeedRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<StopDatafeedRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopTrainedModelDeploymentRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopTrainedModelDeploymentRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -119,7 +118,9 @@ public class StopTrainedModelDeploymentRequest extends RequestBase {
 	 * Builder for {@link StopTrainedModelDeploymentRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StopTrainedModelDeploymentRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<StopTrainedModelDeploymentRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -162,6 +163,11 @@ public class StopTrainedModelDeploymentRequest extends RequestBase {
 		 */
 		public final Builder modelId(String value) {
 			this.modelId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDataFrameAnalyticsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -186,7 +185,7 @@ public class UpdateDataFrameAnalyticsRequest extends RequestBase implements Json
 	 * Builder for {@link UpdateDataFrameAnalyticsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateDataFrameAnalyticsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDatafeedRequest.java
@@ -42,7 +42,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -472,7 +471,7 @@ public class UpdateDatafeedRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link UpdateDatafeedRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateDatafeedRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateFilterRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateFilterRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -161,7 +160,7 @@ public class UpdateFilterRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link UpdateFilterRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateFilterRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateJobRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -406,7 +405,9 @@ public class UpdateJobRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link UpdateJobRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<UpdateJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<UpdateJobRequest> {
 		@Nullable
 		private Boolean allowLazyOpen;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateModelSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateModelSnapshotRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -150,7 +149,7 @@ public class UpdateModelSnapshotRequest extends RequestBase implements JsonpSeri
 	 * Builder for {@link UpdateModelSnapshotRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateModelSnapshotRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpgradeJobSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpgradeJobSnapshotRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -132,7 +131,9 @@ public class UpgradeJobSnapshotRequest extends RequestBase {
 	 * Builder for {@link UpgradeJobSnapshotRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<UpgradeJobSnapshotRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<UpgradeJobSnapshotRequest> {
 		private String jobId;
 
 		private String snapshotId;
@@ -191,6 +192,11 @@ public class UpgradeJobSnapshotRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateDetectorRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateDetectorRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.util.Collections;
@@ -88,7 +87,7 @@ public class ValidateDetectorRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link ValidateDetectorRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ValidateDetectorRequest> {
 		private Detector detector;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -237,7 +236,7 @@ public class ValidateRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link ValidateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<ValidateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ValidateRequest> {
 		@Nullable
 		private AnalysisConfig analysisConfig;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/monitoring/BulkRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/monitoring/BulkRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -156,7 +155,7 @@ public class BulkRequest extends RequestBase implements NdJsonpSerializable, Jso
 	 * Builder for {@link BulkRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<BulkRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<BulkRequest> {
 		private Time interval;
 
 		private String systemApiVersion;
@@ -247,6 +246,11 @@ public class BulkRequest extends RequestBase implements NdJsonpSerializable, Jso
 		 */
 		public final Builder operations(Function<BulkOperation.Builder, ObjectBuilder<BulkOperation>> fn) {
 			return operations(fn.apply(new BulkOperation.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ClearRepositoriesMeteringArchiveRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ClearRepositoriesMeteringArchiveRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -102,7 +101,7 @@ public class ClearRepositoriesMeteringArchiveRequest extends RequestBase {
 	 * Builder for {@link ClearRepositoriesMeteringArchiveRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ClearRepositoriesMeteringArchiveRequest> {
 		private Long maxArchiveVersion;
@@ -146,6 +145,11 @@ public class ClearRepositoriesMeteringArchiveRequest extends RequestBase {
 		 */
 		public final Builder nodeId(String value, String... values) {
 			this.nodeId = _listAdd(this.nodeId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/GetRepositoriesMeteringInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/GetRepositoriesMeteringInfoRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -91,7 +90,9 @@ public class GetRepositoriesMeteringInfoRequest extends RequestBase {
 	 * Builder for {@link GetRepositoriesMeteringInfoRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetRepositoriesMeteringInfoRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetRepositoriesMeteringInfoRequest> {
 		private List<String> nodeId;
 
 		/**
@@ -119,6 +120,11 @@ public class GetRepositoriesMeteringInfoRequest extends RequestBase {
 		 */
 		public final Builder nodeId(String value, String... values) {
 			this.nodeId = _listAdd(this.nodeId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/HotThreadsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/HotThreadsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -204,7 +203,9 @@ public class HotThreadsRequest extends RequestBase {
 	 * Builder for {@link HotThreadsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<HotThreadsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<HotThreadsRequest> {
 		@Nullable
 		private Boolean ignoreIdleThreads;
 
@@ -365,6 +366,11 @@ public class HotThreadsRequest extends RequestBase {
 		 */
 		public final Builder type(@Nullable ThreadType value) {
 			this.type = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesInfoRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -142,7 +141,9 @@ public class NodesInfoRequest extends RequestBase {
 	 * Builder for {@link NodesInfoRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NodesInfoRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<NodesInfoRequest> {
 		@Nullable
 		private Boolean flatSettings;
 
@@ -258,6 +259,11 @@ public class NodesInfoRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesStatsRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -251,7 +250,9 @@ public class NodesStatsRequest extends RequestBase {
 	 * Builder for {@link NodesStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NodesStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<NodesStatsRequest> {
 		@Nullable
 		private List<String> completionFields;
 
@@ -549,6 +550,11 @@ public class NodesStatsRequest extends RequestBase {
 		 */
 		public final Builder types(String value, String... values) {
 			this.types = _listAdd(this.types, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesUsageRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesUsageRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -112,7 +111,9 @@ public class NodesUsageRequest extends RequestBase {
 	 * Builder for {@link NodesUsageRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NodesUsageRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<NodesUsageRequest> {
 		@Nullable
 		private List<String> metric;
 
@@ -191,6 +192,11 @@ public class NodesUsageRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ReloadSecureSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ReloadSecureSettingsRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -133,7 +132,7 @@ public class ReloadSecureSettingsRequest extends RequestBase implements JsonpSer
 	 * Builder for {@link ReloadSecureSettingsRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ReloadSecureSettingsRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/DeleteJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/DeleteJobRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,9 @@ public class DeleteJobRequest extends RequestBase {
 	 * Builder for {@link DeleteJobRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteJobRequest> {
 		private String id;
 
 		/**
@@ -90,6 +91,11 @@ public class DeleteJobRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetJobsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetJobsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,7 @@ public class GetJobsRequest extends RequestBase {
 	 * Builder for {@link GetJobsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetJobsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetJobsRequest> {
 		@Nullable
 		private String id;
 
@@ -94,6 +93,11 @@ public class GetJobsRequest extends RequestBase {
 		 */
 		public final Builder id(@Nullable String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupCapsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupCapsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -83,7 +82,9 @@ public class GetRollupCapsRequest extends RequestBase {
 	 * Builder for {@link GetRollupCapsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetRollupCapsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetRollupCapsRequest> {
 		@Nullable
 		private String id;
 
@@ -95,6 +96,11 @@ public class GetRollupCapsRequest extends RequestBase {
 		 */
 		public final Builder id(@Nullable String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupIndexCapsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupIndexCapsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -85,7 +84,9 @@ public class GetRollupIndexCapsRequest extends RequestBase {
 	 * Builder for {@link GetRollupIndexCapsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetRollupIndexCapsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetRollupIndexCapsRequest> {
 		private List<String> index;
 
 		/**
@@ -111,6 +112,11 @@ public class GetRollupIndexCapsRequest extends RequestBase {
 		 */
 		public final Builder index(String value, String... values) {
 			this.index = _listAdd(this.index, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/PutJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/PutJobRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -274,7 +273,7 @@ public class PutJobRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutJobRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PutJobRequest> {
 		private String cron;
 
 		private Groupings groups;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
@@ -114,7 +113,7 @@ public class RollupRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link RollupRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<RollupRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RollupRequest> {
 		private String index;
 
 		private String rollupIndex;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupSearchRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -160,7 +159,7 @@ public class RollupSearchRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link RollupSearchRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<RollupSearchRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StartJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StartJobRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,7 @@ public class StartJobRequest extends RequestBase {
 	 * Builder for {@link StartJobRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StartJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<StartJobRequest> {
 		private String id;
 
 		/**
@@ -90,6 +89,11 @@ public class StartJobRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StopJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StopJobRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -113,7 +112,7 @@ public class StopJobRequest extends RequestBase {
 	 * Builder for {@link StopJobRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StopJobRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<StopJobRequest> {
 		private String id;
 
 		@Nullable
@@ -161,6 +160,11 @@ public class StopJobRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/CacheStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/CacheStatsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class CacheStatsRequest extends RequestBase {
 	 * Builder for {@link CacheStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CacheStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<CacheStatsRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -146,6 +147,11 @@ public class CacheStatsRequest extends RequestBase {
 		 */
 		public final Builder nodeId(String value, String... values) {
 			this.nodeId = _listAdd(this.nodeId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/ClearCacheRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/ClearCacheRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -154,7 +153,9 @@ public class ClearCacheRequest extends RequestBase {
 	 * Builder for {@link ClearCacheRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClearCacheRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClearCacheRequest> {
 		@Nullable
 		private Boolean allowNoIndices;
 
@@ -259,6 +260,11 @@ public class ClearCacheRequest extends RequestBase {
 		 */
 		public final Builder pretty(@Nullable Boolean value) {
 			this.pretty = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/MountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/MountRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -229,7 +228,7 @@ public class MountRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link MountRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<MountRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<MountRequest> {
 		@Nullable
 		private List<String> ignoreIndexSettings;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/SearchableSnapshotsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/SearchableSnapshotsStatsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class SearchableSnapshotsStatsRequest extends RequestBase {
 	 * Builder for {@link SearchableSnapshotsStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SearchableSnapshotsStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SearchableSnapshotsStatsRequest> {
 		@Nullable
 		private List<String> index;
 
@@ -137,6 +138,11 @@ public class SearchableSnapshotsStatsRequest extends RequestBase {
 		 */
 		public final Builder level(@Nullable StatsLevel value) {
 			this.level = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ActivateUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ActivateUserProfileRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -148,7 +147,7 @@ public class ActivateUserProfileRequest extends RequestBase implements JsonpSeri
 	 * Builder for {@link ActivateUserProfileRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ActivateUserProfileRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ChangePasswordRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ChangePasswordRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -159,7 +158,7 @@ public class ChangePasswordRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link ChangePasswordRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ChangePasswordRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearApiKeyCacheRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearApiKeyCacheRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -83,7 +82,9 @@ public class ClearApiKeyCacheRequest extends RequestBase {
 	 * Builder for {@link ClearApiKeyCacheRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClearApiKeyCacheRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClearApiKeyCacheRequest> {
 		private List<String> ids;
 
 		/**
@@ -107,6 +108,11 @@ public class ClearApiKeyCacheRequest extends RequestBase {
 		 */
 		public final Builder ids(String value, String... values) {
 			this.ids = _listAdd(this.ids, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedPrivilegesRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class ClearCachedPrivilegesRequest extends RequestBase {
 	 * Builder for {@link ClearCachedPrivilegesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClearCachedPrivilegesRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClearCachedPrivilegesRequest> {
 		private String application;
 
 		/**
@@ -91,6 +92,11 @@ public class ClearCachedPrivilegesRequest extends RequestBase {
 		 */
 		public final Builder application(String value) {
 			this.application = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRealmsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRealmsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -97,7 +96,9 @@ public class ClearCachedRealmsRequest extends RequestBase {
 	 * Builder for {@link ClearCachedRealmsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClearCachedRealmsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClearCachedRealmsRequest> {
 		private List<String> realms;
 
 		@Nullable
@@ -148,6 +149,11 @@ public class ClearCachedRealmsRequest extends RequestBase {
 		 */
 		public final Builder usernames(String value, String... values) {
 			this.usernames = _listAdd(this.usernames, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRolesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRolesRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -83,7 +82,9 @@ public class ClearCachedRolesRequest extends RequestBase {
 	 * Builder for {@link ClearCachedRolesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClearCachedRolesRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClearCachedRolesRequest> {
 		private List<String> name;
 
 		/**
@@ -107,6 +108,11 @@ public class ClearCachedRolesRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedServiceTokensRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedServiceTokensRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -108,7 +107,9 @@ public class ClearCachedServiceTokensRequest extends RequestBase {
 	 * Builder for {@link ClearCachedServiceTokensRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ClearCachedServiceTokensRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ClearCachedServiceTokensRequest> {
 		private List<String> name;
 
 		private String namespace;
@@ -156,6 +157,11 @@ public class ClearCachedServiceTokensRequest extends RequestBase {
 		 */
 		public final Builder service(String value) {
 			this.service = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateApiKeyRequest.java
@@ -38,7 +38,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -198,7 +197,7 @@ public class CreateApiKeyRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link CreateApiKeyRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<CreateApiKeyRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateServiceTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateServiceTokenRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -127,7 +126,9 @@ public class CreateServiceTokenRequest extends RequestBase {
 	 * Builder for {@link CreateServiceTokenRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CreateServiceTokenRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<CreateServiceTokenRequest> {
 		@Nullable
 		private String name;
 
@@ -178,6 +179,11 @@ public class CreateServiceTokenRequest extends RequestBase {
 		 */
 		public final Builder service(String value) {
 			this.service = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeletePrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeletePrivilegesRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -114,7 +113,9 @@ public class DeletePrivilegesRequest extends RequestBase {
 	 * Builder for {@link DeletePrivilegesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeletePrivilegesRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeletePrivilegesRequest> {
 		private String application;
 
 		private List<String> name;
@@ -166,6 +167,11 @@ public class DeletePrivilegesRequest extends RequestBase {
 		 */
 		public final Builder refresh(@Nullable Refresh value) {
 			this.refresh = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleMappingRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -100,7 +99,9 @@ public class DeleteRoleMappingRequest extends RequestBase {
 	 * Builder for {@link DeleteRoleMappingRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteRoleMappingRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteRoleMappingRequest> {
 		private String name;
 
 		@Nullable
@@ -126,6 +127,11 @@ public class DeleteRoleMappingRequest extends RequestBase {
 		 */
 		public final Builder refresh(@Nullable Refresh value) {
 			this.refresh = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class DeleteRoleRequest extends RequestBase {
 	 * Builder for {@link DeleteRoleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteRoleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteRoleRequest> {
 		private String name;
 
 		@Nullable
@@ -125,6 +126,11 @@ public class DeleteRoleRequest extends RequestBase {
 		 */
 		public final Builder refresh(@Nullable Refresh value) {
 			this.refresh = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteServiceTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteServiceTokenRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -124,7 +123,9 @@ public class DeleteServiceTokenRequest extends RequestBase {
 	 * Builder for {@link DeleteServiceTokenRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteServiceTokenRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteServiceTokenRequest> {
 		private String name;
 
 		private String namespace;
@@ -174,6 +175,11 @@ public class DeleteServiceTokenRequest extends RequestBase {
 		 */
 		public final Builder service(String value) {
 			this.service = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteUserRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class DeleteUserRequest extends RequestBase {
 	 * Builder for {@link DeleteUserRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteUserRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteUserRequest> {
 		@Nullable
 		private Refresh refresh;
 
@@ -125,6 +126,11 @@ public class DeleteUserRequest extends RequestBase {
 		 */
 		public final Builder username(String value) {
 			this.username = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserProfileRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class DisableUserProfileRequest extends RequestBase {
 	 * Builder for {@link DisableUserProfileRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DisableUserProfileRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DisableUserProfileRequest> {
 		@Nullable
 		private Refresh refresh;
 
@@ -124,6 +125,11 @@ public class DisableUserProfileRequest extends RequestBase {
 		 */
 		public final Builder uid(String value) {
 			this.uid = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class DisableUserRequest extends RequestBase {
 	 * Builder for {@link DisableUserRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DisableUserRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DisableUserRequest> {
 		@Nullable
 		private Refresh refresh;
 
@@ -125,6 +126,11 @@ public class DisableUserRequest extends RequestBase {
 		 */
 		public final Builder username(String value) {
 			this.username = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserProfileRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class EnableUserProfileRequest extends RequestBase {
 	 * Builder for {@link EnableUserProfileRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<EnableUserProfileRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<EnableUserProfileRequest> {
 		@Nullable
 		private Refresh refresh;
 
@@ -124,6 +125,11 @@ public class EnableUserProfileRequest extends RequestBase {
 		 */
 		public final Builder uid(String value) {
 			this.uid = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class EnableUserRequest extends RequestBase {
 	 * Builder for {@link EnableUserRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<EnableUserRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<EnableUserRequest> {
 		@Nullable
 		private Refresh refresh;
 
@@ -125,6 +126,11 @@ public class EnableUserRequest extends RequestBase {
 		 */
 		public final Builder username(String value) {
 			this.username = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetApiKeyRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -139,7 +138,9 @@ public class GetApiKeyRequest extends RequestBase {
 	 * Builder for {@link GetApiKeyRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetApiKeyRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetApiKeyRequest> {
 		@Nullable
 		private String id;
 
@@ -202,6 +203,11 @@ public class GetApiKeyRequest extends RequestBase {
 		 */
 		public final Builder username(@Nullable String value) {
 			this.username = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetPrivilegesRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -96,7 +95,9 @@ public class GetPrivilegesRequest extends RequestBase {
 	 * Builder for {@link GetPrivilegesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetPrivilegesRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetPrivilegesRequest> {
 		@Nullable
 		private String application;
 
@@ -134,6 +135,11 @@ public class GetPrivilegesRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleMappingRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -87,7 +86,9 @@ public class GetRoleMappingRequest extends RequestBase {
 	 * Builder for {@link GetRoleMappingRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetRoleMappingRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetRoleMappingRequest> {
 		@Nullable
 		private List<String> name;
 
@@ -120,6 +121,11 @@ public class GetRoleMappingRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -86,7 +85,7 @@ public class GetRoleRequest extends RequestBase {
 	 * Builder for {@link GetRoleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetRoleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetRoleRequest> {
 		@Nullable
 		private List<String> name;
 
@@ -115,6 +114,11 @@ public class GetRoleRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceAccountsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceAccountsRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -100,7 +99,9 @@ public class GetServiceAccountsRequest extends RequestBase {
 	 * Builder for {@link GetServiceAccountsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetServiceAccountsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetServiceAccountsRequest> {
 		@Nullable
 		private String namespace;
 
@@ -127,6 +128,11 @@ public class GetServiceAccountsRequest extends RequestBase {
 		 */
 		public final Builder service(@Nullable String value) {
 			this.service = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceCredentialsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceCredentialsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -93,7 +92,9 @@ public class GetServiceCredentialsRequest extends RequestBase {
 	 * Builder for {@link GetServiceCredentialsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetServiceCredentialsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetServiceCredentialsRequest> {
 		private String namespace;
 
 		private String service;
@@ -115,6 +116,11 @@ public class GetServiceCredentialsRequest extends RequestBase {
 		 */
 		public final Builder service(String value) {
 			this.service = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetTokenRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -185,7 +184,7 @@ public class GetTokenRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link GetTokenRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<GetTokenRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetTokenRequest> {
 		@Nullable
 		private AccessTokenGrantType grantType;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserPrivilegesRequest.java
@@ -32,7 +32,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -112,7 +111,9 @@ public class GetUserPrivilegesRequest extends RequestBase {
 	 * Builder for {@link GetUserPrivilegesRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetUserPrivilegesRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetUserPrivilegesRequest> {
 		@Nullable
 		private String application;
 
@@ -150,6 +151,11 @@ public class GetUserPrivilegesRequest extends RequestBase {
 		 */
 		public final Builder username(@Nullable String value) {
 			this.username = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserProfileRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -99,7 +98,9 @@ public class GetUserProfileRequest extends RequestBase {
 	 * Builder for {@link GetUserProfileRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetUserProfileRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetUserProfileRequest> {
 		@Nullable
 		private List<String> data;
 
@@ -142,6 +143,11 @@ public class GetUserProfileRequest extends RequestBase {
 		 */
 		public final Builder uid(String value) {
 			this.uid = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -84,7 +83,7 @@ public class GetUserRequest extends RequestBase {
 	 * Builder for {@link GetUserRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetUserRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetUserRequest> {
 		@Nullable
 		private List<String> username;
 
@@ -113,6 +112,11 @@ public class GetUserRequest extends RequestBase {
 		 */
 		public final Builder username(String value, String... values) {
 			this.username = _listAdd(this.username, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GrantApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GrantApiKeyRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -162,7 +161,7 @@ public class GrantApiKeyRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link GrantApiKeyRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<GrantApiKeyRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -162,7 +161,7 @@ public class HasPrivilegesRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link HasPrivilegesRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<HasPrivilegesRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesUserProfileRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -125,7 +124,7 @@ public class HasPrivilegesUserProfileRequest extends RequestBase implements Json
 	 * Builder for {@link HasPrivilegesUserProfileRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<HasPrivilegesUserProfileRequest> {
 		private PrivilegesCheck privileges;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateApiKeyRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -192,7 +191,7 @@ public class InvalidateApiKeyRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link InvalidateApiKeyRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<InvalidateApiKeyRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateTokenRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -152,7 +151,7 @@ public class InvalidateTokenRequest extends RequestBase implements JsonpSerializ
 	 * Builder for {@link InvalidateTokenRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<InvalidateTokenRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
@@ -130,7 +129,7 @@ public class PutPrivilegesRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link PutPrivilegesRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutPrivilegesRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleMappingRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -214,7 +213,7 @@ public class PutRoleMappingRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link PutRoleMappingRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutRoleMappingRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -280,7 +279,7 @@ public class PutRoleRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutRoleRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutRoleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PutRoleRequest> {
 		@Nullable
 		private List<ApplicationPrivileges> applications;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutUserRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -245,7 +244,7 @@ public class PutUserRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutUserRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutUserRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PutUserRequest> {
 		@Nullable
 		private String email;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/QueryApiKeysRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/QueryApiKeysRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -191,7 +190,7 @@ public class QueryApiKeysRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link QueryApiKeysRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<QueryApiKeysRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlAuthenticateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlAuthenticateRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -145,7 +144,7 @@ public class SamlAuthenticateRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link SamlAuthenticateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SamlAuthenticateRequest> {
 		private String content;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlCompleteLogoutRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlCompleteLogoutRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.endpoints.BooleanResponse;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -167,7 +166,7 @@ public class SamlCompleteLogoutRequest extends RequestBase implements JsonpSeria
 	 * Builder for {@link SamlCompleteLogoutRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SamlCompleteLogoutRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlInvalidateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlInvalidateRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -150,7 +149,7 @@ public class SamlInvalidateRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link SamlInvalidateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SamlInvalidateRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlLogoutRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlLogoutRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -121,7 +120,9 @@ public class SamlLogoutRequest extends RequestBase implements JsonpSerializable 
 	 * Builder for {@link SamlLogoutRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<SamlLogoutRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SamlLogoutRequest> {
 		@Nullable
 		private String refreshToken;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlPrepareAuthenticationRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlPrepareAuthenticationRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -149,7 +148,7 @@ public class SamlPrepareAuthenticationRequest extends RequestBase implements Jso
 	 * Builder for {@link SamlPrepareAuthenticationRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SamlPrepareAuthenticationRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlServiceProviderMetadataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlServiceProviderMetadataRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -82,7 +81,9 @@ public class SamlServiceProviderMetadataRequest extends RequestBase {
 	 * Builder for {@link SamlServiceProviderMetadataRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SamlServiceProviderMetadataRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SamlServiceProviderMetadataRequest> {
 		private String realmName;
 
 		/**
@@ -92,6 +93,11 @@ public class SamlServiceProviderMetadataRequest extends RequestBase {
 		 */
 		public final Builder realmName(String value) {
 			this.realmName = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SuggestUserProfilesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SuggestUserProfilesRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -175,7 +174,7 @@ public class SuggestUserProfilesRequest extends RequestBase implements JsonpSeri
 	 * Builder for {@link SuggestUserProfilesRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<SuggestUserProfilesRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateApiKeyRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -153,7 +152,7 @@ public class UpdateApiKeyRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link UpdateApiKeyRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateApiKeyRequest> {
 		private String id;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateUserProfileDataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateUserProfileDataRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
@@ -194,7 +193,7 @@ public class UpdateUserProfileDataRequest extends RequestBase implements JsonpSe
 	 * Builder for {@link UpdateUserProfileDataRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateUserProfileDataRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/DeleteNodeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/DeleteNodeRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -113,7 +112,9 @@ public class DeleteNodeRequest extends RequestBase {
 	 * Builder for {@link DeleteNodeRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteNodeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteNodeRequest> {
 		@Nullable
 		private TimeUnit masterTimeout;
 
@@ -151,6 +152,11 @@ public class DeleteNodeRequest extends RequestBase {
 		 */
 		public final Builder timeout(@Nullable TimeUnit value) {
 			this.timeout = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/GetNodeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/GetNodeRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -116,7 +115,7 @@ public class GetNodeRequest extends RequestBase {
 	 * Builder for {@link GetNodeRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetNodeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetNodeRequest> {
 		@Nullable
 		private TimeUnit masterTimeout;
 
@@ -169,6 +168,11 @@ public class GetNodeRequest extends RequestBase {
 		 */
 		public final Builder timeout(@Nullable TimeUnit value) {
 			this.timeout = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/PutNodeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/PutNodeRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -217,7 +216,7 @@ public class PutNodeRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutNodeRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutNodeRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PutNodeRequest> {
 		@Nullable
 		private String allocationDelay;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/DeleteLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/DeleteLifecycleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,9 @@ public class DeleteLifecycleRequest extends RequestBase {
 	 * Builder for {@link DeleteLifecycleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteLifecycleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteLifecycleRequest> {
 		private String policyId;
 
 		/**
@@ -90,6 +91,11 @@ public class DeleteLifecycleRequest extends RequestBase {
 		 */
 		public final Builder policyId(String value) {
 			this.policyId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/ExecuteLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/ExecuteLifecycleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class ExecuteLifecycleRequest extends RequestBase {
 	 * Builder for {@link ExecuteLifecycleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ExecuteLifecycleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ExecuteLifecycleRequest> {
 		private String policyId;
 
 		/**
@@ -91,6 +92,11 @@ public class ExecuteLifecycleRequest extends RequestBase {
 		 */
 		public final Builder policyId(String value) {
 			this.policyId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetLifecycleRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -83,7 +82,9 @@ public class GetLifecycleRequest extends RequestBase {
 	 * Builder for {@link GetLifecycleRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetLifecycleRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetLifecycleRequest> {
 		@Nullable
 		private List<String> policyId;
 
@@ -108,6 +109,11 @@ public class GetLifecycleRequest extends RequestBase {
 		 */
 		public final Builder policyId(String value, String... values) {
 			this.policyId = _listAdd(this.policyId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/PutLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/PutLifecycleRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -228,7 +227,7 @@ public class PutLifecycleRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link PutLifecycleRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutLifecycleRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CleanupRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CleanupRepositoryRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -112,7 +111,9 @@ public class CleanupRepositoryRequest extends RequestBase {
 	 * Builder for {@link CleanupRepositoryRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CleanupRepositoryRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<CleanupRepositoryRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -167,6 +168,11 @@ public class CleanupRepositoryRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CloneSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CloneSnapshotRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -161,7 +160,7 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 	 * Builder for {@link CloneSnapshotRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<CloneSnapshotRequest> {
 		private String indices;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateRepositoryRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -184,7 +183,7 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link CreateRepositoryRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<CreateRepositoryRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateSnapshotRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -286,7 +285,7 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 	 * Builder for {@link CreateSnapshotRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<CreateSnapshotRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteRepositoryRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -114,7 +113,9 @@ public class DeleteRepositoryRequest extends RequestBase {
 	 * Builder for {@link DeleteRepositoryRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteRepositoryRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteRepositoryRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -185,6 +186,11 @@ public class DeleteRepositoryRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteSnapshotRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -108,7 +107,9 @@ public class DeleteSnapshotRequest extends RequestBase {
 	 * Builder for {@link DeleteSnapshotRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteSnapshotRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteSnapshotRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -152,6 +153,11 @@ public class DeleteSnapshotRequest extends RequestBase {
 		 */
 		public final Builder snapshot(String value) {
 			this.snapshot = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetRepositoryRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -114,7 +113,9 @@ public class GetRepositoryRequest extends RequestBase {
 	 * Builder for {@link GetRepositoryRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetRepositoryRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetRepositoryRequest> {
 		@Nullable
 		private Boolean local;
 
@@ -175,6 +176,11 @@ public class GetRepositoryRequest extends RequestBase {
 		 */
 		public final Builder name(String value, String... values) {
 			this.name = _listAdd(this.name, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetSnapshotRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -309,7 +308,9 @@ public class GetSnapshotRequest extends RequestBase {
 	 * Builder for {@link GetSnapshotRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetSnapshotRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetSnapshotRequest> {
 		@Nullable
 		private String after;
 
@@ -559,6 +560,11 @@ public class GetSnapshotRequest extends RequestBase {
 		 */
 		public final Builder verbose(@Nullable Boolean value) {
 			this.verbose = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/RestoreRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/RestoreRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -300,7 +299,7 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link RestoreRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<RestoreRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<RestoreRequest> {
 		@Nullable
 		private List<String> ignoreIndexSettings;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/SnapshotStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/SnapshotStatusRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -128,7 +127,9 @@ public class SnapshotStatusRequest extends RequestBase {
 	 * Builder for {@link SnapshotStatusRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<SnapshotStatusRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<SnapshotStatusRequest> {
 		@Nullable
 		private Boolean ignoreUnavailable;
 
@@ -202,6 +203,11 @@ public class SnapshotStatusRequest extends RequestBase {
 		 */
 		public final Builder snapshot(String value, String... values) {
 			this.snapshot = _listAdd(this.snapshot, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/VerifyRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/VerifyRepositoryRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -111,7 +110,9 @@ public class VerifyRepositoryRequest extends RequestBase {
 	 * Builder for {@link VerifyRepositoryRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<VerifyRepositoryRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<VerifyRepositoryRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -166,6 +167,11 @@ public class VerifyRepositoryRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/ClearCursorRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/ClearCursorRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -96,7 +95,7 @@ public class ClearCursorRequest extends RequestBase implements JsonpSerializable
 	 * Builder for {@link ClearCursorRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ClearCursorRequest> {
 		private String cursor;

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/DeleteAsyncRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/DeleteAsyncRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class DeleteAsyncRequest extends RequestBase {
 	 * Builder for {@link DeleteAsyncRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteAsyncRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteAsyncRequest> {
 		private String id;
 
 		/**
@@ -91,6 +92,11 @@ public class DeleteAsyncRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -143,7 +142,7 @@ public class GetAsyncRequest extends RequestBase {
 	 * Builder for {@link GetAsyncRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetAsyncRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetAsyncRequest> {
 		@Nullable
 		private String delimiter;
 
@@ -230,6 +229,11 @@ public class GetAsyncRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletionTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.waitForCompletionTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncStatusRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class GetAsyncStatusRequest extends RequestBase {
 	 * Builder for {@link GetAsyncStatusRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetAsyncStatusRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetAsyncStatusRequest> {
 		private String id;
 
 		/**
@@ -91,6 +92,11 @@ public class GetAsyncStatusRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/QueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/QueryRequest.java
@@ -39,7 +39,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -422,7 +421,7 @@ public class QueryRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link QueryRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<QueryRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<QueryRequest> {
 		@Nullable
 		private String catalog;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/TranslateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/TranslateRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -150,7 +149,9 @@ public class TranslateRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link TranslateRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<TranslateRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<TranslateRequest> {
 		@Nullable
 		private Integer fetchSize;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ssl/certificates/CertificateInformation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ssl/certificates/CertificateInformation.java
@@ -51,6 +51,7 @@ import javax.annotation.Nullable;
  */
 @JsonpDeserializable
 public class CertificateInformation implements JsonpSerializable {
+	@Nullable
 	private final String alias;
 
 	private final DateTime expiry;
@@ -69,7 +70,7 @@ public class CertificateInformation implements JsonpSerializable {
 
 	private CertificateInformation(Builder builder) {
 
-		this.alias = ApiTypeHelper.requireNonNull(builder.alias, this, "alias");
+		this.alias = builder.alias;
 		this.expiry = ApiTypeHelper.requireNonNull(builder.expiry, this, "expiry");
 		this.format = ApiTypeHelper.requireNonNull(builder.format, this, "format");
 		this.hasPrivateKey = ApiTypeHelper.requireNonNull(builder.hasPrivateKey, this, "hasPrivateKey");
@@ -84,8 +85,9 @@ public class CertificateInformation implements JsonpSerializable {
 	}
 
 	/**
-	 * Required - API name: {@code alias}
+	 * API name: {@code alias}
 	 */
+	@Nullable
 	public final String alias() {
 		return this.alias;
 	}
@@ -143,9 +145,11 @@ public class CertificateInformation implements JsonpSerializable {
 
 	protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
-		generator.writeKey("alias");
-		generator.write(this.alias);
+		if (this.alias != null) {
+			generator.writeKey("alias");
+			generator.write(this.alias);
 
+		}
 		generator.writeKey("expiry");
 		this.expiry.serialize(generator, mapper);
 		generator.writeKey("format");
@@ -179,6 +183,7 @@ public class CertificateInformation implements JsonpSerializable {
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>
 			implements
 				ObjectBuilder<CertificateInformation> {
+		@Nullable
 		private String alias;
 
 		private DateTime expiry;
@@ -194,9 +199,9 @@ public class CertificateInformation implements JsonpSerializable {
 		private String subjectDn;
 
 		/**
-		 * Required - API name: {@code alias}
+		 * API name: {@code alias}
 		 */
-		public final Builder alias(String value) {
+		public final Builder alias(@Nullable String value) {
 			this.alias = value;
 			return this;
 		}

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/CancelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/CancelRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -143,7 +142,7 @@ public class CancelRequest extends RequestBase {
 	 * Builder for {@link CancelRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<CancelRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<CancelRequest> {
 		@Nullable
 		private List<String> actions;
 
@@ -242,6 +241,11 @@ public class CancelRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/GetTasksRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/GetTasksRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -111,7 +110,7 @@ public class GetTasksRequest extends RequestBase {
 	 * Builder for {@link GetTasksRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetTasksRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetTasksRequest> {
 		private String taskId;
 
 		@Nullable
@@ -156,6 +155,11 @@ public class GetTasksRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/ListRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/ListRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -187,7 +186,7 @@ public class ListRequest extends RequestBase {
 	 * Builder for {@link ListRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ListRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<ListRequest> {
 		@Nullable
 		private List<String> actions;
 
@@ -343,6 +342,11 @@ public class ListRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/DeleteTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/DeleteTransformRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -114,7 +113,9 @@ public class DeleteTransformRequest extends RequestBase {
 	 * Builder for {@link DeleteTransformRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteTransformRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteTransformRequest> {
 		@Nullable
 		private Boolean force;
 
@@ -162,6 +163,11 @@ public class DeleteTransformRequest extends RequestBase {
 		 */
 		public final Builder transformId(String value) {
 			this.transformId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
@@ -156,7 +155,9 @@ public class GetTransformRequest extends RequestBase {
 	 * Builder for {@link GetTransformRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetTransformRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetTransformRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -252,6 +253,11 @@ public class GetTransformRequest extends RequestBase {
 		 */
 		public final Builder transformId(String value, String... values) {
 			this.transformId = _listAdd(this.transformId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformStatsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -141,7 +140,9 @@ public class GetTransformStatsRequest extends RequestBase {
 	 * Builder for {@link GetTransformStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetTransformStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<GetTransformStatsRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -221,6 +222,11 @@ public class GetTransformStatsRequest extends RequestBase {
 		 */
 		public final Builder transformId(String value, String... values) {
 			this.transformId = _listAdd(this.transformId, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PreviewTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PreviewTransformRequest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -298,7 +297,7 @@ public class PreviewTransformRequest extends RequestBase implements JsonpSeriali
 	 * Builder for {@link PreviewTransformRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PreviewTransformRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PutTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PutTransformRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -358,7 +357,7 @@ public class PutTransformRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link PutTransformRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<PutTransformRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/ResetTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/ResetTransformRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -103,7 +102,9 @@ public class ResetTransformRequest extends RequestBase {
 	 * Builder for {@link ResetTransformRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ResetTransformRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ResetTransformRequest> {
 		@Nullable
 		private Boolean force;
 
@@ -130,6 +131,11 @@ public class ResetTransformRequest extends RequestBase {
 		 */
 		public final Builder transformId(String value) {
 			this.transformId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StartTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StartTransformRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.HashMap;
@@ -120,7 +119,9 @@ public class StartTransformRequest extends RequestBase {
 	 * Builder for {@link StartTransformRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StartTransformRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<StartTransformRequest> {
 		@Nullable
 		private Time timeout;
 
@@ -154,6 +155,11 @@ public class StartTransformRequest extends RequestBase {
 		 */
 		public final Builder transformId(String value) {
 			this.transformId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StopTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StopTransformRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -173,7 +172,9 @@ public class StopTransformRequest extends RequestBase {
 	 * Builder for {@link StopTransformRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<StopTransformRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<StopTransformRequest> {
 		@Nullable
 		private Boolean allowNoMatch;
 
@@ -279,6 +280,11 @@ public class StopTransformRequest extends RequestBase {
 		 */
 		public final Builder waitForCompletion(@Nullable Boolean value) {
 			this.waitForCompletion = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpdateTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpdateTransformRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -300,7 +299,7 @@ public class UpdateTransformRequest extends RequestBase implements JsonpSerializ
 	 * Builder for {@link UpdateTransformRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<UpdateTransformRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpgradeTransformsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpgradeTransformsRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -105,7 +104,9 @@ public class UpgradeTransformsRequest extends RequestBase {
 	 * Builder for {@link UpgradeTransformsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<UpgradeTransformsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<UpgradeTransformsRequest> {
 		@Nullable
 		private Boolean dryRun;
 
@@ -141,6 +142,11 @@ public class UpgradeTransformsRequest extends RequestBase {
 		 */
 		public final Builder timeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.timeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/AckWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/AckWatchRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -95,7 +94,7 @@ public class AckWatchRequest extends RequestBase {
 	 * Builder for {@link AckWatchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<AckWatchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<AckWatchRequest> {
 		@Nullable
 		private List<String> actionId;
 
@@ -132,6 +131,11 @@ public class AckWatchRequest extends RequestBase {
 		 */
 		public final Builder watchId(String value) {
 			this.watchId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ActivateWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ActivateWatchRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,9 @@ public class ActivateWatchRequest extends RequestBase {
 	 * Builder for {@link ActivateWatchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<ActivateWatchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<ActivateWatchRequest> {
 		private String watchId;
 
 		/**
@@ -90,6 +91,11 @@ public class ActivateWatchRequest extends RequestBase {
 		 */
 		public final Builder watchId(String value) {
 			this.watchId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeactivateWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeactivateWatchRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -81,7 +80,9 @@ public class DeactivateWatchRequest extends RequestBase {
 	 * Builder for {@link DeactivateWatchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeactivateWatchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeactivateWatchRequest> {
 		private String watchId;
 
 		/**
@@ -91,6 +92,11 @@ public class DeactivateWatchRequest extends RequestBase {
 		 */
 		public final Builder watchId(String value) {
 			this.watchId = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeleteWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeleteWatchRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,9 @@ public class DeleteWatchRequest extends RequestBase {
 	 * Builder for {@link DeleteWatchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<DeleteWatchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<DeleteWatchRequest> {
 		private String id;
 
 		/**
@@ -90,6 +91,11 @@ public class DeleteWatchRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ExecuteWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ExecuteWatchRequest.java
@@ -36,7 +36,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -267,7 +266,7 @@ public class ExecuteWatchRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link ExecuteWatchRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<ExecuteWatchRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/GetWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/GetWatchRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
@@ -80,7 +79,7 @@ public class GetWatchRequest extends RequestBase {
 	 * Builder for {@link GetWatchRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<GetWatchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<GetWatchRequest> {
 		private String id;
 
 		/**
@@ -90,6 +89,11 @@ public class GetWatchRequest extends RequestBase {
 		 */
 		public final Builder id(String value) {
 			this.id = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/PutWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/PutWatchRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Long;
@@ -286,7 +285,7 @@ public class PutWatchRequest extends RequestBase implements JsonpSerializable {
 	 * Builder for {@link PutWatchRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<PutWatchRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder> implements ObjectBuilder<PutWatchRequest> {
 		@Nullable
 		private Map<String, Action> actions;
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/QueryWatchesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/QueryWatchesRequest.java
@@ -37,7 +37,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
@@ -189,7 +188,7 @@ public class QueryWatchesRequest extends RequestBase implements JsonpSerializabl
 	 * Builder for {@link QueryWatchesRequest}.
 	 */
 
-	public static class Builder extends WithJsonObjectBuilderBase<Builder>
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
 			implements
 				ObjectBuilder<QueryWatchesRequest> {
 		@Nullable

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/WatcherStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/WatcherStatsRequest.java
@@ -34,7 +34,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.util.HashMap;
@@ -98,7 +97,9 @@ public class WatcherStatsRequest extends RequestBase {
 	 * Builder for {@link WatcherStatsRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<WatcherStatsRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<WatcherStatsRequest> {
 		@Nullable
 		private Boolean emitStacktraces;
 
@@ -136,6 +137,11 @@ public class WatcherStatsRequest extends RequestBase {
 		 */
 		public final Builder metric(WatcherMetric value, WatcherMetric... values) {
 			this.metric = _listAdd(this.metric, value, values);
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackInfoRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
@@ -114,7 +113,9 @@ public class XpackInfoRequest extends RequestBase {
 	 * Builder for {@link XpackInfoRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<XpackInfoRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<XpackInfoRequest> {
 		@Nullable
 		private Boolean acceptEnterprise;
 
@@ -168,6 +169,11 @@ public class XpackInfoRequest extends RequestBase {
 		 */
 		public final Builder human(@Nullable Boolean value) {
 			this.human = value;
+			return this;
+		}
+
+		@Override
+		protected Builder self() {
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackUsageRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackUsageRequest.java
@@ -33,7 +33,6 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
-import co.elastic.clients.util.ObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.util.HashMap;
 import java.util.Map;
@@ -84,7 +83,9 @@ public class XpackUsageRequest extends RequestBase {
 	 * Builder for {@link XpackUsageRequest}.
 	 */
 
-	public static class Builder extends ObjectBuilderBase implements ObjectBuilder<XpackUsageRequest> {
+	public static class Builder extends RequestBase.AbstractBuilder<Builder>
+			implements
+				ObjectBuilder<XpackUsageRequest> {
 		@Nullable
 		private Time masterTimeout;
 
@@ -107,6 +108,11 @@ public class XpackUsageRequest extends RequestBase {
 		 */
 		public final Builder masterTimeout(Function<Time.Builder, ObjectBuilder<Time>> fn) {
 			return this.masterTimeout(fn.apply(new Time.Builder()).build());
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
 		}
 
 		/**


### PR DESCRIPTION
Builder classes were not extending the parent builder class if that parent had no properties. Although this causes no issues to construct objects, this prevented some use cases where we want to use the parent builder in an abstract way, or if some custom behavior is implemented in a property-less parent builder.

With this PR, this "optimization" in the code generator has been removed and the builder hierarchy follows exactly that of the data classes.