### PR TITLE
[7.17] Re-evaluate predicate in FnCondition.whenReadyIf as the predicate may have changed while awaiting the condition (#502)

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/FnCondition.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/FnCondition.java
@@ -81,6 +81,11 @@ class FnCondition {
                 }
                 condition.awaitUninterruptibly();
             }
+
+            if (canRun != null && !canRun.getAsBoolean()) {
+                return null;
+            }
+
             return fn.get();
         } finally {
             lock.unlock();


### PR DESCRIPTION
Backport #502 to branch 7.17