### PR TITLE
[7.17] Cache the result of `JsonProvider.provider()` (#485)

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
@@ -42,12 +42,24 @@ import java.util.stream.Collectors;
 
 public class JsonpUtils {
 
+    private static JsonProvider systemJsonProvider = null;
+
     /**
      * Get a <code>JsonProvider</code> instance. This method first calls the standard `JsonProvider.provider()` that is based on
-     * the current thread's context classloader, and in case of failure tries to find a provider in other classloaders.
+     * the current thread's context classloader, and in case of failure tries to find a provider in other classloaders. The
+     * value is cached for subsequent calls.
      */
-    @AllowForbiddenApis("Implementation of the JsonProvider lookup")
     public static JsonProvider provider() {
+        JsonProvider result = systemJsonProvider;
+        if (result == null) {
+            result = findProvider();
+            systemJsonProvider = result;
+        }
+        return result;
+    }
+
+    @AllowForbiddenApis("Implementation of the JsonProvider lookup")
+    static JsonProvider findProvider() {
         RuntimeException exception;
         try {
             return JsonProvider.provider();

--- a/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
@@ -70,6 +70,16 @@ public class JsonpUtilsTest extends ModelTestCase {
     }
 
     @Test
+    @AllowForbiddenApis("Testing JsonpUtil.provider()")
+    public void testProviderCache() {
+        // A new provider at each call
+        assertNotSame(JsonpUtils.findProvider(), JsonpUtils.findProvider());
+
+        // Result is cached
+        assertSame(JsonpUtils.provider(), JsonpUtils.provider());
+    }
+
+    @Test
     public void testObjectToString() {
         // Test that we call toString() on application classes.
         Hit<SomeUserData> hit = Hit.of(h -> h


### PR DESCRIPTION
Backport #485 to branch 7.17