### PR TITLE
Re-evaluate predicate in FnCondition.whenReadyIf as the predicate may…

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/FnCondition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/FnCondition.java
@@ -81,6 +81,11 @@ class FnCondition {
                 }
                 condition.awaitUninterruptibly();
             }
+
+            if (canRun != null && !canRun.getAsBoolean()) {
+                return null;
+            }
+
             return fn.get();
         } finally {
             lock.unlock();


### PR DESCRIPTION
… have changed while awaiting the condition

During tests we noticed that the new `BulkIngester` sporadically attempts to submit empty bulk requests (containing zero operations) causing an exception. Digging through the code the most probable cause is that the predicate supplied to `FnCondition.whenReadyIf` may change during `condition.awaitUninterruptibly()` (which temporarily releases the lock), so the predicate needs to be re-evaluated after that call returns. This is what this PR implements.