### PR TITLE
Speed up URL path encoding and remove dependency on httpclient

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
@@ -22,7 +22,6 @@ package co.elastic.clients.transport.endpoints;
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.transport.JsonEndpoint;
-import org.apache.http.client.utils.URLEncodedUtils;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -87,15 +86,5 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
             body,
             newResponseParser
         );
-    }
-
-    public static RuntimeException noPathTemplateFound(String what) {
-        return new RuntimeException("Could not find a request " + what + " with this set of properties. " +
-            "Please check the API documentation, or raise an issue if this should be a valid request.");
-    }
-
-    public static void pathEncode(String src, StringBuilder dest) {
-        // TODO: avoid dependency on HttpClient here (and use something more efficient)
-        dest.append(URLEncodedUtils.formatSegments(src).substring(1));
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/transport/endpoints/EndpointBaseTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/endpoints/EndpointBaseTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.endpoints;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EndpointBaseTest extends Assertions {
+
+    @Test
+    public void testPathEncoding() {
+        assertEquals("abCD12;-_*", pathEncode("abCD12;-_*"));
+        assertEquals("XYZ%5B", pathEncode("XYZ["));
+        assertEquals("xyz%7B", pathEncode("xyz{"));
+        assertEquals("foo%2Fbar", pathEncode("foo/bar"));
+        assertEquals("foo%20bar", pathEncode("foo bar"));
+        assertEquals("f%C3%AAl%C3%A9", pathEncode("fêlé"));
+    }
+
+    private String pathEncode(String s) {
+        StringBuilder sb = new StringBuilder();
+        EndpointBase.pathEncode(s, sb);
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Rewrite `EndpointBase.pathEncode`:
* remove dependency on Apache httpclient. Dependencies on that library are now limited to `transport.rest_client` since this transport is based on Apache httpclient.
* speed up path encoding, as this function only needs to encode a path segment and not a list of segments like the one provided by Apache httpclient.