### PR TITLE
[WIP] Extract base abstract behavior from RestClientTransport

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/transport/TransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/TransportBase.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ErrorResponse;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.NdJsonpSerializable;
+import co.elastic.clients.transport.endpoints.BinaryDataResponse;
+import co.elastic.clients.transport.endpoints.BinaryEndpoint;
+import co.elastic.clients.transport.endpoints.BooleanEndpoint;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
+import co.elastic.clients.util.ApiTypeHelper;
+import co.elastic.clients.util.BinaryData;
+import co.elastic.clients.util.ByteArrayBinaryData;
+import co.elastic.clients.util.ContentType;
+import co.elastic.clients.util.MissingRequiredPropertyException;
+import co.elastic.clients.util.NoCopyByteArrayOutputStream;
+import jakarta.json.JsonException;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public abstract class TransportBase<
+    Options extends TransportOptions
+    > implements Transport {
+
+    public static class TransportRequest {
+        public final String method;
+        public final String path;
+        public final Map<String, String> queryParams;
+        @Nullable public final String contentType;
+        @Nullable public final Iterable<ByteBuffer> body;
+
+        public TransportRequest(String method, String path, Map<String, String> queryParams, @Nullable String contentType, @Nullable Iterable<ByteBuffer> body) {
+            this.method = method;
+            this.path = path;
+            this.queryParams = queryParams;
+            this.contentType = contentType;
+            this.body = body;
+        }
+    }
+
+    public static final String JsonContentType;
+
+    static {
+        if (Version.VERSION == null) {
+            JsonContentType = ContentType.APPLICATION_JSON;
+        } else {
+            JsonContentType =
+                "application/vnd.elasticsearch+json; compatible-with=" +
+                Version.VERSION.major();
+        }
+    }
+
+    /**
+     * Create implementation-specific options from optional initial options.
+     */
+    protected abstract Options createOptions(@Nullable TransportOptions options);
+    protected abstract TransportResponse performRequest(TransportRequest request, Options options) throws IOException;
+    protected abstract CompletableFuture<TransportResponse> performRequestAsync(TransportRequest request, Options options);
+
+    private final JsonpMapper mapper;
+    protected final Options transportOptions;
+
+    protected TransportBase(JsonpMapper jsonpMapper, Options options) {
+        this.mapper = jsonpMapper;
+        this.transportOptions = options;
+    }
+
+    @Override
+    public final JsonpMapper jsonpMapper() {
+        return mapper;
+    }
+
+    @Override
+    public final TransportOptions options() {
+        return transportOptions;
+    }
+
+    @Override
+    public final <RequestT, ResponseT, ErrorT> ResponseT performRequest(
+        RequestT request,
+        Endpoint<RequestT, ResponseT, ErrorT> endpoint,
+        @Nullable TransportOptions options
+    ) throws IOException {
+        TransportRequest req = prepareTransportRequest(request, endpoint, options);
+        Options opts = createOptions(options);
+        TransportResponse resp = performRequest(req, opts);
+        return getApiResponse(resp, endpoint);
+    }
+
+    @Override
+    public final <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, @Nullable TransportOptions options) {
+        TransportRequest clientReq;
+        try {
+            clientReq = prepareTransportRequest(request, endpoint, options);
+        } catch (Exception e) {
+            // Terminate early
+            CompletableFuture<ResponseT> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
+
+        // Propagate required property checks to the thread that will decode the response
+        boolean disableRequiredChecks = ApiTypeHelper.requiredPropertiesCheckDisabled();
+
+        CompletableFuture<TransportResponse> clientFuture = performRequestAsync(clientReq, createOptions(options));
+
+        // Cancelling the result will cancel the upstream future created by the http client, allowing to stop in-flight requests
+        CompletableFuture<ResponseT> future = new CompletableFuture<ResponseT>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                boolean cancelled = super.cancel(mayInterruptIfRunning);
+                if (cancelled) {
+                    clientFuture.cancel(mayInterruptIfRunning);
+                }
+                return cancelled;
+            }
+        };
+
+        clientFuture.handle((clientResp, thr) -> {
+            if (thr != null) {
+                future.completeExceptionally(thr);
+            } else {
+                try (ApiTypeHelper.DisabledChecksHandle h =
+                         ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(disableRequiredChecks)) {
+
+                    ResponseT response = getApiResponse(clientResp, endpoint);
+                    future.complete(response);
+
+                } catch (Throwable e) {
+                    future.completeExceptionally(e);
+                }
+            }
+            return null;
+        });
+
+        return future;
+    }
+
+    private <RequestT, ResponseT, ErrorT> TransportRequest prepareTransportRequest(
+        RequestT request,
+        Endpoint<RequestT, ResponseT, ErrorT> endpoint,
+        @Nullable TransportOptions options
+    ) throws IOException {
+        String method = endpoint.method(request);
+        String path = endpoint.requestUrl(request);
+        Map<String, String> params = endpoint.queryParameters(request);
+
+        List<ByteBuffer> bodyBuffers = null;
+        String contentType = null;
+
+        Object body = endpoint.body(request);
+        if (body != null) {
+            // Request has a body
+            if (body instanceof NdJsonpSerializable) {
+                bodyBuffers = new ArrayList<>();
+                collectNdJsonLines(bodyBuffers, (NdJsonpSerializable) request);
+                contentType = JsonContentType;
+
+            } else if (body instanceof BinaryData) {
+                BinaryData data = (BinaryData)body;
+
+                // ES expects the Accept and Content-Type headers to be consistent.
+                String dataContentType = data.contentType();
+                if (ContentType.APPLICATION_JSON.equals(dataContentType)) {
+                    // Fast path
+                    contentType = JsonContentType;
+                } else {
+                    contentType = dataContentType;
+                }
+                bodyBuffers = Collections.singletonList(data.asByteBuffer());
+
+            } else {
+                NoCopyByteArrayOutputStream baos = new NoCopyByteArrayOutputStream();
+                JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
+                mapper.serialize(body, generator);
+                generator.close();
+                bodyBuffers = Collections.singletonList(baos.asByteBuffer());
+                contentType = JsonContentType;
+            }
+        }
+
+        return new TransportRequest(method, path, params, contentType, bodyBuffers);
+    }
+
+    private static final ByteBuffer NdJsonSeparator = ByteBuffer.wrap("\n".getBytes(StandardCharsets.UTF_8));
+
+    private void collectNdJsonLines(List<ByteBuffer> lines, NdJsonpSerializable value) throws IOException {
+        Iterator<?> values = value._serializables();
+        while(values.hasNext()) {
+            Object item = values.next();
+            if (item == null) {
+                // Skip
+            } else if (item instanceof NdJsonpSerializable && item != value) { // do not recurse on the item itself
+                collectNdJsonLines(lines, (NdJsonpSerializable)item);
+            } else {
+                // TODO: items that aren't already BinaryData could be serialized to ByteBuffers lazily
+                // to reduce the number of buffers to keep in memory
+                lines.add(BinaryData.of(item, this.mapper).asByteBuffer());
+                lines.add(NdJsonSeparator);
+            }
+        }
+    }
+
+    protected interface TransportResponse {
+        int statusCode();
+        String getHeader(String name);
+        @Nullable BinaryData getBody() throws IOException;
+        Throwable createException() throws IOException;
+        void close() throws IOException;
+    }
+
+    private <ResponseT, ErrorT> ResponseT getApiResponse(
+        TransportResponse clientResp,
+        Endpoint<?, ResponseT, ErrorT> endpoint
+    ) throws IOException {
+
+        int statusCode = clientResp.statusCode();
+
+        try {
+            if (statusCode == 200) {
+                checkProductHeader(clientResp, endpoint);
+            }
+
+            if (endpoint.isError(statusCode)) {
+                JsonpDeserializer<ErrorT> errorDeserializer = endpoint.errorDeserializer(statusCode);
+                if (errorDeserializer == null) {
+                    throw new TransportException(
+                        statusCode,
+                        "Request failed with status code '" + statusCode + "'",
+                        endpoint.id(), clientResp.createException()
+                    );
+                }
+
+                BinaryData entity = clientResp.getBody();
+                if (entity == null) {
+                    throw new TransportException(
+                        statusCode,
+                        "Expecting a response body, but none was sent",
+                        endpoint.id(), clientResp.createException()
+                    );
+                }
+
+                // We may have to replay it.
+                if (!entity.isRepeatable()) {
+                    entity = new ByteArrayBinaryData(entity);
+                }
+
+                try {
+                    InputStream content = entity.asInputStream();
+                    try (JsonParser parser = mapper.jsonProvider().createParser(content)) {
+                        ErrorT error = errorDeserializer.deserialize(parser, mapper);
+                        // TODO: have the endpoint provide the exception constructor
+                        throw new ElasticsearchException(endpoint.id(), (ErrorResponse) error);
+                    }
+                } catch(JsonException | MissingRequiredPropertyException errorEx) {
+                    // Could not decode exception, try the response type
+                    try {
+                        ResponseT response = decodeTransportResponse(statusCode, entity, clientResp, endpoint);
+                        return response;
+                    } catch(Exception respEx) {
+                        // No better luck: throw the original error decoding exception
+                        throw new TransportException(statusCode,
+                            "Failed to decode error response, check exception cause for additional details", endpoint.id(),
+                            clientResp.createException()
+                        );
+                    }
+                }
+            } else {
+                return decodeTransportResponse(statusCode, clientResp.getBody(), clientResp, endpoint);
+            }
+
+
+        } finally {
+            // Consume the entity unless this is a successful binary endpoint, where the user must consume the entity
+            if (!(endpoint instanceof BinaryEndpoint && !endpoint.isError(statusCode))) {
+                clientResp.close();
+            }
+        }
+    }
+
+    private <ResponseT> ResponseT decodeTransportResponse(
+        int statusCode, @Nullable BinaryData entity, TransportResponse clientResp, Endpoint<?, ResponseT, ?> endpoint
+    ) throws IOException {
+
+        if (endpoint instanceof JsonEndpoint) {
+            @SuppressWarnings("unchecked")
+            JsonEndpoint<?, ResponseT, ?> jsonEndpoint = (JsonEndpoint<?, ResponseT, ?>) endpoint;
+            // Successful response
+            ResponseT response = null;
+            JsonpDeserializer<ResponseT> responseParser = jsonEndpoint.responseDeserializer();
+            if (responseParser != null) {
+                // Expecting a body
+                if (entity == null) {
+                    throw new TransportException(
+                        statusCode,
+                        "Expecting a response body, but none was sent",
+                        endpoint.id(), clientResp.createException()
+                    );
+                }
+                InputStream content = entity.asInputStream();
+                try (JsonParser parser = mapper.jsonProvider().createParser(content)) {
+                    response = responseParser.deserialize(parser, mapper);
+                } catch (Exception e) {
+                    throw new TransportException(
+                        statusCode,
+                        "Failed to decode response",
+                        endpoint.id(),
+                        e
+                    );
+                }
+            }
+            return response;
+
+        } else if(endpoint instanceof BooleanEndpoint) {
+            BooleanEndpoint<?> bep = (BooleanEndpoint<?>) endpoint;
+
+            @SuppressWarnings("unchecked")
+            ResponseT response = (ResponseT) new BooleanResponse(bep.getResult(statusCode));
+            return response;
+
+
+        } else if (endpoint instanceof BinaryEndpoint) {
+            @SuppressWarnings("unchecked")
+            ResponseT response = (ResponseT) new BinaryDataResponse(entity);
+            return response;
+
+        } else {
+            throw new TransportException(statusCode, "Unhandled endpoint type: '" + endpoint.getClass().getName() + "'", endpoint.id());
+        }
+    }
+
+    // Endpoints that (incorrectly) do not return the Elastic product header
+    private static final Set<String> endpointsMissingProductHeader = new HashSet<>(Arrays.asList(
+        "es/snapshot.create" // #74 / elastic/elasticsearch#82358
+    ));
+
+    private void checkProductHeader(TransportResponse clientResp, Endpoint<?, ?, ?> endpoint) throws IOException {
+        String header = clientResp.getHeader("X-Elastic-Product");
+        if (header == null) {
+            if (endpointsMissingProductHeader.contains(endpoint.id())) {
+                return;
+            }
+            throw new TransportException(
+                clientResp.statusCode(),
+                "Missing [X-Elastic-Product] header. Please check that you are connecting to an Elasticsearch "
+                    + "instance, and that any networking filters are preserving that header.",
+                endpoint.id(),
+                clientResp.createException()
+            );
+        }
+
+        if (!"Elasticsearch".equals(header)) {
+            throw new TransportException(
+                clientResp.statusCode(),
+                "Invalid value '" + header + "' for 'X-Elastic-Product' header.",
+                endpoint.id(),
+                clientResp.createException()
+            );
+        }
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryDataResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryDataResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.endpoints;
+
+import co.elastic.clients.util.BinaryData;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class BinaryDataResponse implements BinaryResponse {
+
+    private final BinaryData data;
+
+    public BinaryDataResponse(BinaryData data) {
+        this.data = data;
+    }
+
+    @Override
+    public String contentType() {
+        return data.contentType();
+    }
+
+    @Override
+    public long contentLength() {
+        return data.size();
+    }
+
+    @Override
+    public InputStream content() throws IOException {
+        return data.asInputStream();
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientMonolithTransport.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientMonolithTransport.java
@@ -1,0 +1,442 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.rest_client;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ErrorResponse;
+import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.NdJsonpSerializable;
+import co.elastic.clients.transport.JsonEndpoint;
+import co.elastic.clients.transport.TransportException;
+import co.elastic.clients.transport.Version;
+import co.elastic.clients.transport.endpoints.BinaryEndpoint;
+import co.elastic.clients.transport.endpoints.BooleanEndpoint;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import co.elastic.clients.util.ApiTypeHelper;
+import co.elastic.clients.util.BinaryData;
+import co.elastic.clients.util.MissingRequiredPropertyException;
+import jakarta.json.JsonException;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Cancellable;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.client.RestClient;
+
+import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public class RestClientMonolithTransport implements ElasticsearchTransport {
+
+    static final ContentType JsonContentType;
+
+    static {
+
+        if (Version.VERSION == null) {
+            JsonContentType = ContentType.APPLICATION_JSON;
+        } else {
+            JsonContentType = ContentType.create(
+                "application/vnd.elasticsearch+json",
+                new BasicNameValuePair("compatible-with", String.valueOf(Version.VERSION.major()))
+            );
+        }
+    }
+
+    /**
+     * The {@code Future} implementation returned by async requests.
+     * It wraps the RestClient's cancellable and propagates cancellation.
+     */
+    private static class RequestFuture<T> extends CompletableFuture<T> {
+        private volatile Cancellable cancellable;
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            boolean cancelled = super.cancel(mayInterruptIfRunning);
+            if (cancelled && cancellable != null) {
+                cancellable.cancel();
+            }
+            return cancelled;
+        }
+    }
+
+    private final RestClient restClient;
+    private final JsonpMapper mapper;
+    private final RestClientOptions transportOptions;
+
+    public RestClientMonolithTransport(RestClient restClient, JsonpMapper mapper, @Nullable TransportOptions options) {
+        this.restClient = restClient;
+        this.mapper = mapper;
+        this.transportOptions = createOptions(options);
+    }
+
+    protected RestClientOptions createOptions(@Nullable TransportOptions options) {
+        return options == null ? RestClientOptions.initialOptions() : RestClientOptions.of(options);
+    }
+
+    public RestClientMonolithTransport(RestClient restClient, JsonpMapper mapper) {
+        this(restClient, mapper, null);
+    }
+
+    /**
+     * Returns the underlying low level Rest Client used by this transport.
+     */
+    public RestClient restClient() {
+        return this.restClient;
+    }
+
+    /**
+     * Copies this {@link #RestClientTransport} with specific request options.
+     */
+    public RestClientTransport withRequestOptions(@Nullable TransportOptions options) {
+        return new RestClientTransport(this.restClient, this.mapper, options);
+    }
+
+    @Override
+    public JsonpMapper jsonpMapper() {
+        return mapper;
+    }
+
+    @Override
+    public TransportOptions options() {
+        return transportOptions;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.restClient.close();
+    }
+
+    public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
+        RequestT request,
+        Endpoint<RequestT, ResponseT, ErrorT> endpoint,
+        @Nullable TransportOptions options
+    ) throws IOException {
+
+        org.elasticsearch.client.Request clientReq = prepareLowLevelRequest(request, endpoint, options);
+        org.elasticsearch.client.Response clientResp = restClient.performRequest(clientReq);
+        return getHighLevelResponse(clientResp, endpoint);
+    }
+
+    public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(
+        RequestT request,
+        Endpoint<RequestT, ResponseT, ErrorT> endpoint,
+        @Nullable TransportOptions options
+    ) {
+        RequestFuture<ResponseT> future = new RequestFuture<>();
+        org.elasticsearch.client.Request clientReq;
+        try {
+            clientReq = prepareLowLevelRequest(request, endpoint, options);
+        } catch (Exception e) {
+            // Terminate early
+            future.completeExceptionally(e);
+            return future;
+        }
+
+        // Propagate required property checks to the thread that will decode the response
+        boolean disableRequiredChecks = ApiTypeHelper.requiredPropertiesCheckDisabled();
+
+        future.cancellable = restClient.performRequestAsync(clientReq, new ResponseListener() {
+            @Override
+            public void onSuccess(Response clientResp) {
+                try (ApiTypeHelper.DisabledChecksHandle h =
+                         ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(disableRequiredChecks)) {
+
+                    ResponseT response = getHighLevelResponse(clientResp, endpoint);
+                    future.complete(response);
+
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+
+        return future;
+    }
+
+    private <RequestT> org.elasticsearch.client.Request prepareLowLevelRequest(
+        RequestT request,
+        Endpoint<RequestT, ?, ?> endpoint,
+        @Nullable TransportOptions options
+    ) throws IOException {
+        String method = endpoint.method(request);
+        String path = endpoint.requestUrl(request);
+        Map<String, String> params = endpoint.queryParameters(request);
+
+        org.elasticsearch.client.Request clientReq = new org.elasticsearch.client.Request(method, path);
+
+        RequestOptions restOptions = options == null ?
+            transportOptions.restClientRequestOptions() :
+            RestClientOptions.of(options).restClientRequestOptions();
+
+        if (restOptions != null) {
+            clientReq.setOptions(restOptions);
+        }
+
+        clientReq.addParameters(params);
+
+        Object body = endpoint.body(request);
+        if (body != null) {
+            // Request has a body
+            if (body instanceof NdJsonpSerializable) {
+                List<ByteBuffer> lines = new ArrayList<>();
+                collectNdJsonLines(lines, (NdJsonpSerializable) request);
+                clientReq.setEntity(new MultiBufferEntity(lines, JsonContentType));
+
+            } else if (body instanceof BinaryData) {
+                BinaryData data = (BinaryData)body;
+
+                // ES expects the Accept and Content-Type headers to be consistent.
+                ContentType contentType;
+                String dataContentType = data.contentType();
+                if (co.elastic.clients.util.ContentType.APPLICATION_JSON.equals(dataContentType)) {
+                    // Fast path
+                    contentType = JsonContentType;
+                } else {
+                    contentType = ContentType.parse(dataContentType);
+                }
+
+                clientReq.setEntity(new MultiBufferEntity(
+                    Collections.singletonList(data.asByteBuffer()),
+                    contentType
+                ));
+
+            } else {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
+                mapper.serialize(body, generator);
+                generator.close();
+                clientReq.setEntity(new ByteArrayEntity(baos.toByteArray(), JsonContentType));
+            }
+        }
+
+        // Request parameter intercepted by LLRC
+        clientReq.addParameter("ignore", "400,401,403,404,405");
+        return clientReq;
+    }
+
+    private static final ByteBuffer NdJsonSeparator = ByteBuffer.wrap("\n".getBytes(StandardCharsets.UTF_8));
+
+    private void collectNdJsonLines(List<ByteBuffer> lines, NdJsonpSerializable value) throws IOException {
+        Iterator<?> values = value._serializables();
+        while(values.hasNext()) {
+            Object item = values.next();
+            if (item == null) {
+                // Skip
+            } else if (item instanceof NdJsonpSerializable && item != value) { // do not recurse on the item itself
+                collectNdJsonLines(lines, (NdJsonpSerializable)item);
+            } else {
+                // TODO: items that aren't already BinaryData could be serialized to ByteBuffers lazily
+                // to reduce the number of buffers to keep in memory
+                lines.add(BinaryData.of(item, this.mapper).asByteBuffer());
+                lines.add(NdJsonSeparator);
+            }
+        }
+    }
+
+//    /**
+//     * Write an nd-json value by serializing each of its items on a separate line, recursing if its items themselves implement
+//     * {@link NdJsonpSerializable} to flattening nested structures.
+//     */
+//    private void writeNdJson(NdJsonpSerializable value, ByteArrayOutputStream baos) throws IOException {
+//        Iterator<?> values = value._serializables();
+//        while(values.hasNext()) {
+//            Object item = values.next();
+//            if (item instanceof NdJsonpSerializable && item != value) { // do not recurse on the item itself
+//                writeNdJson((NdJsonpSerializable) item, baos);
+//            } else {
+//                JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
+//                mapper.serialize(item, generator);
+//                generator.close();
+//                baos.write('\n');
+//            }
+//        }
+//    }
+
+    private <ResponseT, ErrorT> ResponseT getHighLevelResponse(
+        org.elasticsearch.client.Response clientResp,
+        Endpoint<?, ResponseT, ErrorT> endpoint
+    ) throws IOException {
+
+        int statusCode = clientResp.getStatusLine().getStatusCode();
+        try {
+
+            if (statusCode == 200) {
+                checkProductHeader(clientResp, endpoint);
+            }
+
+            if (endpoint.isError(statusCode)) {
+                JsonpDeserializer<ErrorT> errorDeserializer = endpoint.errorDeserializer(statusCode);
+                if (errorDeserializer == null) {
+                    throw new TransportException(
+                        statusCode,
+                        "Request failed with status code '" + statusCode + "'",
+                        endpoint.id(), new ResponseException(clientResp)
+                    );
+                }
+
+                HttpEntity entity = clientResp.getEntity();
+                if (entity == null) {
+                    throw new TransportException(
+                        statusCode,
+                        "Expecting a response body, but none was sent",
+                        endpoint.id(), new ResponseException(clientResp)
+                    );
+                }
+
+                // We may have to replay it.
+                entity = new BufferedHttpEntity(entity);
+
+                try {
+                    InputStream content = entity.getContent();
+                    try (JsonParser parser = mapper.jsonProvider().createParser(content)) {
+                        ErrorT error = errorDeserializer.deserialize(parser, mapper);
+                        // TODO: have the endpoint provide the exception constructor
+                        throw new ElasticsearchException(endpoint.id(), (ErrorResponse) error);
+                    }
+                } catch(JsonException | MissingRequiredPropertyException errorEx) {
+                    // Could not decode exception, try the response type
+                    try {
+                        ResponseT response = decodeResponse(statusCode, entity, clientResp, endpoint);
+                        return response;
+                    } catch(Exception respEx) {
+                        // No better luck: throw the original error decoding exception
+                        throw new TransportException(statusCode,
+                            "Failed to decode error response, check exception cause for additional details", endpoint.id(),
+                            new ResponseException(clientResp)
+                        );
+                    }
+                }
+            } else {
+                return decodeResponse(statusCode, clientResp.getEntity(), clientResp, endpoint);
+            }
+        } finally {
+            // Consume the entity unless this is a successful binary endpoint, where the user must consume the entity
+            if (!(endpoint instanceof BinaryEndpoint && !endpoint.isError(statusCode))) {
+                EntityUtils.consume(clientResp.getEntity());
+            }
+        }
+    }
+
+    private <ResponseT> ResponseT decodeResponse(
+        int statusCode, @Nullable HttpEntity entity, Response clientResp, Endpoint<?, ResponseT, ?> endpoint
+    ) throws IOException {
+
+        if (endpoint instanceof JsonEndpoint) {
+            @SuppressWarnings("unchecked")
+            JsonEndpoint<?, ResponseT, ?> jsonEndpoint = (JsonEndpoint<?, ResponseT, ?>) endpoint;
+            // Successful response
+            ResponseT response = null;
+            JsonpDeserializer<ResponseT> responseParser = jsonEndpoint.responseDeserializer();
+            if (responseParser != null) {
+                // Expecting a body
+                if (entity == null) {
+                    throw new TransportException(
+                        statusCode,
+                        "Expecting a response body, but none was sent",
+                        endpoint.id(), new ResponseException(clientResp)
+                    );
+                }
+                InputStream content = entity.getContent();
+                try (JsonParser parser = mapper.jsonProvider().createParser(content)) {
+                    response = responseParser.deserialize(parser, mapper);
+                }
+            }
+            return response;
+
+        } else if(endpoint instanceof BooleanEndpoint) {
+            BooleanEndpoint<?> bep = (BooleanEndpoint<?>) endpoint;
+
+            @SuppressWarnings("unchecked")
+            ResponseT response = (ResponseT) new BooleanResponse(bep.getResult(statusCode));
+            return response;
+
+
+        } else if (endpoint instanceof BinaryEndpoint) {
+            BinaryEndpoint<?> bep = (BinaryEndpoint<?>) endpoint;
+
+            @SuppressWarnings("unchecked")
+            ResponseT response = (ResponseT) new HttpClientBinaryResponse(entity);
+            return response;
+
+        } else {
+            throw new TransportException(statusCode, "Unhandled endpoint type: '" + endpoint.getClass().getName() + "'", endpoint.id());
+        }
+    }
+
+    // Endpoints that (incorrectly) do not return the Elastic product header
+    private static final Set<String> endpointsMissingProductHeader = new HashSet<>(Arrays.asList(
+        "es/snapshot.create" // #74 / elastic/elasticsearch#82358
+    ));
+
+    private void checkProductHeader(Response clientResp, Endpoint<?, ?, ?> endpoint) throws IOException {
+        String header = clientResp.getHeader("X-Elastic-Product");
+        if (header == null) {
+            if (endpointsMissingProductHeader.contains(endpoint.id())) {
+                return;
+            }
+            throw new TransportException(
+                clientResp.getStatusLine().getStatusCode(),
+                "Missing [X-Elastic-Product] header. Please check that you are connecting to an Elasticsearch "
+                    + "instance, and that any networking filters are preserving that header.",
+                endpoint.id(),
+                new ResponseException(clientResp)
+            );
+        }
+
+        if (!"Elasticsearch".equals(header)) {
+            throw new TransportException(
+                clientResp.getStatusLine().getStatusCode(),
+                "Invalid value '" + header + "' for 'X-Elastic-Product' header.",
+                endpoint.id(),
+                new ResponseException(clientResp)
+            );
+        }
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientOptions.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientOptions.java
@@ -173,7 +173,7 @@ public class RestClientOptions implements TransportOptions {
             builder.addHeader(USER_AGENT_HEADER, USER_AGENT_VALUE);
         }
         if (builder.getHeaders().stream().noneMatch(h -> h.getName().equalsIgnoreCase("Accept"))) {
-            builder.addHeader("Accept", RestClientTransport.JsonContentType.toString());
+            builder.addHeader("Accept", RestClientTransport.JsonContentType);
         }
 
         return builder;

--- a/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientTransport.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientTransport.java
@@ -19,33 +19,18 @@
 
 package co.elastic.clients.transport.rest_client;
 
-import co.elastic.clients.elasticsearch._types.ElasticsearchException;
-import co.elastic.clients.elasticsearch._types.ErrorResponse;
-import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
-import co.elastic.clients.json.NdJsonpSerializable;
-import co.elastic.clients.transport.JsonEndpoint;
-import co.elastic.clients.transport.TransportException;
-import co.elastic.clients.transport.Version;
-import co.elastic.clients.transport.endpoints.BinaryEndpoint;
-import co.elastic.clients.transport.endpoints.BooleanEndpoint;
-import co.elastic.clients.transport.endpoints.BooleanResponse;
+import co.elastic.clients.transport.TransportBase;
 import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.TransportOptions;
-import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.BinaryData;
-import co.elastic.clients.util.MissingRequiredPropertyException;
-import jakarta.json.JsonException;
-import jakarta.json.stream.JsonGenerator;
-import jakarta.json.stream.JsonParser;
+import co.elastic.clients.util.NoCopyByteArrayOutputStream;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
-import org.apache.http.entity.BufferedHttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
-import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Cancellable;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -53,36 +38,16 @@ import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 
 import javax.annotation.Nullable;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
-public class RestClientTransport implements ElasticsearchTransport {
+public class RestClientTransport extends TransportBase<RestClientOptions> implements ElasticsearchTransport {
 
-    static final ContentType JsonContentType;
-
-    static {
-
-        if (Version.VERSION == null) {
-            JsonContentType = ContentType.APPLICATION_JSON;
-        } else {
-            JsonContentType = ContentType.create(
-                "application/vnd.elasticsearch+json",
-                new BasicNameValuePair("compatible-with", String.valueOf(Version.VERSION.major()))
-            );
-        }
-    }
+    private static final ConcurrentHashMap<String, ContentType> ContentTypeCache = new ConcurrentHashMap<>();
 
     /**
      * The {@code Future} implementation returned by async requests.
@@ -102,17 +67,14 @@ public class RestClientTransport implements ElasticsearchTransport {
     }
 
     private final RestClient restClient;
-    private final JsonpMapper mapper;
-    private final RestClientOptions transportOptions;
-
-    public RestClientTransport(RestClient restClient, JsonpMapper mapper, @Nullable TransportOptions options) {
-        this.restClient = restClient;
-        this.mapper = mapper;
-        this.transportOptions = options == null ? RestClientOptions.initialOptions() : RestClientOptions.of(options);
-    }
 
     public RestClientTransport(RestClient restClient, JsonpMapper mapper) {
         this(restClient, mapper, null);
+    }
+
+    public RestClientTransport(RestClient restClient, JsonpMapper mapper, @Nullable TransportOptions options) {
+        super(mapper, options == null ? RestClientOptions.initialOptions() : RestClientOptions.of(options));
+        this.restClient = restClient;
     }
 
     /**
@@ -122,21 +84,45 @@ public class RestClientTransport implements ElasticsearchTransport {
         return this.restClient;
     }
 
-    /**
-     * Copies this {@link #RestClientTransport} with specific request options.
-     */
-    public RestClientTransport withRequestOptions(@Nullable TransportOptions options) {
-        return new RestClientTransport(this.restClient, this.mapper, options);
+    @Override
+    protected RestClientOptions createOptions(@Nullable TransportOptions options) {
+        return options == null ? transportOptions : RestClientOptions.of(options);
     }
 
     @Override
-    public JsonpMapper jsonpMapper() {
-        return mapper;
+    protected TransportResponse performRequest(TransportRequest request, RestClientOptions options) throws IOException {
+        Request restRequest = createRestRequest(request, options);
+        Response restResponse = restClient.performRequest(restRequest);
+        return new RestResponse(restResponse);
     }
 
     @Override
-    public TransportOptions options() {
-        return transportOptions;
+    protected CompletableFuture<TransportResponse> performRequestAsync(TransportRequest request, RestClientOptions options) {
+
+        RequestFuture<TransportResponse> future = new RequestFuture<>();
+        org.elasticsearch.client.Request restRequest;
+
+        try {
+            restRequest = createRestRequest(request, options);
+        } catch(Throwable thr) {
+            // Terminate early
+            future.completeExceptionally(thr);
+            return future;
+        }
+
+        future.cancellable = restClient.performRequestAsync(restRequest, new ResponseListener() {
+            @Override
+            public void onSuccess(org.elasticsearch.client.Response response) {
+                future.complete(new RestResponse(response));
+            }
+
+            @Override
+            public void onFailure(Exception exception) {
+                future.completeExceptionally(exception);
+            }
+        });
+
+        return future;
     }
 
     @Override
@@ -144,68 +130,10 @@ public class RestClientTransport implements ElasticsearchTransport {
         this.restClient.close();
     }
 
-    public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
-        RequestT request,
-        Endpoint<RequestT, ResponseT, ErrorT> endpoint,
-        @Nullable TransportOptions options
-    ) throws IOException {
-
-        org.elasticsearch.client.Request clientReq = prepareLowLevelRequest(request, endpoint, options);
-        org.elasticsearch.client.Response clientResp = restClient.performRequest(clientReq);
-        return getHighLevelResponse(clientResp, endpoint);
-    }
-
-    public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(
-        RequestT request,
-        Endpoint<RequestT, ResponseT, ErrorT> endpoint,
-        @Nullable TransportOptions options
-    ) {
-        RequestFuture<ResponseT> future = new RequestFuture<>();
-        org.elasticsearch.client.Request clientReq;
-        try {
-            clientReq = prepareLowLevelRequest(request, endpoint, options);
-        } catch (Exception e) {
-            // Terminate early
-            future.completeExceptionally(e);
-            return future;
-        }
-
-        // Propagate required property checks to the thread that will decode the response
-        boolean disableRequiredChecks = ApiTypeHelper.requiredPropertiesCheckDisabled();
-
-        future.cancellable = restClient.performRequestAsync(clientReq, new ResponseListener() {
-            @Override
-            public void onSuccess(Response clientResp) {
-                try (ApiTypeHelper.DisabledChecksHandle h =
-                         ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(disableRequiredChecks)) {
-
-                    ResponseT response = getHighLevelResponse(clientResp, endpoint);
-                    future.complete(response);
-
-                } catch (Exception e) {
-                    future.completeExceptionally(e);
-                }
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                future.completeExceptionally(e);
-            }
-        });
-
-        return future;
-    }
-
-    private <RequestT> org.elasticsearch.client.Request prepareLowLevelRequest(
-        RequestT request,
-        Endpoint<RequestT, ?, ?> endpoint,
-        @Nullable TransportOptions options
-    ) throws IOException {
-        String method = endpoint.method(request);
-        String path = endpoint.requestUrl(request);
-        Map<String, String> params = endpoint.queryParameters(request);
-
-        org.elasticsearch.client.Request clientReq = new org.elasticsearch.client.Request(method, path);
+    private org.elasticsearch.client.Request createRestRequest(TransportRequest request, RestClientOptions options) {
+        org.elasticsearch.client.Request clientReq = new org.elasticsearch.client.Request(
+            request.method, request.path
+        );
 
         RequestOptions restOptions = options == null ?
             transportOptions.restClientRequestOptions() :
@@ -215,41 +143,12 @@ public class RestClientTransport implements ElasticsearchTransport {
             clientReq.setOptions(restOptions);
         }
 
-        clientReq.addParameters(params);
+        clientReq.addParameters(request.queryParams);
 
-        Object body = endpoint.body(request);
+        Iterable<ByteBuffer> body = request.body;
         if (body != null) {
-            // Request has a body
-            if (body instanceof NdJsonpSerializable) {
-                List<ByteBuffer> lines = new ArrayList<>();
-                collectNdJsonLines(lines, (NdJsonpSerializable) request);
-                clientReq.setEntity(new MultiBufferEntity(lines, JsonContentType));
-
-            } else if (body instanceof BinaryData) {
-                BinaryData data = (BinaryData)body;
-
-                // ES expects the Accept and Content-Type headers to be consistent.
-                ContentType contentType;
-                String dataContentType = data.contentType();
-                if (co.elastic.clients.util.ContentType.APPLICATION_JSON.equals(dataContentType)) {
-                    // Fast path
-                    contentType = JsonContentType;
-                } else {
-                    contentType = ContentType.parse(dataContentType);
-                }
-
-                clientReq.setEntity(new MultiBufferEntity(
-                    Collections.singletonList(data.asByteBuffer()),
-                    contentType
-                ));
-
-            } else {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
-                mapper.serialize(body, generator);
-                generator.close();
-                clientReq.setEntity(new ByteArrayEntity(baos.toByteArray(), JsonContentType));
-            }
+            ContentType ct = ContentTypeCache.computeIfAbsent(request.contentType, ContentType::parse);
+            clientReq.setEntity(new MultiBufferEntity(body, ct));
         }
 
         // Request parameter intercepted by LLRC
@@ -257,182 +156,80 @@ public class RestClientTransport implements ElasticsearchTransport {
         return clientReq;
     }
 
-    private static final ByteBuffer NdJsonSeparator = ByteBuffer.wrap("\n".getBytes(StandardCharsets.UTF_8));
+    private static class RestResponse implements TransportResponse {
+        private final org.elasticsearch.client.Response restResponse;
 
-    private void collectNdJsonLines(List<ByteBuffer> lines, NdJsonpSerializable value) {
-        Iterator<?> values = value._serializables();
-        while(values.hasNext()) {
-            Object item = values.next();
-            if (item == null) {
-                // Skip
-            } else if (item instanceof NdJsonpSerializable && item != value) { // do not recurse on the item itself
-                collectNdJsonLines(lines, (NdJsonpSerializable)item);
-            } else {
-                // TODO: items that aren't already BinaryData could be serialized to ByteBuffers lazily
-                // to reduce the number of buffers to keep in memory
-                lines.add(BinaryData.of(item, this.mapper).asByteBuffer());
-                lines.add(NdJsonSeparator);
-            }
+        public RestResponse(org.elasticsearch.client.Response restResponse) {
+            this.restResponse = restResponse;
+        }
+
+        @Override
+        public int statusCode() {
+            return restResponse.getStatusLine().getStatusCode();
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return restResponse.getHeader(name);
+        }
+
+        @Nullable
+        @Override
+        public BinaryData getBody() throws IOException {
+            HttpEntity entity = restResponse.getEntity();
+            return entity == null ? null : new HttpEntityBinaryData(restResponse.getEntity());
+        }
+
+        @Override
+        public Throwable createException() throws IOException {
+            return new ResponseException(this.restResponse);
+        }
+
+        @Override
+        public void close() throws IOException {
+            EntityUtils.consume(restResponse.getEntity());
         }
     }
 
-    /**
-     * Write an nd-json value by serializing each of its items on a separate line, recursing if its items themselves implement
-     * {@link NdJsonpSerializable} to flattening nested structures.
-     */
-    private void writeNdJson(NdJsonpSerializable value, ByteArrayOutputStream baos) throws IOException {
-        Iterator<?> values = value._serializables();
-        while(values.hasNext()) {
-            Object item = values.next();
-            if (item instanceof NdJsonpSerializable && item != value) { // do not recurse on the item itself
-                writeNdJson((NdJsonpSerializable) item, baos);
-            } else {
-                JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
-                mapper.serialize(item, generator);
-                generator.close();
-                baos.write('\n');
-            }
-        }
-    }
+    private static class HttpEntityBinaryData implements BinaryData {
+        private final HttpEntity entity;
 
-    private <ResponseT, ErrorT> ResponseT getHighLevelResponse(
-        org.elasticsearch.client.Response clientResp,
-        Endpoint<?, ResponseT, ErrorT> endpoint
-    ) throws IOException {
-
-        int statusCode = clientResp.getStatusLine().getStatusCode();
-        try {
-
-            if (statusCode == 200) {
-                checkProductHeader(clientResp, endpoint);
-            }
-
-            if (endpoint.isError(statusCode)) {
-                JsonpDeserializer<ErrorT> errorDeserializer = endpoint.errorDeserializer(statusCode);
-                if (errorDeserializer == null) {
-                    throw new TransportException(
-                        statusCode,
-                        "Request failed with status code '" + statusCode + "'",
-                        endpoint.id(), new ResponseException(clientResp)
-                    );
-                }
-
-                HttpEntity entity = clientResp.getEntity();
-                if (entity == null) {
-                    throw new TransportException(
-                        statusCode,
-                        "Expecting a response body, but none was sent",
-                        endpoint.id(), new ResponseException(clientResp)
-                    );
-                }
-
-                // We may have to replay it.
-                entity = new BufferedHttpEntity(entity);
-
-                try {
-                    InputStream content = entity.getContent();
-                    try (JsonParser parser = mapper.jsonProvider().createParser(content)) {
-                        ErrorT error = errorDeserializer.deserialize(parser, mapper);
-                        // TODO: have the endpoint provide the exception constructor
-                        throw new ElasticsearchException(endpoint.id(), (ErrorResponse) error);
-                    }
-                } catch(JsonException | MissingRequiredPropertyException errorEx) {
-                    // Could not decode exception, try the response type
-                    try {
-                        ResponseT response = decodeResponse(statusCode, entity, clientResp, endpoint);
-                        return response;
-                    } catch(Exception respEx) {
-                        // No better luck: throw the original error decoding exception
-                        throw new TransportException(statusCode,
-                            "Failed to decode error response, check exception cause for additional details", endpoint.id(),
-                            new ResponseException(clientResp)
-                        );
-                    }
-                }
-            } else {
-                return decodeResponse(statusCode, clientResp.getEntity(), clientResp, endpoint);
-            }
-        } finally {
-            // Consume the entity unless this is a successful binary endpoint, where the user must consume the entity
-            if (!(endpoint instanceof BinaryEndpoint && !endpoint.isError(statusCode))) {
-                EntityUtils.consume(clientResp.getEntity());
-            }
-        }
-    }
-
-    private <ResponseT> ResponseT decodeResponse(
-        int statusCode, @Nullable HttpEntity entity, Response clientResp, Endpoint<?, ResponseT, ?> endpoint
-    ) throws IOException {
-
-        if (endpoint instanceof JsonEndpoint) {
-            @SuppressWarnings("unchecked")
-            JsonEndpoint<?, ResponseT, ?> jsonEndpoint = (JsonEndpoint<?, ResponseT, ?>) endpoint;
-            // Successful response
-            ResponseT response = null;
-            JsonpDeserializer<ResponseT> responseParser = jsonEndpoint.responseDeserializer();
-            if (responseParser != null) {
-                // Expecting a body
-                if (entity == null) {
-                    throw new TransportException(
-                        statusCode,
-                        "Expecting a response body, but none was sent",
-                        endpoint.id(), new ResponseException(clientResp)
-                    );
-                }
-                InputStream content = entity.getContent();
-                try (JsonParser parser = mapper.jsonProvider().createParser(content)) {
-                    response = responseParser.deserialize(parser, mapper);
-                }
-            }
-            return response;
-
-        } else if(endpoint instanceof BooleanEndpoint) {
-            BooleanEndpoint<?> bep = (BooleanEndpoint<?>) endpoint;
-
-            @SuppressWarnings("unchecked")
-            ResponseT response = (ResponseT) new BooleanResponse(bep.getResult(statusCode));
-            return response;
-
-
-        } else if (endpoint instanceof BinaryEndpoint) {
-            BinaryEndpoint<?> bep = (BinaryEndpoint<?>) endpoint;
-
-            @SuppressWarnings("unchecked")
-            ResponseT response = (ResponseT) new HttpClientBinaryResponse(entity);
-            return response;
-
-        } else {
-            throw new TransportException(statusCode, "Unhandled endpoint type: '" + endpoint.getClass().getName() + "'", endpoint.id());
-        }
-    }
-
-    // Endpoints that (incorrectly) do not return the Elastic product header
-    private static final Set<String> endpointsMissingProductHeader = new HashSet<>(Arrays.asList(
-        "es/snapshot.create" // #74 / elastic/elasticsearch#82358
-    ));
-
-    private void checkProductHeader(Response clientResp, Endpoint<?, ?, ?> endpoint) throws IOException {
-        String header = clientResp.getHeader("X-Elastic-Product");
-        if (header == null) {
-            if (endpointsMissingProductHeader.contains(endpoint.id())) {
-                return;
-            }
-            throw new TransportException(
-                clientResp.getStatusLine().getStatusCode(),
-                "Missing [X-Elastic-Product] header. Please check that you are connecting to an Elasticsearch "
-                    + "instance, and that any networking filters are preserving that header.",
-                endpoint.id(),
-                new ResponseException(clientResp)
-            );
+        public HttpEntityBinaryData(HttpEntity entity) {
+            this.entity = entity;
         }
 
-        if (!"Elasticsearch".equals(header)) {
-            throw new TransportException(
-                clientResp.getStatusLine().getStatusCode(),
-                "Invalid value '" + header + "' for 'X-Elastic-Product' header.",
-                endpoint.id(),
-                new ResponseException(clientResp)
-            );
+        @Override
+        public String contentType() {
+            Header h = entity.getContentType();
+            return h == null ? "application/octet-stream" : h.getValue();
+        }
+
+        @Override
+        public void writeTo(OutputStream out) throws IOException {
+            entity.writeTo(out);
+        }
+
+        @Override
+        public ByteBuffer asByteBuffer() throws IOException {
+            NoCopyByteArrayOutputStream out = new NoCopyByteArrayOutputStream();
+            entity.writeTo(out);
+            return out.asByteBuffer();
+        }
+
+        @Override
+        public InputStream asInputStream() throws IOException {
+            return entity.getContent();
+        }
+
+        @Override
+        public boolean isRepeatable() {
+            return entity.isRepeatable();
+        }
+
+        @Override
+        public long size() {
+            long len = entity.getContentLength();
+            return len < 0 ? -1 : entity.getContentLength();
         }
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/util/BinaryData.java
+++ b/java-client/src/main/java/co/elastic/clients/util/BinaryData.java
@@ -27,6 +27,7 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
@@ -43,13 +44,31 @@ public interface BinaryData {
 
     /**
      * Write this data to an output stream.
+     * @throws IllegalStateException if the content has already been consumed and the object
+     *         isn't replayable.
      */
     void writeTo(OutputStream out) throws IOException;
 
     /**
-     * Return this data as a {@code ByteBuffer}
+     * Return this data as a {@code ByteBuffer}.
+     *
+     * @throws IllegalStateException if the content has already been consumed and the object
+     *         isn't replayable.
      */
-    ByteBuffer asByteBuffer();
+    ByteBuffer asByteBuffer() throws IOException;
+
+    /**
+     * Return this data as an {@code InputStream}.
+     *
+     * @throws IllegalStateException if the content has already been consumed and the object
+     *         isn't replayable.
+     */
+    InputStream asInputStream() throws IOException;
+
+    /**
+     * Can this object be consumed several times?
+     */
+    boolean isRepeatable();
 
     /**
      * Get the estimated size in bytes of the data.

--- a/java-client/src/main/java/co/elastic/clients/util/ByteArrayBinaryData.java
+++ b/java-client/src/main/java/co/elastic/clients/util/ByteArrayBinaryData.java
@@ -27,8 +27,10 @@ import co.elastic.clients.json.JsonpUtils;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.EnumSet;
@@ -55,6 +57,18 @@ public class ByteArrayBinaryData implements BinaryData {
         this.length = bytes.length;
     }
 
+    /**
+     * Copy another {@link BinaryData}. Typically used to make a replayable {@link BinaryData}
+     * from a non-replayable one.
+     */
+    public ByteArrayBinaryData(BinaryData data) throws IOException {
+        NoCopyByteArrayOutputStream out = new NoCopyByteArrayOutputStream();
+        data.writeTo(out);
+        this.contentType = data.contentType();
+        this.bytes = out.array();
+        this.offset = 0;
+        this.length = out.size();
+    }
 
     @Override
     public String contentType() {
@@ -74,6 +88,16 @@ public class ByteArrayBinaryData implements BinaryData {
     @Override
     public ByteBuffer asByteBuffer() {
         return ByteBuffer.wrap(bytes, offset, length);
+    }
+
+    @Override
+    public InputStream asInputStream() {
+        return new ByteArrayInputStream(bytes, offset, length);
+    }
+
+    @Override
+    public boolean isRepeatable() {
+        return true;
     }
 
     private static class Deserializer extends JsonpDeserializerBase<ByteArrayBinaryData> {

--- a/java-client/src/main/java/co/elastic/clients/util/NoCopyByteArrayOutputStream.java
+++ b/java-client/src/main/java/co/elastic/clients/util/NoCopyByteArrayOutputStream.java
@@ -21,6 +21,7 @@ package co.elastic.clients.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 
 /**
  * A {@code ByteArrayOutputStream} that reduces copy operations of its underlying buffer.
@@ -47,5 +48,12 @@ public class NoCopyByteArrayOutputStream extends ByteArrayOutputStream {
      */
     public ByteArrayInputStream asInputStream() {
         return new ByteArrayInputStream(this.buf, 0, this.count);
+    }
+
+    /**
+     * Get a {@code ByteBuffer} view on this object, based on the current buffer and size.
+     */
+    public ByteBuffer asByteBuffer() {
+        return ByteBuffer.wrap(this.buf, 0, this.count);
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/transport/rest_client/RestClientOptionsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/rest_client/RestClientOptionsTest.java
@@ -20,7 +20,9 @@
 package co.elastic.clients.transport.rest_client;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.SimpleJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.Version;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
 import com.sun.net.httpserver.Headers;
@@ -58,6 +60,8 @@ class RestClientOptionsTest extends Assertions {
         // Register a handler on the core.exists("capture-handler/{name}") endpoint that will capture request headers.
         httpServer.createContext("/capture-headers/_doc/", exchange -> {
             String testName = exchange.getRequestURI().getPath().substring("/capture-headers/_doc/".length());
+            System.out.println(exchange.getResponseHeaders());
+            System.out.println();
             collectedHeaders.put(testName, exchange.getRequestHeaders());
 
             // Reply with an empty 200 response
@@ -74,6 +78,15 @@ class RestClientOptionsTest extends Assertions {
         httpServer.stop(0);
         httpServer = null;
         collectedHeaders = null;
+    }
+    
+    private ElasticsearchTransport newRestClientTransport(RestClient restClient, JsonpMapper mapper) {
+        return newRestClientTransport(restClient, mapper, null);
+    }
+
+    private ElasticsearchTransport newRestClientTransport(RestClient restClient, JsonpMapper mapper, RestClientOptions options) {
+        return new RestClientTransport(restClient, mapper, options);
+        //return new RestClientMonolithTransport(restClient, mapper, options);
     }
 
     /**
@@ -114,7 +127,7 @@ class RestClientOptionsTest extends Assertions {
             new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
         ).build();
 
-        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper());
+        ElasticsearchTransport transport = newRestClientTransport(llrc, new SimpleJsonpMapper());
         ElasticsearchClient esClient = new ElasticsearchClient(transport);
 
         String id = checkHeaders(esClient);
@@ -127,7 +140,7 @@ class RestClientOptionsTest extends Assertions {
             new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
         ).build();
 
-        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper(),
+        ElasticsearchTransport transport = newRestClientTransport(llrc, new SimpleJsonpMapper(),
             new RestClientOptions.Builder(RequestOptions.DEFAULT.toBuilder()).build()
         );
         ElasticsearchClient esClient = new ElasticsearchClient(transport);
@@ -142,7 +155,7 @@ class RestClientOptionsTest extends Assertions {
             new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
         ).build();
 
-        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper());
+        ElasticsearchTransport transport = newRestClientTransport(llrc, new SimpleJsonpMapper());
         ElasticsearchClient esClient = new ElasticsearchClient(transport).withTransportOptions(
             new RestClientOptions.Builder(RequestOptions.DEFAULT.toBuilder()).build()
         );
@@ -157,7 +170,7 @@ class RestClientOptionsTest extends Assertions {
             new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
         ).build();
 
-        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper());
+        ElasticsearchTransport transport = newRestClientTransport(llrc, new SimpleJsonpMapper());
         ElasticsearchClient esClient = new ElasticsearchClient(transport)
             .withTransportOptions(o -> o
                 .addHeader("Foo", "bar")
@@ -179,7 +192,7 @@ class RestClientOptionsTest extends Assertions {
             new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort(), "http")
         ).build();
 
-        RestClientTransport transport = new RestClientTransport(llrc, new SimpleJsonpMapper(), new RestClientOptions(options));
+        ElasticsearchTransport transport = newRestClientTransport(llrc, new SimpleJsonpMapper(), new RestClientOptions(options));
         ElasticsearchClient esClient = new ElasticsearchClient(transport);
         // Should not override client meta
         String id = checkHeaders(esClient);


### PR DESCRIPTION
**[work in progress]**

Extract the logic related to high-level API objects (serialization, deserialization, error handling, etc) that exists in `RestClientTransport` to a new abstract `ClientTransportBase` class. `ClientTransportBase` expect subclasses to implement the http layer using two lightweight request and response abstractions.

`RestClientTransport` therefore becomes a thin layer implementing these abstractions with `RestClient`.

The goal is to allow future additional implementations to be provided, e.g. based on the builting http client in JDK11+, and allow users to easily implement their own when needed.

Note that `ClientTransportBase` does not implement multi-node retry and cluster sniffing, which is provided by `RestClient` and would have to be re-implemented for other http libraries.

Fixes #550