### PR TITLE
Reorder key-values in meta header to match other clients #334

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Backport

--- a/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientOptions.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientOptions.java
@@ -211,9 +211,9 @@ public class RestClientOptions implements TransportOptions {
             + metaVersion
             + ",jv="
             + System.getProperty("java.specification.version")
-            + ",hl=2"
             + ",t="
             + metaVersion
+            + ",hl=2"
             + ",hc="
             + (httpClientVersion == null ? "" : httpClientVersion.getRelease())
             + LanguageRuntimeVersions.getRuntimeMetadata();


### PR DESCRIPTION
corrected the sequence for the CLIENT META VALUE sequence as mentioned in the description from the following link

Closes https://github.com/elastic/elasticsearch-java/issues/334