### PR TITLE
Allow unparsed binary data to be used for ingestion

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
@@ -512,5 +512,5 @@ public class CreateRequest<TDocument> extends RequestBase implements JsonpSerial
 				}
 				return params;
 
-			}, SimpleEndpoint.emptyMap(), true, CreateResponse._DESERIALIZER);
+			}, SimpleEndpoint.emptyMap(), r -> r.document(), CreateResponse._DESERIALIZER);
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
@@ -663,5 +663,5 @@ public class IndexRequest<TDocument> extends RequestBase implements JsonpSeriali
 				}
 				return params;
 
-			}, SimpleEndpoint.emptyMap(), true, IndexResponse._DESERIALIZER);
+			}, SimpleEndpoint.emptyMap(), r -> r.document(), IndexResponse._DESERIALIZER);
 }

--- a/java-client/src/main/java/co/elastic/clients/transport/Endpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/Endpoint.java
@@ -70,7 +70,23 @@ public interface Endpoint<RequestT, ResponseT, ErrorT> {
     return Collections.emptyMap();
   }
 
-  boolean hasRequestBody();
+  /**
+   * Get the body for a request. The caller must handle several cases depending on the interface implemented by the result:
+   * <li>
+   *     {@code null} means the request has no body.
+   * </li>
+   * <li>
+   *     {@link co.elastic.clients.json.NdJsonpSerializable} must be serialized as nd-json.
+   * </li>
+   * <li>
+   *     {@link co.elastic.clients.util.BinaryData} must be serialized as is.
+   * </li>
+   * <li>
+   *     All other objects must be serialized as JSON using a {@link co.elastic.clients.json.JsonpMapper}
+   * </li>
+   */
+  @Nullable
+  Object body(RequestT request);
 
   /**
    * Is this status code to be considered as an error?
@@ -90,7 +106,7 @@ public interface Endpoint<RequestT, ResponseT, ErrorT> {
           this::requestUrl,
           this::queryParameters,
           this::headers,
-          this.hasRequestBody(),
+          this::body,
           null
       );
   }

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryEndpoint.java
@@ -31,10 +31,23 @@ public class BinaryEndpoint<RequestT> extends EndpointBase<RequestT, BinaryRespo
         Function<RequestT,
             Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
+        Function<RequestT, Object> body,
+        Object ignored // same number of arguments as SimpleEndpoint
+    ) {
+        super(id, method, requestUrl, queryParameters, headers, body);
+    }
+
+    public BinaryEndpoint(
+        String id,
+        Function<RequestT, String> method,
+        Function<RequestT, String> requestUrl,
+        Function<RequestT,
+            Map<String, String>> queryParameters,
+        Function<RequestT, Map<String, String>> headers,
         boolean hasRequestBody,
         Object ignored // same number of arguments as SimpleEndpoint
     ) {
-        super(id, method, requestUrl, queryParameters, headers, hasRequestBody);
+        super(id, method, requestUrl, queryParameters, headers, hasRequestBody ? returnSelf() : returnNull());
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/BooleanEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/BooleanEndpoint.java
@@ -34,7 +34,7 @@ public class BooleanEndpoint<RequestT> extends EndpointBase<RequestT, BooleanRes
         boolean hasRequestBody,
         Object ignored // same number of arguments as SimpleEndpoint
     ) {
-        super(id, method, requestUrl, queryParameters, headers, hasRequestBody);
+        super(id, method, requestUrl, queryParameters, headers, hasRequestBody ? returnSelf() : returnNull());
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/DelegatingJsonEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/DelegatingJsonEndpoint.java
@@ -58,9 +58,10 @@ public class DelegatingJsonEndpoint<Req, Res, Err> implements JsonEndpoint<Req, 
         return endpoint.headers(request);
     }
 
+    @Nullable
     @Override
-    public boolean hasRequestBody() {
-        return endpoint.hasRequestBody();
+    public Object body(Req request) {
+        return endpoint.body(request);
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
@@ -24,23 +24,11 @@ import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.transport.JsonEndpoint;
 import org.apache.http.client.utils.URLEncodedUtils;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
 public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, ResponseT>
     implements JsonEndpoint<RequestT, ResponseT, ErrorResponse> {
-
-    private static final Function<?, Map<String, String>> EMPTY_MAP = x -> Collections.emptyMap();
-
-    /**
-     * Returns a function that always returns an empty String to String map. Useful to avoid creating lots of
-     * duplicate lambdas in endpoints that don't have headers or parameters.
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> Function<T, Map<String, String>> emptyMap() {
-        return (Function<T, Map<String, String>>) EMPTY_MAP;
-    }
 
     private final JsonpDeserializer<ResponseT> responseParser;
 
@@ -50,11 +38,31 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
         Function<RequestT, String> requestUrl,
         Function<RequestT, Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
-        boolean hasRequestBody,
+        Function<RequestT, Object> body,
         JsonpDeserializer<ResponseT> responseParser
     ) {
-        super(id, method, requestUrl, queryParameters, headers, hasRequestBody);
+        super(id, method, requestUrl, queryParameters, headers, body);
         this.responseParser = responseParser;
+    }
+
+    public SimpleEndpoint(
+        String id,
+        Function<RequestT, String> method,
+        Function<RequestT, String> requestUrl,
+        Function<RequestT, Map<String, String>> queryParameters,
+        Function<RequestT, Map<String, String>> headers,
+        boolean hasResponseBody,
+        JsonpDeserializer<ResponseT> responseParser
+    ) {
+        this(
+            id,
+            method,
+            requestUrl,
+            queryParameters,
+            headers,
+            hasResponseBody ? returnSelf() : returnNull(),
+            responseParser
+        );
     }
 
     @Override
@@ -76,7 +84,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
             requestUrl,
             queryParameters,
             headers,
-            hasRequestBody,
+            body,
             newResponseParser
         );
     }

--- a/java-client/src/main/java/co/elastic/clients/util/ByteArrayBinaryData.java
+++ b/java-client/src/main/java/co/elastic/clients/util/ByteArrayBinaryData.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.util;
+
+import co.elastic.clients.json.JsonpDeserializable;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpDeserializerBase;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.JsonpUtils;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+
+@JsonpDeserializable
+public class ByteArrayBinaryData implements BinaryData {
+
+    private final byte[] bytes;
+    private final int offset;
+    private final int length;
+    private final String contentType;
+
+    ByteArrayBinaryData(byte[] bytes, int offset, int length, String contentType) {
+        this.contentType = contentType;
+        this.bytes = bytes;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    ByteArrayBinaryData(byte[] bytes, String contentType) {
+        this.contentType = contentType;
+        this.bytes = bytes;
+        this.offset = 0;
+        this.length = bytes.length;
+    }
+
+
+    @Override
+    public String contentType() {
+        return this.contentType;
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException {
+        out.write(bytes, offset, length);
+    }
+
+    @Override
+    public long size() {
+        return length;
+    }
+
+    @Override
+    public ByteBuffer asByteBuffer() {
+        return ByteBuffer.wrap(bytes, offset, length);
+    }
+
+    private static class Deserializer extends JsonpDeserializerBase<ByteArrayBinaryData> {
+
+        Deserializer() {
+            super(EnumSet.allOf(JsonParser.Event.class));
+        }
+
+        @Override
+        public ByteArrayBinaryData deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
+            JsonpUtils.copy(parser, generator, event);
+            generator.close();
+            return new ByteArrayBinaryData(baos.toByteArray(), ContentType.APPLICATION_JSON);
+        }
+    }
+
+    public static final JsonpDeserializer<ByteArrayBinaryData> _DESERIALIZER = new Deserializer();
+}

--- a/java-client/src/main/java/co/elastic/clients/util/ContentType.java
+++ b/java-client/src/main/java/co/elastic/clients/util/ContentType.java
@@ -17,21 +17,14 @@
  * under the License.
  */
 
-package co.elastic.clients.transport.endpoints;
+package co.elastic.clients.util;
 
-import co.elastic.clients.elasticsearch.core.ExistsRequest;
-import co.elastic.clients.elasticsearch.security.SamlCompleteLogoutRequest;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+/**
+ * Constants for content-type values.
+ */
+public class ContentType {
 
-public class BooleanEndpointTest extends Assertions {
+    private ContentType() {}
 
-    @Test
-    public void testHasRequestBody() {
-        ExistsRequest er = ExistsRequest.of(r -> r.index("foo").id("1"));
-        assertNull(ExistsRequest._ENDPOINT.body(er));
-
-        SamlCompleteLogoutRequest sclr = SamlCompleteLogoutRequest.of(r -> r.ids("1").realm("r"));
-        assertNotNull(SamlCompleteLogoutRequest._ENDPOINT.body(sclr));
-    }
+    public static final String APPLICATION_JSON = "application/json";
 }

--- a/java-client/src/test/java/co/elastic/clients/documentation/usage/IndexingBulkTest.java
+++ b/java-client/src/test/java/co/elastic/clients/documentation/usage/IndexingBulkTest.java
@@ -28,6 +28,7 @@ import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.model.ModelTestCase;
 import co.elastic.clients.util.BinaryData;
+import co.elastic.clients.util.ContentType;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -109,7 +110,7 @@ public class IndexingBulkTest extends ModelTestCase {
 
         for (File file: logFiles) {
             FileInputStream input = new FileInputStream(file);
-            BinaryData data = BinaryData.of(IOUtils.toByteArray(input));
+            BinaryData data = BinaryData.of(IOUtils.toByteArray(input), ContentType.APPLICATION_JSON);
 
             br.operations(op -> op
                 .index(idx -> idx
@@ -138,7 +139,7 @@ public class IndexingBulkTest extends ModelTestCase {
 
         for (File file: logFiles) {
             FileInputStream input = new FileInputStream(file);
-            BinaryData data = BinaryData.of(IOUtils.toByteArray(input));
+            BinaryData data = BinaryData.of(IOUtils.toByteArray(input), ContentType.APPLICATION_JSON);
 
             ingester.add(op -> op // <4>
                 .index(idx -> idx
@@ -194,7 +195,7 @@ public class IndexingBulkTest extends ModelTestCase {
 
         for (File file: logFiles) {
             FileInputStream input = new FileInputStream(file);
-            BinaryData data = BinaryData.of(IOUtils.toByteArray(input));
+            BinaryData data = BinaryData.of(IOUtils.toByteArray(input), ContentType.APPLICATION_JSON);
 
             ingester.add(op -> op
                 .index(idx -> idx


### PR DESCRIPTION
PR #474 added a `BinaryData` class used to pre-serialize documents in bulk requests in order to evaluate their size.

This PR extends the usage of `BinaryData` to API requests whose body is an application-provided object. These are the `create` and `index` ingestion endpoints, in addition to `bulk`. This allows providing JSON data as a binary blob without incurring the cost of parsing and reserializing with no additional processing. 