### PR TITLE
Add Type in addition to Class to map types with generic parameters

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -231,10 +231,6 @@ dependencies {
     // https://www.testcontainers.org/
     testImplementation("org.testcontainers", "testcontainers", "1.17.3")
     testImplementation("org.testcontainers", "elasticsearch", "1.17.3")
-
-    // Apache 2.0
-    // https://guava.dev/
-    testImplementation("com.google.guava:guava:31.1-jre")
 }
 
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -231,6 +231,10 @@ dependencies {
     // https://www.testcontainers.org/
     testImplementation("org.testcontainers", "testcontainers", "1.17.3")
     testImplementation("org.testcontainers", "elasticsearch", "1.17.3")
+
+    // Apache 2.0
+    // https://guava.dev/
+    testImplementation("com.google.guava:guava:31.1-jre")
 }
 
 

--- a/java-client/src/main/java/co/elastic/clients/ApiClient.java
+++ b/java-client/src/main/java/co/elastic/clients/ApiClient.java
@@ -26,6 +26,7 @@ import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapperBase;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.Type;
 import java.util.function.Function;
 
 public abstract class ApiClient<T extends Transport, Self extends ApiClient<T, Self>> {
@@ -38,14 +39,14 @@ public abstract class ApiClient<T extends Transport, Self extends ApiClient<T, S
         this.transportOptions = transportOptions;
     }
 
-    protected <V> JsonpDeserializer<V> getDeserializer(Class<V> clazz) {
+    protected <V> JsonpDeserializer<V> getDeserializer(Type type) {
         // Try the built-in deserializers first to avoid repeated lookups in the Jsonp mapper for client-defined classes
-        JsonpDeserializer<V> result = JsonpMapperBase.findDeserializer(clazz);
+        JsonpDeserializer<V> result = JsonpMapperBase.findDeserializer(type);
         if (result != null) {
             return result;
         }
 
-        return JsonpDeserializer.of(clazz);
+        return JsonpDeserializer.of(type);
     }
 
     /**

--- a/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonpMapper.java
@@ -24,6 +24,7 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.Type;
 
 public abstract class DelegatingJsonpMapper implements JsonpMapper {
 
@@ -39,8 +40,8 @@ public abstract class DelegatingJsonpMapper implements JsonpMapper {
     }
 
     @Override
-    public <T> T deserialize(JsonParser parser, Class<T> clazz) {
-        return mapper.deserialize(parser, clazz);
+    public <T> T deserialize(JsonParser parser, Type type) {
+        return mapper.deserialize(parser, type);
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/json/JsonData.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonData.java
@@ -26,6 +26,7 @@ import jakarta.json.stream.JsonParser;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.reflect.Type;
 import java.util.EnumSet;
 
 /**
@@ -60,9 +61,21 @@ public interface JsonData extends JsonpSerializable {
     <T> T to(Class<T> clazz);
 
     /**
+     * Converts this object to a target type. A mapper must have been provided at creation time.
+     *
+     * @throws IllegalStateException if no mapper was provided at creation time.
+     */
+    <T> T to(Type type);
+
+    /**
      * Converts this object to a target class.
      */
      <T> T to(Class<T> clazz, JsonpMapper mapper);
+
+    /**
+     * Converts this object to a target type.
+     */
+    <T> T to(Type type, JsonpMapper mapper);
 
     /**
      * Converts this object using a deserializer. A mapper must have been provided at creation time.

--- a/java-client/src/main/java/co/elastic/clients/json/JsonDataImpl.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonDataImpl.java
@@ -25,6 +25,7 @@ import jakarta.json.stream.JsonParser;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.reflect.Type;
 
 class JsonDataImpl implements JsonData {
     private final Object value;
@@ -65,19 +66,30 @@ class JsonDataImpl implements JsonData {
 
     @Override
     public <T> T to(Class<T> clazz) {
+        return to((Type)clazz, null);
+    }
+
+    @Override
+    public <T> T to(Type clazz) {
         return to(clazz, null);
     }
 
     @Override
     public <T> T to(Class<T> clazz, JsonpMapper mapper) {
-        if (clazz.isAssignableFrom(value.getClass())) {
-            return (T) value;
+        return to((Type)clazz, mapper);
+    }
+
+    @Override
+    public <T> T to(Type type, JsonpMapper mapper) {
+        if (type instanceof Class<?> && ((Class<?>)type).isAssignableFrom(value.getClass())) {
+            @SuppressWarnings("unchecked")
+            T result = (T) value;
+            return result;
         }
 
         mapper = getMapper(mapper);
-
         JsonParser parser = getParser(mapper);
-        return mapper.deserialize(parser, clazz);
+        return mapper.deserialize(parser, type);
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
@@ -25,6 +25,7 @@ import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParser.Event;
 
 import java.io.StringReader;
+import java.lang.reflect.Type;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -88,15 +89,23 @@ public interface JsonpDeserializer<V> {
 
     //---------------------------------------------------------------------------------------------
 
+//    /**
+//     * Creates a deserializer for a class that delegates to the mapper provided to
+//     * {@link #deserialize(JsonParser, JsonpMapper)}.
+//     */
+//    static <T>JsonpDeserializer<T> of(Class<T> clazz) {
+//        return of((Type)clazz);
+//    }
+
     /**
-     * Creates a deserializer for a class that delegates to the mapper provided to
+     * Creates a deserializer for a type that delegates to the mapper provided to
      * {@link #deserialize(JsonParser, JsonpMapper)}.
      */
-    static <T>JsonpDeserializer<T> of (Class<T> clazz) {
+    static <T>JsonpDeserializer<T> of(Type type) {
         return new JsonpDeserializerBase<T>(EnumSet.allOf(JsonParser.Event.class)) {
             @Override
             public T deserialize(JsonParser parser, JsonpMapper mapper) {
-                return mapper.deserialize(parser, clazz);
+                return mapper.deserialize(parser, type);
             }
 
             @Override

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpMapper.java
@@ -24,6 +24,7 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.Type;
 
 /**
  * A {@code JsonpMapper} combines a JSON-P provider and object serialization/deserialization based on JSON-P events.
@@ -44,7 +45,14 @@ public interface JsonpMapper {
     /**
      * Deserialize an object, given its class.
      */
-    <T> T deserialize(JsonParser parser, Class<T> clazz);
+    default <T> T deserialize(JsonParser parser, Class<T> clazz) {
+        return deserialize(parser, (Type)clazz);
+    }
+
+    /**
+     * Deserialize an object, given its type.
+     */
+    <T> T deserialize(JsonParser parser, Type type);
 
     /**
      * Serialize an object.

--- a/java-client/src/main/java/co/elastic/clients/json/SimpleJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/SimpleJsonpMapper.java
@@ -23,6 +23,7 @@ import jakarta.json.JsonException;
 import jakarta.json.spi.JsonProvider;
 import jakarta.json.stream.JsonGenerator;
 
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,8 +38,8 @@ public class SimpleJsonpMapper extends JsonpMapperBase {
     public static SimpleJsonpMapper INSTANCE = new SimpleJsonpMapper(true);
     public static SimpleJsonpMapper INSTANCE_REJECT_UNKNOWN_FIELDS = new SimpleJsonpMapper(false);
 
-    private static final Map<Class<?>, JsonpSerializer<?>> serializers = new HashMap<>();
-    private static final Map<Class<?>, JsonpDeserializer<?>> deserializers = new HashMap<>();
+    private static final Map<Type, JsonpSerializer<?>> serializers = new HashMap<>();
+    private static final Map<Type, JsonpDeserializer<?>> deserializers = new HashMap<>();
 
     static {
         serializers.put(String.class, (JsonpSerializer<String>) (value, generator, mapper) -> generator.write(value));
@@ -117,14 +118,14 @@ public class SimpleJsonpMapper extends JsonpMapperBase {
     }
 
     @Override
-    protected <T> JsonpDeserializer<T> getDefaultDeserializer(Class<T> clazz) {
+    protected <T> JsonpDeserializer<T> getDefaultDeserializer(Type type) {
         @SuppressWarnings("unchecked")
-        JsonpDeserializer<T> deserializer = (JsonpDeserializer<T>) deserializers.get(clazz);
+        JsonpDeserializer<T> deserializer = (JsonpDeserializer<T>) deserializers.get(type);
         if (deserializer != null) {
             return deserializer;
         } else {
             throw new JsonException(
-                "Cannot find a deserializer for type " + clazz.getName() +
+                "Cannot find a deserializer for type " + type.getTypeName() +
                     ". Consider using a full-featured JsonpMapper"
             );
         }

--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
@@ -32,6 +32,7 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.EnumSet;
 
 public class JacksonJsonpMapper extends JsonpMapperBase {
@@ -76,8 +77,8 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
     }
 
     @Override
-    protected  <T> JsonpDeserializer<T> getDefaultDeserializer(Class<T> clazz) {
-        return new JacksonValueParser<>(clazz);
+    protected  <T> JsonpDeserializer<T> getDefaultDeserializer(Type type) {
+        return new JacksonValueParser<>(type);
     }
 
     @Override
@@ -103,11 +104,11 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
 
     private class JacksonValueParser<T> extends JsonpDeserializerBase<T> {
 
-        private final Class<T> clazz;
+        private final Type type;
 
-        protected JacksonValueParser(Class<T> clazz) {
+        protected JacksonValueParser(Type type) {
             super(EnumSet.allOf(JsonParser.Event.class));
-            this.clazz = clazz;
+            this.type = type;
         }
 
         @Override
@@ -120,7 +121,7 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
             com.fasterxml.jackson.core.JsonParser jkParser = ((JacksonJsonpParser)parser).jacksonParser();
 
             try {
-                return objectMapper.readValue(jkParser, clazz);
+                return objectMapper.readValue(jkParser, objectMapper().constructType(type));
             } catch(IOException ioe) {
                 throw JacksonUtils.convertException(ioe);
             }

--- a/java-client/src/main/java/co/elastic/clients/json/jsonb/JsonbJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jsonb/JsonbJsonpMapper.java
@@ -34,6 +34,7 @@ import jakarta.json.stream.JsonParser.Event;
 
 import java.io.CharArrayReader;
 import java.io.CharArrayWriter;
+import java.lang.reflect.Type;
 import java.util.EnumSet;
 
 public class JsonbJsonpMapper extends JsonpMapperBase {
@@ -60,8 +61,8 @@ public class JsonbJsonpMapper extends JsonpMapperBase {
     }
 
     @Override
-    protected <T> JsonpDeserializer<T> getDefaultDeserializer(Class<T> clazz) {
-        return new Deserializer<>(clazz);
+    protected <T> JsonpDeserializer<T> getDefaultDeserializer(Type type) {
+        return new Deserializer<>(type);
     }
 
     @Override
@@ -86,11 +87,11 @@ public class JsonbJsonpMapper extends JsonpMapperBase {
     }
 
     private class Deserializer<T> extends JsonpDeserializerBase<T> {
-        private final Class<T> clazz;
+        private final Type type;
 
-        Deserializer(Class<T> clazz) {
+        Deserializer(Type type) {
             super(EnumSet.allOf(JsonParser.Event.class));
-            this.clazz = clazz;
+            this.type = type;
         }
 
         @Override
@@ -106,7 +107,7 @@ public class JsonbJsonpMapper extends JsonpMapperBase {
             generator.close();
 
             CharArrayReader car = new CharArrayReader(caw.toCharArray());
-            return jsonb.fromJson(car, clazz);
+            return jsonb.fromJson(car, type);
         }
     }
 

--- a/java-client/src/main/java/co/elastic/clients/util/MissingRequiredPropertyException.java
+++ b/java-client/src/main/java/co/elastic/clients/util/MissingRequiredPropertyException.java
@@ -26,8 +26,9 @@ package co.elastic.clients.util;
  * available in {@link ApiTypeHelper} to disable checks. Use with caution.
  */
 public class MissingRequiredPropertyException extends RuntimeException {
-    private Class<?> clazz;
-    private String property;
+    private final Class<?> clazz;
+    private final String property;
+
     public MissingRequiredPropertyException(Object obj, String property) {
         super("Missing required property '" + obj.getClass().getSimpleName() + "." + property + "'");
         this.clazz = obj.getClass();

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpMapperTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpMapperTest.java
@@ -23,9 +23,9 @@ import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.json.jsonb.JsonbJsonpMapper;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.google.common.reflect.TypeToken;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import org.junit.jupiter.api.Assertions;
@@ -96,10 +96,10 @@ public class JsonpMapperTest extends Assertions {
 
         // Use a j.l.reflect.Type to deserialize map values correctly
         {
-            TypeToken<Map<String, SomeClass>> typeToken = new TypeToken<Map<String, SomeClass>>() {};
+            TypeReference<Map<String, SomeClass>> typeRef = new TypeReference<Map<String, SomeClass>>() {};
 
             JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
-            Map<String, SomeClass> map = mapper.deserialize(parser, typeToken.getType());
+            Map<String, SomeClass> map = mapper.deserialize(parser, typeRef.getType());
 
             System.out.println(map);
             assertEquals(1, map.get("foo").intValue);

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpMapperTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/json/JsonpMapperTest.java
@@ -25,6 +25,7 @@ import co.elastic.clients.json.jsonb.JsonbJsonpMapper;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.google.common.reflect.TypeToken;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import org.junit.jupiter.api.Assertions;
@@ -32,8 +33,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class JsonpMapperTest extends Assertions {
 
@@ -67,6 +71,40 @@ public class JsonpMapperTest extends Assertions {
 
         testSerialize(mapper, json);
         testDeserialize(mapper, json);
+    }
+
+    @Test
+    public void testDeserializeWithType() {
+
+        String json = "{\"foo\":{\"int_value\":1,\"double_value\":1.0},\"bar\":{\"int_value\":2,\"double_value\":2.0}}";
+
+        ObjectMapper jkMapper = new ObjectMapper();
+        jkMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper(jkMapper);
+
+        // With type erasure, map values are raw json nodes
+        {
+            JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+            Map<String, SomeClass> map = new HashMap<>();
+            map = mapper.deserialize(parser, (Type) map.getClass());
+
+            Map<String, SomeClass> finalMap = map;
+            assertThrows(ClassCastException.class, () -> {
+                assertEquals(1, finalMap.get("foo").intValue);
+            });
+        }
+
+        // Use a j.l.reflect.Type to deserialize map values correctly
+        {
+            TypeToken<Map<String, SomeClass>> typeToken = new TypeToken<Map<String, SomeClass>>() {};
+
+            JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+            Map<String, SomeClass> map = mapper.deserialize(parser, typeToken.getType());
+
+            System.out.println(map);
+            assertEquals(1, map.get("foo").intValue);
+            assertEquals(2, map.get("bar").intValue);
+        }
     }
 
     private void testSerialize(JsonpMapper mapper, String expected) {

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/ModelTestCase.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/ModelTestCase.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.Random;
 
 /**
@@ -93,12 +94,20 @@ public abstract class ModelTestCase extends Assertions {
     }
 
     public static <T> T fromJson(String json, Class<T> clazz, JsonpMapper mapper) {
+        return fromJson(json, (Type)clazz, mapper);
+    }
+
+    public static <T> T fromJson(String json, Type type, JsonpMapper mapper) {
         JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
-        return mapper.deserialize(parser, clazz);
+        return mapper.deserialize(parser, type);
     }
 
     protected <T> T fromJson(String json, Class<T> clazz) {
         return fromJson(json, clazz, mapper);
+    }
+
+    protected <T> T fromJson(String json, Type type) {
+        return fromJson(json, type, mapper);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Adds support for `java.lang.reflect.Type` in deserializers to allow mapping types with generic parameters. This comes in addition to methods with a `Class<T>` parameter that are kept as is, as they allow better type inference by the compiler when using non-parameterized types.

The endpoint methods will have additional overloaded methods using `Type` in the next code generation.

Fixes #118