### PR TITLE
Add update documentation (#281)

### DIFF
--- a/docs/usage/updating.asciidoc
+++ b/docs/usage/updating.asciidoc
@@ -1,0 +1,52 @@
+[[updating]]
+=== Updating single documents
+
+The {java-client} offers an easy way to update parts of documents.
+
+NOTE: See the {es-docs}/docs-update.html[{es} API documentation] for a full explanation of update requests.
+
+[discrete]
+==== Using the fluent DSL
+
+The example below updates the document with identifier `bk-1` from the `products` index.
+
+We have four important concepts in the following example:
+
+* the first object represents the whole document, in this case `Product`
+* the second object represents a part of the document, here `ProductName` to indicate to only update the `name` field
+* the third parameter is the actual request, built below with the fluent DSL
+* the fourth parameter is the class we want the document's JSON from the response to be mapped to
+
+NOTE: Use the {es-docs}/docs-index_.html[{es} API documentation] for overwriting a whole document.
+
+
+["source", "java"]
+--------------------------------------------------
+include-tagged::{doc-tests-src}/usage/UpdatingTest.java[update-by-id-dsl]
+--------------------------------------------------
+<1> The `Product` object representing the corresponding document.
+<2> The `ProductName` object representing the part of the `Product`, which should be updated.
+<3> The `update` request, with the index name and the document id.
+<4> The target class, here `Product`.
+
+[discrete]
+==== Using classic builders
+
+You can also use the classic builder pattern, if you're more used to it.
+["source", "java"]
+--------------------------------------------------
+include-tagged::{doc-tests-src}/usage/UpdatingTest.java[update-by-id-builder]
+--------------------------------------------------
+<1> Note, how the first generic parameter corresponds to the full document `Product` and the second parameter, which corresponds to `ProductName`.
+
+[discrete]
+==== Using the asynchronous client
+
+The examples above used the synchronous {es} client. All {es} APIs are also available in the asynchronous client, using the same request and response types. See also <<blocking-and-async>> for additional details.
+
+["source", "java"]
+--------------------------------------------------
+include-tagged::{doc-tests-src}/usage/UpdatingTest.java[update-by-id-dsl-async]
+--------------------------------------------------
+
+{doc-tests-blurb}

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateRequest.java
@@ -50,7 +50,6 @@ import java.lang.Long;
 import java.lang.String;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -500,7 +499,7 @@ public class UpdateRequest<TDocument, TPartialDocument> extends RequestBase impl
 		 * <p>
 		 * API name: {@code doc}
 		 */
-		public final Builder<TDocument, TPartialDocument> doc(@Nullable TPartialDocument value) {
+		public final Builder<TDocument, TPartialDocument> document(@Nullable TPartialDocument value) {
 			this.doc = value;
 			return this;
 		}
@@ -510,7 +509,7 @@ public class UpdateRequest<TDocument, TPartialDocument> extends RequestBase impl
 		 * <p>
 		 * API name: {@code doc_as_upsert}
 		 */
-		public final Builder<TDocument, TPartialDocument> docAsUpsert(@Nullable Boolean value) {
+		public final Builder<TDocument, TPartialDocument> documentAsUpsert(@Nullable Boolean value) {
 			this.docAsUpsert = value;
 			return this;
 		}
@@ -764,8 +763,8 @@ public class UpdateRequest<TDocument, TPartialDocument> extends RequestBase impl
 
 		op.add(Builder::source, SourceConfig._DESERIALIZER, "_source");
 		op.add(Builder::detectNoop, JsonpDeserializer.booleanDeserializer(), "detect_noop");
-		op.add(Builder::doc, tPartialDocumentDeserializer, "doc");
-		op.add(Builder::docAsUpsert, JsonpDeserializer.booleanDeserializer(), "doc_as_upsert");
+		op.add(Builder::document, tPartialDocumentDeserializer, "doc");
+		op.add(Builder::documentAsUpsert, JsonpDeserializer.booleanDeserializer(), "doc_as_upsert");
 		op.add(Builder::script, Script._DESERIALIZER, "script");
 		op.add(Builder::scriptedUpsert, JsonpDeserializer.booleanDeserializer(), "scripted_upsert");
 		op.add(Builder::upsert, tDocumentDeserializer, "upsert");

--- a/java-client/src/test/java/co/elastic/clients/documentation/usage/ProductName.java
+++ b/java-client/src/test/java/co/elastic/clients/documentation/usage/ProductName.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.documentation.usage;
+
+public class ProductName {
+
+    private String name;
+
+    public ProductName(){}
+    public ProductName(String name){
+        this.name = name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/java-client/src/test/java/co/elastic/clients/documentation/usage/UpdatingTest.java
+++ b/java-client/src/test/java/co/elastic/clients/documentation/usage/UpdatingTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.documentation.usage;
+
+import co.elastic.clients.documentation.DocTestsTransport;
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Result;
+import co.elastic.clients.elasticsearch.core.UpdateRequest;
+import co.elastic.clients.elasticsearch.core.UpdateResponse;
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UpdatingTest extends ModelTestCase {
+
+    private final DocTestsTransport transport = new DocTestsTransport();
+    private final ElasticsearchClient esClient = new ElasticsearchClient(transport);
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    UpdateResponse<Product> result = UpdateResponse.of(u -> u
+        .index("product")
+        .id("bk-1")
+        .version(2)
+        .seqNo(2)
+        .result(Result.Updated)
+        .primaryTerm(1)
+        .shards(s -> s.total(1).successful(1).failed(0)));
+
+    @Test
+    public void singleDocumentDSLwithOf() throws Exception {
+
+        // Stub response
+        transport.setResult(result);
+
+        //tag::update-by-id-dsl
+        Product product = new Product("bk-1", "City bike", 123.0); // <1>
+        ProductName productName = new ProductName("Track bike"); // <2>
+
+        UpdateResponse<Product> response = esClient.update(u -> u
+            .index("product") // <3>
+            .id(product.getSku())
+            .document(productName),
+            Product.class // <4>
+        );
+
+        logger.info("Updated with version " + response.version());
+        //end::update-by-id-dsl
+    }
+
+    @Test
+    public void singleDocumentBuilder() throws Exception {
+
+        // Stub response
+        transport.setResult(result);
+
+        //tag::update-by-id-builder
+        Product product = new Product("bk-1", "City bike", 123.0);
+        ProductName productName = new ProductName("Track bike");
+
+        UpdateRequest.Builder<Product, ProductName> updateReqBuilder = new UpdateRequest.Builder<>(); // <1>
+        updateReqBuilder.index("product");
+        updateReqBuilder.id(product.getSku());
+        updateReqBuilder.document(productName);
+
+        UpdateResponse<Product> response = esClient.update(
+                updateReqBuilder.build(),
+                Product.class
+        );
+
+        logger.info("Updated with version " + response.version());
+        //end::update-by-id-builder
+    }
+
+    @Test
+    public void singleDocumentDSLAsync() {
+
+        // Stub response
+        transport.setResult(result);
+
+        //tag::update-by-id-dsl-async
+        ElasticsearchAsyncClient esAsyncClient = new ElasticsearchAsyncClient(transport);
+
+        Product product = new Product("bk-1", "City bike", 123.0);
+        ProductName productName = new ProductName("Track bike");
+
+        esAsyncClient.update(u -> u
+            .index("product")
+            .id(product.getSku())
+            .document(productName),
+            Product.class
+        ).whenComplete((response, exception) -> {
+            if (exception != null) {
+                logger.error("Failed to update", exception);
+            } else {
+                logger.info("Updated with version " + response.version());
+            }
+        });
+        //end::update-by-id-dsl-async
+    }
+
+}


### PR DESCRIPTION
Just played around with the java-client today and saw, that the update documentation is missing, but already noted as TODO in #281. Played around with the update API and thought it could be helpful to add it directly to the repo.