### PR TITLE
Throw a TransportException when an error response cannot be parsed

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/transport/TransportException.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/TransportException.java
@@ -24,22 +24,32 @@ import java.io.IOException;
 
 public class TransportException extends IOException {
 
+    private final int statusCode;
     private final String endpointId;
 
-    public TransportException(String message, String endpointId) {
-        this(message, endpointId, null);
+    public TransportException(int statusCode, String message, String endpointId) {
+        this(statusCode, message, endpointId, null);
     }
 
-    public TransportException(String message, String endpointId, Throwable cause) {
-        super(endpointId == null ? message : "[" + endpointId + "] " + message, cause);
+    public TransportException(int statusCode, String message, String endpointId, Throwable cause) {
+        super("status: " + statusCode + ", " + (endpointId == null ? message : "[" + endpointId + "] " + message), cause);
+        this.statusCode = statusCode;
         this.endpointId = endpointId;
+    }
+
+    /**
+     * Status code returned by the http resquest
+     */
+    public int statusCode() {
+        return statusCode;
     }
 
     /**
      * Identifier of the API endpoint that caused the exception, if known.
      */
     @Nullable
-    String getEndpointId() {
+    public String endpointId() {
         return endpointId;
     }
+
 }

--- a/java-client/src/test/java/co/elastic/clients/transport/TransportTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/TransportTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+public class TransportTest extends Assertions {
+
+    @Test
+    public void testXMLResponse() throws Exception {
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+
+        httpServer.createContext("/_cat/indices", exchange -> {
+            exchange.sendResponseHeaders(401, 0);
+            OutputStream out = exchange.getResponseBody();
+            out.write(
+                "<?xml version=\"1.0\"?><error>Error</error>".getBytes(StandardCharsets.UTF_8)
+            );
+            out.close();
+        });
+
+        httpServer.start();
+        InetSocketAddress address = httpServer.getAddress();
+
+        RestClient restClient = RestClient
+            .builder(new HttpHost(address.getHostString(), address.getPort(), "http"))
+            .build();
+
+        ElasticsearchClient esClient = new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper()));
+
+        TransportException ex = Assertions.assertThrows(
+            TransportException.class,
+            () -> esClient.cat().indices()
+        );
+
+        httpServer.stop(0);
+
+        assertEquals(401, ex.statusCode());
+        assertEquals("es/cat.indices", ex.endpointId());
+
+        // Cause is transport-dependent
+        ResponseException restException = (ResponseException) ex.getCause();
+        assertEquals(401, restException.getResponse().getStatusLine().getStatusCode());
+    }
+}


### PR DESCRIPTION
When an error response cannot be parsed, make sure we throw a `TransportException` that wraps the original response for further inspection. This is useful when a request fails because a proxy rejected the response and returns its own error response which can be anything.

Also add status code to `TransportException`.

Fixes #563