### PR TITLE
Allow JacksonJsonpMapper user provided ObjectMapper to maintain configuration

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
@@ -45,17 +45,17 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
     }
 
     public JacksonJsonpMapper(ObjectMapper objectMapper) {
-        this(
-            objectMapper
-                .configure(SerializationFeature.INDENT_OUTPUT, false)
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL),
+        this(objectMapper,
             // Creating the json factory from the mapper ensures it will be returned by JsonParser.getCodec()
             new JacksonJsonProvider(objectMapper.getFactory())
         );
     }
 
     public JacksonJsonpMapper() {
-        this(new ObjectMapper());
+        this(new ObjectMapper()
+            .configure(SerializationFeature.INDENT_OUTPUT, false)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        );
     }
 
     @Override


### PR DESCRIPTION
The JacksonJsonpMapper has a public constructor that takes in a user provided ObjectMapper to allow customization for serialization and deserialization.  The constructor can be misleading since it overrides two configurations to disable pretty print and disregard null values on serialization.  As far as I can tell, there is no other way to modify the ObjectMapper configuration other than through the constructor.

The proposal is that these configurations be moved to the default constructor.  This allows users with no preference to take the default configuration, but if custom configuration is desired a user can provide the ObjectMapper.  A few advantages to this strategy:

1. Default constructor still provides desired default configuration
2. Provides more flexibility of configuration to the user
3. Constructor with parameter ObjectMapper will be less confusing to the users

For context, the change was made in this [commit](https://github.com/elastic/elasticsearch-java/commit/1df3f02ceaa3e1900ff58995eeb6e7a628c207a0#diff-8b6b1783b9732bea958c33e27b933df8bd8f87643315d82cf5a3ba5f8469766c).