### PR TITLE
[DOCS] Changes getting started button link on landing page

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -63,7 +63,7 @@
         The Java API client provides strongly typed requests and responses for all Elasticsearch APIs.
       </p>
       <p>
-        <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/_getting_started.html">
+        <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html">
           <button class="btn btn-primary">Get started</button>
         </a>
       </p>


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/elasticsearch-java/pull/623.
This PR changes the URL of the getting started button on the landing page.