### PR TITLE
[DOCS] Temporarily redirect getting started button link on landing page

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -63,7 +63,7 @@
         The Java API client provides strongly typed requests and responses for all Elasticsearch APIs.
       </p>
       <p>
-        <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/_getting_started.html">
+        <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html">
           <button class="btn btn-primary">Get started</button>
         </a>
       </p>


### PR DESCRIPTION
## Overview

This PR temporarily redirects the get started button on the landing page to point to the `Introduction` section. Unblocks https://github.com/elastic/elasticsearch-java/pull/621.

As https://github.com/elastic/elasticsearch-java/pull/617 changed the page title and ID of the previous getting started page and renamed it to Setup, the links that point to that page on the `/current/` branch will be broken after the [backport PR](https://github.com/elastic/elasticsearch-java/pull/621) on 8.8 (the current branch) is merged. The following branches are affected: `main`, `8.9`, `8.8`, `8.7`. However, the 8.8 backport PR already contains the fix which makes the backport of this PR to 8.8 unnecessary.

After this PR is merged and backported all the way down to 8.7 (except 8.8), the backport PR – https://github.com/elastic/elasticsearch-java/pull/621 – will be unblocked.

After https://github.com/elastic/elasticsearch-java/pull/621 is merged, another PR will update the button link to point to the newly created getting started page.