### PR TITLE
Add buffered JsonData implementation for Jackson

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/BufferingJsonParser.java
+++ b/java-client/src/main/java/co/elastic/clients/json/BufferingJsonParser.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.stream.JsonParser;
+
+public interface BufferingJsonParser extends JsonParser {
+
+    /**
+     * Get the value at the current parser position as a <code>JsonData</code> object.
+     * @return
+     */
+    JsonData getJsonData();
+
+}

--- a/java-client/src/main/java/co/elastic/clients/json/JsonBuffer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonBuffer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.stream.JsonParser;
+
+/**
+ * A buffer of JSON events.
+ */
+public interface JsonBuffer {
+
+    /**
+     * Get the contents of this buffer as a JSON parser. Can be called multiple times.
+     */
+    JsonParser asParser();
+}

--- a/java-client/src/main/java/co/elastic/clients/json/JsonData.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonData.java
@@ -58,7 +58,9 @@ public interface JsonData extends JsonpSerializable {
      *
      * @throws IllegalStateException if no mapper was provided at creation time.
      */
-    <T> T to(Class<T> clazz);
+    default <T> T to(Class<T> clazz) {
+        return to((Type)clazz);
+    }
 
     /**
      * Converts this object to a target type. A mapper must have been provided at creation time.
@@ -70,7 +72,9 @@ public interface JsonData extends JsonpSerializable {
     /**
      * Converts this object to a target class.
      */
-     <T> T to(Class<T> clazz, JsonpMapper mapper);
+     default <T> T to(Class<T> clazz, JsonpMapper mapper) {
+         return to((Type)clazz, mapper);
+     }
 
     /**
      * Converts this object to a target type.
@@ -145,8 +149,7 @@ public interface JsonData extends JsonpSerializable {
      * {@link #deserialize(JsonpDeserializer)}.
      */
     static JsonData from(JsonParser parser, JsonpMapper mapper) {
-        parser.next(); // Need to be at the beginning of the value to read
-        return of(parser.getValue(), mapper);
+        return from(parser, mapper, parser.next());
     }
 
     /**
@@ -155,7 +158,11 @@ public interface JsonData extends JsonpSerializable {
      * {@link #deserialize(JsonpDeserializer)}.
      */
     static JsonData from(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
-        return of(parser.getValue(), mapper);
+        if (parser instanceof BufferingJsonParser) {
+            return ((BufferingJsonParser)parser).getJsonData();
+        } else {
+            return of(parser.getValue(), mapper);
+        }
     }
 
     JsonpDeserializer<JsonData> _DESERIALIZER = JsonpDeserializer.of(

--- a/java-client/src/main/java/co/elastic/clients/json/JsonDataImpl.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonDataImpl.java
@@ -65,18 +65,8 @@ class JsonDataImpl implements JsonData {
     }
 
     @Override
-    public <T> T to(Class<T> clazz) {
-        return to((Type)clazz, null);
-    }
-
-    @Override
     public <T> T to(Type clazz) {
         return to(clazz, null);
-    }
-
-    @Override
-    public <T> T to(Class<T> clazz, JsonpMapper mapper) {
-        return to((Type)clazz, mapper);
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
@@ -153,6 +153,13 @@ public class JsonpUtils {
     /**
      * Copy the JSON value at the current parser location to a JSON generator.
      */
+    public static void copy(JsonParser parser, JsonGenerator generator) {
+        copy(parser, generator, parser.next());
+    }
+
+    /**
+     * Copy the JSON value at the current parser location to a JSON generator.
+     */
     public static void copy(JsonParser parser, JsonGenerator generator, JsonParser.Event event) {
 
         switch (event) {

--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonBuffer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonBuffer.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json.jackson;
+
+import co.elastic.clients.json.JsonBuffer;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.JsonpUtils;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+class JacksonJsonBuffer implements JsonBuffer, JsonData {
+    private final TokenBuffer buffer;
+    private final JacksonJsonpMapper mapper;
+
+    JacksonJsonBuffer(TokenBuffer buffer, JacksonJsonpMapper mapper) {
+        this.buffer = buffer;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public JsonParser asParser() {
+        return new JacksonJsonpParser(buffer.asParser(), mapper);
+    }
+
+    @Override
+    public JsonValue toJson() {
+        try (JsonParser parser = asParser()) {
+            parser.next(); // move to first event
+            return parser.getValue();
+        }
+    }
+
+    @Override
+    public JsonValue toJson(JsonpMapper mapper) {
+        // We don't need the mapper
+        return toJson();
+    }
+
+    @Override
+    public <T> T to(Type type) {
+        return to(type, this.mapper);
+    }
+
+    @Override
+    public <T> T to(Type type, JsonpMapper mapper) {
+        try (JsonParser parser = asParser()) {
+            return mapper.deserialize(parser, type);
+        }
+    }
+
+    @Override
+    public <T> T deserialize(JsonpDeserializer<T> deserializer) {
+        return deserialize(deserializer, this.mapper);
+    }
+
+    @Override
+    public <T> T deserialize(JsonpDeserializer<T> deserializer, JsonpMapper mapper) {
+        try (JsonParser parser = asParser()) {
+            return deserializer.deserialize(parser, mapper);
+        }
+    }
+
+    @Override
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        if (generator instanceof JacksonJsonpGenerator) {
+            JacksonJsonpGenerator jkGenerator = (JacksonJsonpGenerator) generator;
+            try {
+                buffer.serialize(jkGenerator.jacksonGenerator());
+            } catch (IOException e) {
+                throw JacksonUtils.convertException(e);
+            }
+        } else {
+            try (JsonParser parser = asParser()) {
+                JsonpUtils.copy(parser, generator);
+            }
+        }
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonProvider.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonProvider.java
@@ -52,21 +52,20 @@ import java.util.Map;
  */
 public class JacksonJsonProvider extends JsonProvider {
 
+    private final JacksonJsonpMapper mapper;
     private final JsonFactory jsonFactory;
 
-    public JacksonJsonProvider(JsonFactory jsonFactory) {
-        this.jsonFactory = jsonFactory;
+    public JacksonJsonProvider(JacksonJsonpMapper mapper) {
+        this.mapper = mapper;
+        this.jsonFactory = mapper.objectMapper().getFactory();
     }
 
     public JacksonJsonProvider() {
-        this(new JsonFactory());
+        this(new JacksonJsonpMapper());
     }
 
-    /**
-     * Return the underlying Jackson {@link JsonFactory}.
-     */
-    public JsonFactory jacksonJsonFactory() {
-        return this.jsonFactory;
+    public JacksonJsonpMapper mapper() {
+        return this.mapper;
     }
 
     //---------------------------------------------------------------------------------------------
@@ -105,7 +104,7 @@ public class JacksonJsonProvider extends JsonProvider {
         @Override
         public JsonParser createParser(Reader reader) {
             try {
-                return new JacksonJsonpParser(jsonFactory.createParser(reader));
+                return new JacksonJsonpParser(jsonFactory.createParser(reader), mapper);
             } catch (IOException ioe) {
                 throw JacksonUtils.convertException(ioe);
             }
@@ -114,7 +113,7 @@ public class JacksonJsonProvider extends JsonProvider {
         @Override
         public JsonParser createParser(InputStream in) {
             try {
-                return new JacksonJsonpParser(jsonFactory.createParser(in));
+                return new JacksonJsonpParser(jsonFactory.createParser(in), mapper);
             } catch (IOException ioe) {
                 throw JacksonUtils.convertException(ioe);
             }
@@ -123,7 +122,7 @@ public class JacksonJsonProvider extends JsonProvider {
         @Override
         public JsonParser createParser(InputStream in, Charset charset) {
             try {
-                return new JacksonJsonpParser(jsonFactory.createParser(new InputStreamReader(in, charset)));
+                return new JacksonJsonpParser(jsonFactory.createParser(new InputStreamReader(in, charset)), mapper);
             } catch (IOException ioe) {
                 throw JacksonUtils.convertException(ioe);
             }

--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonpMapper.java
@@ -46,10 +46,9 @@ public class JacksonJsonpMapper extends JsonpMapperBase {
     }
 
     public JacksonJsonpMapper(ObjectMapper objectMapper) {
-        this(objectMapper,
-            // Creating the json factory from the mapper ensures it will be returned by JsonParser.getCodec()
-            new JacksonJsonProvider(objectMapper.getFactory())
-        );
+        this.objectMapper = objectMapper;
+        // Order is important as JacksonJsonProvider(this) will get ObjectMapper
+        this.provider = new JacksonJsonProvider(this);
     }
 
     public JacksonJsonpMapper() {

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/ModelTestCase.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/ModelTestCase.java
@@ -33,6 +33,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.EnumSet;
 import java.util.Random;
 
 /**
@@ -40,15 +41,22 @@ import java.util.Random;
  */
 public abstract class ModelTestCase extends Assertions {
 
+    protected enum JsonImpl { Jsonb, Jackson, Simple };
+
     // Same value for all tests in a test run
     private static final int RAND = new Random().nextInt(100);
 
+    protected final JsonImpl jsonImpl;
     protected final JsonpMapper mapper;
 
-    private JsonpMapper setupMapper(int rand) {
-        // Randomly choose json-b or jackson
-        switch(rand % 3) {
-            case 0:
+    private static JsonImpl chooseJsonImpl(EnumSet<JsonImpl> jsonImplCandidates, int rand) {
+        // Converting an EnumSet to an array always uses the same order.
+        return jsonImplCandidates.toArray(new JsonImpl[jsonImplCandidates.size()])[rand % jsonImplCandidates.size()];
+    }
+
+    private static JsonpMapper createMapper(JsonImpl jsonImpl, int rand) {
+        switch(jsonImpl) {
+            case Jsonb:
                 System.out.println("Using a JsonB mapper (rand = " + rand + ").");
                 return new JsonbJsonpMapper() {
                     @Override
@@ -57,7 +65,7 @@ public abstract class ModelTestCase extends Assertions {
                     }
                 };
 
-            case 1:
+            case Jackson:
                 System.out.println("Using a Jackson mapper (rand = " + rand + ").");
                 return new JacksonJsonpMapper() {
                     @Override
@@ -72,12 +80,25 @@ public abstract class ModelTestCase extends Assertions {
         }
     }
 
-    protected ModelTestCase() {
-        this(RAND);
+    protected ModelTestCase(EnumSet<JsonImpl> jsonImplCandidates, int rand) {
+        jsonImpl = chooseJsonImpl(jsonImplCandidates, rand);
+        mapper = createMapper(jsonImpl, rand);
+    }
+
+    protected ModelTestCase(EnumSet<JsonImpl> jsonImplCandidates) {
+        this(jsonImplCandidates, RAND);
+    }
+
+    protected ModelTestCase(JsonImpl jsonImpl) {
+        this(EnumSet.of(jsonImpl), RAND);
     }
 
     protected ModelTestCase(int rand) {
-        mapper = setupMapper(rand);
+        this(EnumSet.allOf(JsonImpl.class), rand);
+    }
+
+    protected ModelTestCase() {
+        this(EnumSet.allOf(JsonImpl.class), RAND);
     }
 
     protected <T> String toJson(T value) {


### PR DESCRIPTION
This PR adds a `BufferingJsonParser` interface that a JSON parser can implement to provide an implementation of `JsonData` based on a JSON event buffer, instead of a materialized `JsonValue`.

This brings some important performance and memory usage improvements when the `JsonData` data is later deserialized into an application object, or even a primitive type.

Fixes #548, and will be part of version 8.8.0.