### PR TITLE
Add buffered lookahead for Jackson

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/LookAheadJsonParser.java
+++ b/java-client/src/main/java/co/elastic/clients/json/LookAheadJsonParser.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.stream.JsonParser;
+
+import java.util.Map;
+
+public interface LookAheadJsonParser extends JsonParser {
+
+    /**
+     * Look ahead the value of a text property in the JSON stream. The parser must be on the {@code START_OBJECT} event.
+     *
+     * @param name the field name to look up.
+     * @param defaultValue default value if the field is not found.
+     * @return a pair containing the field value (or {@code null} if not found), and a parser to be used to read the JSON object.
+     */
+    Map.Entry<String, JsonParser> lookAheadFieldValue(String name, String defaultValue);
+
+    /**
+     * In union types, find the variant to be used by looking up property names in the JSON stream until we find one that
+     * uniquely identifies the variant.
+     *
+     * @param <Variant> the type of variant descriptors used by the caller.
+     * @param variants a map of variant descriptors, keyed by the property name that uniquely identifies the variant.
+     * @return a pair containing the variant descriptor (or {@code null} if not found), and a parser to be used to read the JSON object.
+     */
+    <Variant> Map.Entry<Variant, JsonParser> findVariant(Map<String, Variant> variants);
+}

--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpParser.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpParser.java
@@ -19,7 +19,11 @@
 
 package co.elastic.clients.json.jackson;
 
+import co.elastic.clients.json.LookAheadJsonParser;
+import co.elastic.clients.json.UnexpectedJsonEventException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.util.JsonParserSequence;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
@@ -29,6 +33,7 @@ import jakarta.json.stream.JsonParsingException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.AbstractMap;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -42,7 +47,7 @@ import java.util.stream.Stream;
  * getter method (e.g. {@link #getInt()} or {@link #getString()} should be called until the next call to {@link #next()}.
  * Such calls will throw an {@code IllegalStateException}.
  */
-public class JacksonJsonpParser implements JsonParser {
+public class JacksonJsonpParser implements LookAheadJsonParser {
 
     private final com.fasterxml.jackson.core.JsonParser parser;
 
@@ -306,7 +311,100 @@ public class JacksonJsonpParser implements JsonParser {
      */
     @Override
     public Stream<JsonValue> getValueStream() {
-        return JsonParser.super.getValueStream();
+        return LookAheadJsonParser.super.getValueStream();
+    }
+
+    //----- Look ahead methods
+
+    public Map.Entry<String, JsonParser> lookAheadFieldValue(String name, String defaultValue) {
+
+        TokenBuffer tb = new TokenBuffer(parser, null);
+
+        try {
+            // The resulting parser must contain the full object, including START_EVENT
+            tb.copyCurrentEvent(parser);
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+
+                expectEvent(JsonToken.FIELD_NAME);
+                // Do not copy current event here, each branch will take care of it
+
+                String fieldName = parser.getCurrentName();
+                if (fieldName.equals(name)) {
+                    // Found
+                    tb.copyCurrentEvent(parser);
+                    expectNextEvent(JsonToken.VALUE_STRING);
+                    tb.copyCurrentEvent(parser);
+
+                    return new AbstractMap.SimpleImmutableEntry<>(
+                        parser.getText(),
+                        new JacksonJsonpParser(JsonParserSequence.createFlattened(false, tb.asParser(), parser))
+                    );
+                } else {
+                    tb.copyCurrentStructure(parser);
+                }
+            }
+            // Copy ending END_OBJECT
+            tb.copyCurrentEvent(parser);
+        } catch (IOException e) {
+            throw JacksonUtils.convertException(e);
+        }
+
+        // Field not found
+        return new AbstractMap.SimpleImmutableEntry<>(
+            defaultValue,
+            new JacksonJsonpParser(JsonParserSequence.createFlattened(false, tb.asParser(), parser))
+        );
+    }
+
+    @Override
+    public <Variant> Map.Entry<Variant, JsonParser> findVariant(Map<String, Variant> variants) {
+        // We're on a START_OBJECT event
+        TokenBuffer tb = new TokenBuffer(parser, null);
+
+        try {
+            // The resulting parser must contain the full object, including START_EVENT
+            tb.copyCurrentEvent(parser);
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+
+                expectEvent(JsonToken.FIELD_NAME);
+                String fieldName = parser.getCurrentName();
+
+                Variant variant = variants.get(fieldName);
+                if (variant != null) {
+                    tb.copyCurrentEvent(parser);
+                    return new AbstractMap.SimpleImmutableEntry<>(
+                        variant,
+                        new JacksonJsonpParser(JsonParserSequence.createFlattened(false, tb.asParser(), parser))
+                    );
+                } else {
+                    tb.copyCurrentStructure(parser);
+                }
+            }
+            // Copy ending END_OBJECT
+            tb.copyCurrentEvent(parser);
+        } catch (IOException e) {
+            throw JacksonUtils.convertException(e);
+        }
+
+        // No variant found: return the buffered parser and let the caller decide what to do.
+        return new AbstractMap.SimpleImmutableEntry<>(
+            null,
+            new JacksonJsonpParser(JsonParserSequence.createFlattened(false, tb.asParser(), parser))
+        );
+    }
+
+    private void expectNextEvent(JsonToken expected) throws IOException {
+        JsonToken event = parser.nextToken();
+        if (event != expected) {
+            throw new UnexpectedJsonEventException(this, tokenToEvent.get(event), tokenToEvent.get(expected));
+        }
+    }
+
+    private void expectEvent(JsonToken expected) {
+        JsonToken event = parser.currentToken();
+        if (event != expected) {
+            throw new UnexpectedJsonEventException(this, tokenToEvent.get(event), tokenToEvent.get(expected));
+        }
     }
 }
 

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/VariantsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/VariantsTest.java
@@ -186,6 +186,14 @@ public class VariantsTest extends ModelTestCase {
     }
 
     @Test
+    public void testEmptyProperty() {
+        // Edge case where we have a property with no fields and no type
+        String json = "{}";
+        Property property = fromJson(json, Property.class);
+        assertEquals(Property.Kind.Object, property._kind());
+    }
+
+    @Test
     public void testNestedVariantsWithContainerProperties() {
 
         SearchRequest search = SearchRequest.of(s -> s

--- a/java-client/src/test/java/co/elastic/clients/json/JsonpMappingExceptionTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpMappingExceptionTest.java
@@ -95,7 +95,7 @@ public class JsonpMappingExceptionTest extends ModelTestCase {
             "}";
 
         // Error deserializing co.elastic.clients.elasticsearch._types.mapping.TextProperty:
-        // Unknown field 'baz' (JSON path: properties['foo-bar'].baz) (in object at line no=1, column no=36, offset=35)
+        // Unknown field 'baz' (JSON path: properties['foo-bar'].baz) (...line no=1, column no=36, offset=35)
 
         JsonpMappingException e = assertThrows(JsonpMappingException.class, () -> {
             fromJson(json, TypeMapping.class);
@@ -106,7 +106,5 @@ public class JsonpMappingExceptionTest extends ModelTestCase {
 
         String msg = e.getMessage();
         assertTrue(msg.contains("Unknown field 'baz'"));
-        // Check look ahead position (see JsonpUtils.lookAheadFieldValue)
-        assertTrue(msg.contains("(in object at line no="));
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/json/jackson/JacksonJsonpParserTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/jackson/JacksonJsonpParserTest.java
@@ -19,15 +19,17 @@
 
 package co.elastic.clients.json.jackson;
 
-import co.elastic.clients.json.jackson.JacksonJsonProvider;
+import co.elastic.clients.elasticsearch.core.MsearchResponse;
+import co.elastic.clients.elasticsearch.model.ModelTestCase;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParser.Event;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
 
-public class JacksonJsonpParserTest extends Assertions {
+public class JacksonJsonpParserTest extends ModelTestCase {
 
     private static final String json = "{ 'foo': 'fooValue', 'bar': { 'baz': 1}, 'quux': [true] }".replace('\'', '"');
 
@@ -95,4 +97,95 @@ public class JacksonJsonpParserTest extends Assertions {
             // expected
         }
     }
+
+    @Test void testMultiSearchResponse() {
+        String json =
+            "{\n" +
+                "  \"took\" : 1,\n" +
+                "  \"responses\" : [\n" +
+                "    {\n" +
+                "      \"error\" : {\n" +
+                "        \"root_cause\" : [\n" +
+                "          {\n" +
+                "            \"type\" : \"index_not_found_exception\",\n" +
+                "            \"reason\" : \"no such index [foo_bar]\",\n" +
+                "            \"resource.type\" : \"index_or_alias\",\n" +
+                "            \"resource.id\" : \"foo_bar\",\n" +
+                "            \"index_uuid\" : \"_na_\",\n" +
+                "            \"index\" : \"foo_bar\"\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"type\" : \"index_not_found_exception\",\n" +
+                "        \"reason\" : \"no such index [foo_bar]\",\n" +
+                "        \"resource.type\" : \"index_or_alias\",\n" +
+                "        \"resource.id\" : \"foo_bar\",\n" +
+                "        \"index_uuid\" : \"_na_\",\n" +
+                "        \"index\" : \"foo_bar\"\n" +
+                "      },\n" +
+                "      \"status\" : 404\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"took\" : 1,\n" +
+                "      \"timed_out\" : false,\n" +
+                "      \"_shards\" : {\n" +
+                "        \"total\" : 1,\n" +
+                "        \"successful\" : 1,\n" +
+                "        \"skipped\" : 0,\n" +
+                "        \"failed\" : 0\n" +
+                "      },\n" +
+                "      \"hits\" : {\n" +
+                "        \"total\" : {\n" +
+                "          \"value\" : 5,\n" +
+                "          \"relation\" : \"eq\"\n" +
+                "        },\n" +
+                "        \"max_score\" : 1.0,\n" +
+                "        \"hits\" : [\n" +
+                "          {\n" +
+                "            \"_index\" : \"foo\",\n" +
+                "            \"_id\" : \"Wr0ApoEBa_iiaABtVM57\",\n" +
+                "            \"_score\" : 1.0,\n" +
+                "            \"_source\" : {\n" +
+                "              \"x\" : 1,\n" +
+                "              \"y\" : true\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      \"status\" : 200\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n";
+
+        JsonpMapper mapper = new JacksonJsonpMapper();
+        mapper = mapper.withAttribute("co.elastic.clients:Deserializer:_global.msearch.TDocument", JsonpDeserializer.of(Foo.class));
+
+        @SuppressWarnings("unchecked")
+        MsearchResponse<Foo> response = fromJson(json, MsearchResponse.class, mapper);
+
+        assertEquals(2, response.responses().size());
+        assertEquals(404, response.responses().get(0).failure().status());
+        assertEquals(200, response.responses().get(1).result().status());
+    }
+
+    public static class Foo {
+        private int x;
+        private boolean y;
+
+        public int getX() {
+            return x;
+        }
+
+        public void setX(int x) {
+            this.x = x;
+        }
+
+        public boolean isY() {
+            return y;
+        }
+
+        public void setY(boolean y) {
+            this.y = y;
+        }
+    }
+
 }


### PR DESCRIPTION
JSON deserialization requires to look ahead in JSON objects on two occasions:

* for polymorphic types that are distinguished by their type property (i.e. a property inside the JSON object). An example is the `Property` type, whose variant is defined by the inner `type` property.
* for some types with variants that can be disambiguated by looking at the structure of the JSON objects. The variants do not have the same properties, and inspecting the properties allows knowing what is the actual variant that has to be deserialized. An exemple is the items of a multisearch response, that can be either errors if the `error` property is present and a successful result if the `took`, `hits` or a number of other properties are present.

The JSON-P API doesn't offer a way to buffer JSON events and replay them, and the initial approach was to parse the JSON stream as a JSON object (map of maps), pick the information we need, and, since the JSON stream had been consumed, serialize it back to create a parser. This is suboptimal but somehow acceptable for small objects.

However, the multisearch response can contain arbitrary large JSON objects containing index documents on which we have to perform a look ahead, and in that case the performance hit can be significant as shown in #471.

This PR introduces the `LookAheadJsonParser` extension to JSON-P's `JsonParser` that expose the look ahead functions we need in the deserizalization framework. And it provides an implementation for Jackson, which is by far the most often used JSON library, based on Jackson's `TokenBuffer`. This allows look ahead to consume the actual parser only until we find the information we need, and buffer the JSON stream in a data structure that can be efficiently replayed.

The previous implementation is kept as a fallback for parsers not implementing `LookAheadJsonParser`. It will be improved in a subsequent PR.

Fixes #471.