### PR TITLE
Add pipeline setup to index and create operations

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/IngesterOperation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/IngesterOperation.java
@@ -80,7 +80,7 @@ public class IngesterOperation {
             BinaryData binaryDoc = BinaryData.of(create.document(), mapper);
             size += binaryDoc.size();
             newOperation = BulkOperation.of(bo -> bo.create(idx -> {
-                copyBaseProperties(create, idx);
+                copyCreateProperties(create, idx);
                 return idx.document(binaryDoc);
             }));
         }
@@ -102,7 +102,7 @@ public class IngesterOperation {
             BinaryData binaryDoc = BinaryData.of(index.document(), mapper);
             size += binaryDoc.size();
             newOperation = BulkOperation.of(bo -> bo.index(idx -> {
-                copyBaseProperties(index, idx);
+                copyIndexProperties(index, idx);
                 return idx.document(binaryDoc);
             }));
         }
@@ -152,6 +152,16 @@ public class IngesterOperation {
             .routing(op.routing())
             .version(op.version())
             .versionType(op.versionType());
+    }
+
+    private static void copyIndexProperties(IndexOperation<?> op, IndexOperation.Builder<?> builder) {
+        copyBaseProperties(op, builder);
+        builder.pipeline(op.pipeline());
+    }
+
+    private static void copyCreateProperties(CreateOperation<?> op, CreateOperation.Builder<?> builder) {
+        copyBaseProperties(op, builder);
+        builder.pipeline(op.pipeline());
     }
 
     private static int size(String name, @Nullable Boolean value) {


### PR DESCRIPTION
This pull request introduces a change to allow the pipeline in index operations to be set up individually. Previously, the pipeline was not set up for each index operation, which resulted in using the default pipeline on the index.

The changes include:
- Adding a copyIndexProperties method to copy the pipeline property from the IndexOperation to the IndexOperation.Builder.
- Modifying the indexOperation method to use copyIndexProperties instead of copyBaseProperties, ensuring the pipeline is copied for each index operation.
- Similar changes have been made for createOperation method to ensure consistency.

These changes allow each request to have its corresponding pipeline, providing more flexibility and control over how documents are indexed. This is particularly useful when different documents in the same index require different processing.

This change aligns with the existing structure of the BulkRequest, which also includes a "pipeline" field. With this change, the pipeline field in the BulkRequest will be correctly set up by the BulkIngester.