### PR TITLE
[8.10] Add instrumentation API and native OpenTelemetry implementation (#588)

### DIFF
--- a/example-transports/src/main/java/co/elastic/clients/transport/netty/NettyTransportHttpClient.java
+++ b/example-transports/src/main/java/co/elastic/clients/transport/netty/NettyTransportHttpClient.java
@@ -56,9 +56,9 @@ import io.netty.util.concurrent.Future;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -231,12 +231,8 @@ public class NettyTransportHttpClient implements TransportHttpClient {
                 .entrySet()
                 .stream()
                 .map(e -> {
-                    try {
-                        return URLEncoder.encode(e.getKey(), "UTF-8") + "=" +
-                            URLEncoder.encode(e.getValue(), "UTF-8");
-                    } catch(UnsupportedEncodingException ex) {
-                        throw new RuntimeException(ex);
-                    }
+                    return URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8) + "=" +
+                        URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8);
                 })
                 .collect(Collectors.joining("&"));
         }

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -18,8 +18,8 @@
  */
 
 import com.github.jk1.license.ProjectData
-import com.github.jk1.license.render.ReportRenderer
 import com.github.jk1.license.render.LicenseDataCollector
+import com.github.jk1.license.render.ReportRenderer
 import java.io.FileWriter
 
 plugins {
@@ -53,8 +53,8 @@ tasks.getByName<ProcessResources>("processResources") {
         if (name != "apis.json") {
             // Only process main source-set resources (test files are large)
             expand(
-                "version" to version,
-                "git_revision" to (if (rootProject.extra.has("gitHashFull")) rootProject.extra["gitHashFull"] else "unknown")
+                    "version" to version,
+                    "git_revision" to (if (rootProject.extra.has("gitHashFull")) rootProject.extra["gitHashFull"] else "unknown")
             )
         }
     }
@@ -69,7 +69,7 @@ tasks.withType<Jar> {
         if (rootProject.extra.has("gitHashFull")) {
             val jar = this as Jar
             jar.manifest.attributes["X-Git-Revision"] = rootProject.extra["gitHashFull"]
-            jar.manifest.attributes["X-Git-Commit-Time"] = rootProject .extra["gitCommitTime"]
+            jar.manifest.attributes["X-Git-Commit-Time"] = rootProject.extra["gitCommitTime"]
         } else {
             throw GradleException("No git information available")
         }
@@ -154,7 +154,7 @@ publishing {
                     // are the same as the one used in the dependency section below.
                     val xPathFactory = javax.xml.xpath.XPathFactory.newInstance()
                     val depSelector = xPathFactory.newXPath()
-                        .compile("/project/dependencies/dependency[groupId/text() = 'org.elasticsearch.client']")
+                            .compile("/project/dependencies/dependency[groupId/text() = 'org.elasticsearch.client']")
                     val versionSelector = xPathFactory.newXPath().compile("version")
 
                     var foundVersion = false;
@@ -183,6 +183,7 @@ dependencies {
     // the Java API client coexists with a 7.x HLRC work fine
     val elasticsearchVersion = "7.17.7"
     val jacksonVersion = "2.13.3"
+    val openTelemetryVersion = "1.29.0"
 
     // Apache 2.0
     // https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html
@@ -200,6 +201,13 @@ dependencies {
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/parsson
     api("org.eclipse.parsson:parsson:1.0.0")
+
+    // OpenTelemetry API for native instrumentation of the client.
+    // Apache 2.0
+    // https://github.com/open-telemetry/opentelemetry-java
+    implementation("io.opentelemetry", "opentelemetry-api", openTelemetryVersion)
+    // Use it once it's stable (see Instrumentation.java). Limited to tests for now.
+    testImplementation("io.opentelemetry", "opentelemetry-semconv", "$openTelemetryVersion-alpha")
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/jsonb-api
@@ -236,6 +244,9 @@ dependencies {
     // https://www.testcontainers.org/
     testImplementation("org.testcontainers", "testcontainers", "1.17.3")
     testImplementation("org.testcontainers", "elasticsearch", "1.17.3")
+
+
+    testImplementation("io.opentelemetry", "opentelemetry-sdk", openTelemetryVersion)
 }
 
 
@@ -247,17 +258,18 @@ licenseReport {
 class SpdxReporter(val dest: File) : ReportRenderer {
     // License names to their SPDX identifier
     val spdxIds = mapOf(
-        "Apache License, Version 2.0" to "Apache-2.0",
-        "The Apache Software License, Version 2.0" to "Apache-2.0",
-        "BSD Zero Clause License" to "0BSD",
-        "Eclipse Public License 2.0" to "EPL-2.0",
-        "Eclipse Public License v. 2.0" to "EPL-2.0",
-        "Eclipse Public License - v 2.0" to "EPL-2.0",
-        "GNU General Public License, version 2 with the GNU Classpath Exception" to "GPL-2.0 WITH Classpath-exception-2.0",
-        "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0" to "CDDL-1.0"
+            "The Apache License, Version 2.0" to "Apache-2.0",
+            "Apache License, Version 2.0" to "Apache-2.0",
+            "The Apache Software License, Version 2.0" to "Apache-2.0",
+            "BSD Zero Clause License" to "0BSD",
+            "Eclipse Public License 2.0" to "EPL-2.0",
+            "Eclipse Public License v. 2.0" to "EPL-2.0",
+            "Eclipse Public License - v 2.0" to "EPL-2.0",
+            "GNU General Public License, version 2 with the GNU Classpath Exception" to "GPL-2.0 WITH Classpath-exception-2.0",
+            "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0" to "CDDL-1.0"
     )
 
-    private fun quote(str: String) : String {
+    private fun quote(str: String): String {
         return if (str.contains(',') || str.contains("\"")) {
             "\"" + str.replace("\"", "\"\"") + "\""
         } else {

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/AsyncSearchStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/AsyncSearchStatusRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -147,6 +149,21 @@ public class AsyncSearchStatusRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/DeleteAsyncSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/DeleteAsyncSearchRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -148,6 +150,21 @@ public class DeleteAsyncSearchRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/GetAsyncSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/GetAsyncSearchRequest.java
@@ -248,6 +248,21 @@ public class GetAsyncSearchRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/SubmitRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/async_search/SubmitRequest.java
@@ -2436,6 +2436,24 @@ public class SubmitRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/DeleteAutoscalingPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/DeleteAutoscalingPolicyRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -147,6 +149,21 @@ public class DeleteAutoscalingPolicyRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/GetAutoscalingCapacityRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/GetAutoscalingCapacityRequest.java
@@ -77,6 +77,11 @@ public class GetAutoscalingCapacityRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/GetAutoscalingPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/GetAutoscalingPolicyRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class GetAutoscalingPolicyRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/PutAutoscalingPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/autoscaling/PutAutoscalingPolicyRequest.java
@@ -39,6 +39,8 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -201,6 +203,21 @@ public class PutAutoscalingPolicyRequest extends RequestBase implements JsonpSer
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AliasesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AliasesRequest.java
@@ -223,6 +223,24 @@ public class AliasesRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AllocationRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/AllocationRequest.java
@@ -205,6 +205,24 @@ public class AllocationRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ComponentTemplatesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ComponentTemplatesRequest.java
@@ -162,6 +162,24 @@ public class ComponentTemplatesRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/CountRequest.java
@@ -179,6 +179,24 @@ public class CountRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/FielddataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/FielddataRequest.java
@@ -206,6 +206,24 @@ public class FielddataRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _fields = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.fields()))
+					propsSet |= _fields;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_fields)) {
+					params.put("fields", request.fields.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HealthRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HealthRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -171,6 +172,11 @@ public class HealthRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/health";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HelpRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/HelpRequest.java
@@ -32,6 +32,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +73,11 @@ public class HelpRequest extends CatRequestBase {
 			request -> {
 				return "/_cat";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/IndicesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/IndicesRequest.java
@@ -369,6 +369,24 @@ public class IndicesRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MasterRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MasterRequest.java
@@ -32,6 +32,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +76,11 @@ public class MasterRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/master";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDataFrameAnalyticsRequest.java
@@ -344,6 +344,24 @@ public class MlDataFrameAnalyticsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDatafeedsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlDatafeedsRequest.java
@@ -327,6 +327,24 @@ public class MlDatafeedsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.datafeedId() != null)
+					propsSet |= _datafeedId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlJobsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlJobsRequest.java
@@ -355,6 +355,24 @@ public class MlJobsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.jobId() != null)
+					propsSet |= _jobId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlTrainedModelsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/MlTrainedModelsRequest.java
@@ -365,6 +365,24 @@ public class MlTrainedModelsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.modelId() != null)
+					propsSet |= _modelId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodeattrsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodeattrsRequest.java
@@ -32,6 +32,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +76,11 @@ public class NodeattrsRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/nodeattrs";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/NodesRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -192,6 +193,11 @@ public class NodesRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/nodes";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PendingTasksRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PendingTasksRequest.java
@@ -32,6 +32,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +76,11 @@ public class PendingTasksRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/pending_tasks";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PluginsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/PluginsRequest.java
@@ -32,6 +32,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +76,11 @@ public class PluginsRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/plugins";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RecoveryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RecoveryRequest.java
@@ -269,6 +269,24 @@ public class RecoveryRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RepositoriesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/RepositoriesRequest.java
@@ -32,6 +32,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +76,11 @@ public class RepositoriesRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/repositories";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SegmentsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SegmentsRequest.java
@@ -208,6 +208,24 @@ public class SegmentsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ShardsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ShardsRequest.java
@@ -207,6 +207,24 @@ public class ShardsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SnapshotsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/SnapshotsRequest.java
@@ -211,6 +211,24 @@ public class SnapshotsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _repository = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.repository()))
+					propsSet |= _repository;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_repository)) {
+					params.put("repository", request.repository.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TasksRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TasksRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -244,6 +245,11 @@ public class TasksRequest extends CatRequestBase {
 			request -> {
 				return "/_cat/tasks";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TemplatesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TemplatesRequest.java
@@ -161,6 +161,24 @@ public class TemplatesRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ThreadPoolRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/ThreadPoolRequest.java
@@ -206,6 +206,25 @@ public class ThreadPoolRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _threadPoolPatterns = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.threadPoolPatterns()))
+					propsSet |= _threadPoolPatterns;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_threadPoolPatterns)) {
+					params.put("threadPoolPatterns",
+							request.threadPoolPatterns.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TransformsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cat/TransformsRequest.java
@@ -368,6 +368,24 @@ public class TransformsRequest extends CatRequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.transformId() != null)
+					propsSet |= _transformId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/CcrStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/CcrStatsRequest.java
@@ -74,6 +74,11 @@ public class CcrStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/DeleteAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/DeleteAutoFollowPatternRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class DeleteAutoFollowPatternRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowInfoRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -164,6 +166,21 @@ public class FollowInfoRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowRequest.java
@@ -590,6 +590,21 @@ public class FollowRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/FollowStatsRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -164,6 +166,21 @@ public class FollowStatsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ForgetFollowerRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ForgetFollowerRequest.java
@@ -38,6 +38,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -291,6 +293,21 @@ public class ForgetFollowerRequest extends RequestBase implements JsonpSerializa
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/GetAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/GetAutoFollowPatternRequest.java
@@ -35,6 +35,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -157,6 +159,24 @@ public class GetAutoFollowPatternRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseAutoFollowPatternRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -148,6 +150,21 @@ public class PauseAutoFollowPatternRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseFollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PauseFollowRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -147,6 +149,21 @@ public class PauseFollowRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PutAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/PutAutoFollowPatternRequest.java
@@ -41,6 +41,7 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -800,6 +801,21 @@ public class PutAutoFollowPatternRequest extends RequestBase implements JsonpSer
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeAutoFollowPatternRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeAutoFollowPatternRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -149,6 +151,21 @@ public class ResumeAutoFollowPatternRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeFollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/ResumeFollowRequest.java
@@ -40,6 +40,8 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -483,6 +485,21 @@ public class ResumeFollowRequest extends RequestBase implements JsonpSerializabl
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/UnfollowRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ccr/UnfollowRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -145,6 +147,21 @@ public class UnfollowRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/AllocationExplainRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/AllocationExplainRequest.java
@@ -38,6 +38,7 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -327,6 +328,11 @@ public class AllocationExplainRequest extends RequestBase implements JsonpSerial
 			request -> {
 				return "/_cluster/allocation/explain";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ClusterInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ClusterInfoRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -163,6 +165,22 @@ public class ClusterInfoRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _target = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _target;
+
+				if (propsSet == (_target)) {
+					params.put("target",
+							request.target.stream().map(v -> v.jsonValue()).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ClusterStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ClusterStatsRequest.java
@@ -253,6 +253,24 @@ public class ClusterStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteComponentTemplateRequest.java
@@ -248,6 +248,21 @@ public class DeleteComponentTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteVotingConfigExclusionsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/DeleteVotingConfigExclusionsRequest.java
@@ -36,6 +36,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -147,6 +148,11 @@ public class DeleteVotingConfigExclusionsRequest extends RequestBase {
 			request -> {
 				return "/_cluster/voting_config_exclusions";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ExistsComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/ExistsComponentTemplateRequest.java
@@ -239,6 +239,21 @@ public class ExistsComponentTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetClusterSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetClusterSettingsRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -240,6 +241,11 @@ public class GetClusterSettingsRequest extends RequestBase {
 			request -> {
 				return "/_cluster/settings";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/GetComponentTemplateRequest.java
@@ -281,6 +281,24 @@ public class GetComponentTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/HealthRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/HealthRequest.java
@@ -561,6 +561,24 @@ public class HealthRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PendingTasksRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PendingTasksRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -182,6 +183,11 @@ public class PendingTasksRequest extends RequestBase {
 			request -> {
 				return "/_cluster/pending_tasks";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PostVotingConfigExclusionsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PostVotingConfigExclusionsRequest.java
@@ -38,6 +38,7 @@ import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -243,6 +244,11 @@ public class PostVotingConfigExclusionsRequest extends RequestBase {
 			request -> {
 				return "/_cluster/voting_config_exclusions";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutClusterSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutClusterSettingsRequest.java
@@ -40,6 +40,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -329,6 +330,11 @@ public class PutClusterSettingsRequest extends RequestBase implements JsonpSeria
 			request -> {
 				return "/_cluster/settings";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutComponentTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/PutComponentTemplateRequest.java
@@ -456,6 +456,21 @@ public class PutComponentTemplateRequest extends RequestBase implements JsonpSer
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RemoteInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RemoteInfoRequest.java
@@ -76,6 +76,11 @@ public class RemoteInfoRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RerouteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/RerouteRequest.java
@@ -40,6 +40,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -404,6 +405,11 @@ public class RerouteRequest extends RequestBase implements JsonpSerializable {
 			request -> {
 				return "/_cluster/reroute";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/StateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/cluster/StateRequest.java
@@ -489,6 +489,31 @@ public class StateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _metric = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.metric()))
+					propsSet |= _metric;
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_metric)) {
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_metric | _index)) {
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/BulkRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/BulkRequest.java
@@ -545,6 +545,24 @@ public class BulkRequest extends RequestBase implements NdJsonpSerializable, Jso
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.index() != null)
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClearScrollRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClearScrollRequest.java
@@ -183,6 +183,11 @@ public class ClearScrollRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClosePointInTimeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ClosePointInTimeRequest.java
@@ -162,6 +162,11 @@ public class ClosePointInTimeRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
@@ -651,6 +651,24 @@ public class CountRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CreateRequest.java
@@ -486,6 +486,24 @@ public class CreateRequest<TDocument> extends RequestBase implements JsonpSerial
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRequest.java
@@ -1189,6 +1189,21 @@ public class DeleteByQueryRequest extends RequestBase implements JsonpSerializab
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRethrottleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteByQueryRethrottleRequest.java
@@ -180,6 +180,21 @@ public class DeleteByQueryRethrottleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _taskId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _taskId;
+
+				if (propsSet == (_taskId)) {
+					params.put("taskId", request.taskId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteRequest.java
@@ -434,6 +434,24 @@ public class DeleteRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteScriptRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/DeleteScriptRequest.java
@@ -219,6 +219,21 @@ public class DeleteScriptRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsRequest.java
@@ -500,6 +500,24 @@ public class ExistsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsSourceRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExistsSourceRequest.java
@@ -463,6 +463,24 @@ public class ExistsSourceRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExplainRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExplainRequest.java
@@ -620,6 +620,24 @@ public class ExplainRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/FieldCapsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/FieldCapsRequest.java
@@ -589,6 +589,24 @@ public class FieldCapsRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetRequest.java
@@ -501,6 +501,24 @@ public class GetRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptContextRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptContextRequest.java
@@ -75,6 +75,11 @@ public class GetScriptContextRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptLanguagesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptLanguagesRequest.java
@@ -75,6 +75,11 @@ public class GetScriptLanguagesRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetScriptRequest.java
@@ -183,6 +183,21 @@ public class GetScriptRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetSourceRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/GetSourceRequest.java
@@ -497,6 +497,24 @@ public class GetSourceRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/HealthReportRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/HealthReportRequest.java
@@ -263,6 +263,24 @@ public class HealthReportRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _feature = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.feature()))
+					propsSet |= _feature;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_feature)) {
+					params.put("feature", request.feature.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/IndexRequest.java
@@ -625,6 +625,28 @@ public class IndexRequest<TDocument> extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/InfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/InfoRequest.java
@@ -73,6 +73,11 @@ public class InfoRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/KnnSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/KnnSearchRequest.java
@@ -560,6 +560,21 @@ public class KnnSearchRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MgetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MgetRequest.java
@@ -597,6 +597,24 @@ public class MgetRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.index() != null)
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchRequest.java
@@ -545,6 +545,24 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchTemplateRequest.java
@@ -323,6 +323,24 @@ public class MsearchTemplateRequest extends RequestBase implements NdJsonpSerial
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MtermvectorsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MtermvectorsRequest.java
@@ -628,6 +628,24 @@ public class MtermvectorsRequest extends RequestBase implements JsonpSerializabl
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.index() != null)
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/OpenPointInTimeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/OpenPointInTimeRequest.java
@@ -336,6 +336,21 @@ public class OpenPointInTimeRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/PingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/PingRequest.java
@@ -76,6 +76,11 @@ public class PingRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/PutScriptRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/PutScriptRequest.java
@@ -318,6 +318,28 @@ public class PutScriptRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _context = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				if (request.context() != null)
+					propsSet |= _context;
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				if (propsSet == (_id | _context)) {
+					params.put("id", request.id);
+					params.put("context", request.context);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RankEvalRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RankEvalRequest.java
@@ -451,6 +451,24 @@ public class RankEvalRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRequest.java
@@ -46,6 +46,7 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Float;
 import java.lang.Long;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -597,6 +598,11 @@ public class ReindexRequest extends RequestBase implements JsonpSerializable {
 			request -> {
 				return "/_reindex";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRethrottleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ReindexRethrottleRequest.java
@@ -178,6 +178,21 @@ public class ReindexRethrottleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _taskId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _taskId;
+
+				if (propsSet == (_taskId)) {
+					params.put("taskId", request.taskId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RenderSearchTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/RenderSearchTemplateRequest.java
@@ -39,6 +39,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -290,6 +291,24 @@ public class RenderSearchTemplateRequest extends RequestBase implements JsonpSer
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScriptsPainlessExecuteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScriptsPainlessExecuteRequest.java
@@ -242,6 +242,11 @@ public class ScriptsPainlessExecuteRequest extends RequestBase implements JsonpS
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScrollRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ScrollRequest.java
@@ -204,6 +204,11 @@ public class ScrollRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchMvtRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchMvtRequest.java
@@ -49,6 +49,7 @@ import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -990,6 +991,33 @@ public class SearchMvtRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _field = 1 << 0;
+				final int _x = 1 << 1;
+				final int _index = 1 << 2;
+				final int _y = 1 << 3;
+				final int _zoom = 1 << 4;
+
+				int propsSet = 0;
+
+				propsSet |= _field;
+				propsSet |= _x;
+				propsSet |= _index;
+				propsSet |= _y;
+				propsSet |= _zoom;
+
+				if (propsSet == (_index | _field | _zoom | _x | _y)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("field", request.field);
+					params.put("zoom", String.valueOf(request.zoom));
+					params.put("x", String.valueOf(request.x));
+					params.put("y", String.valueOf(request.y));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchRequest.java
@@ -2571,6 +2571,24 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchShardsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchShardsRequest.java
@@ -362,6 +362,24 @@ public class SearchShardsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchTemplateRequest.java
@@ -664,6 +664,24 @@ public class SearchTemplateRequest extends RequestBase implements JsonpSerializa
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermsEnumRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermsEnumRequest.java
@@ -42,6 +42,8 @@ import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -434,6 +436,21 @@ public class TermsEnumRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermvectorsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/TermvectorsRequest.java
@@ -681,6 +681,28 @@ public class TermvectorsRequest<TDocument> extends RequestBase implements JsonpS
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRequest.java
@@ -1259,6 +1259,21 @@ public class UpdateByQueryRequest extends RequestBase implements JsonpSerializab
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRethrottleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateByQueryRethrottleRequest.java
@@ -180,6 +180,21 @@ public class UpdateByQueryRethrottleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _taskId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _taskId;
+
+				if (propsSet == (_taskId)) {
+					params.put("taskId", request.taskId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/UpdateRequest.java
@@ -808,6 +808,24 @@ public class UpdateRequest<TDocument, TPartialDocument> extends RequestBase impl
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _id = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _id;
+
+				if (propsSet == (_index | _id)) {
+					params.put("index", request.index);
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/DeleteDanglingIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/DeleteDanglingIndexRequest.java
@@ -245,6 +245,21 @@ public class DeleteDanglingIndexRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _indexUuid = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _indexUuid;
+
+				if (propsSet == (_indexUuid)) {
+					params.put("indexUuid", request.indexUuid);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/ImportDanglingIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/ImportDanglingIndexRequest.java
@@ -245,6 +245,21 @@ public class ImportDanglingIndexRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _indexUuid = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _indexUuid;
+
+				if (propsSet == (_indexUuid)) {
+					params.put("indexUuid", request.indexUuid);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/ListDanglingIndicesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/dangling_indices/ListDanglingIndicesRequest.java
@@ -75,6 +75,11 @@ public class ListDanglingIndicesRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/DeletePolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/DeletePolicyRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class DeletePolicyRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/EnrichStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/EnrichStatsRequest.java
@@ -75,6 +75,11 @@ public class EnrichStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/ExecutePolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/ExecutePolicyRequest.java
@@ -178,6 +178,21 @@ public class ExecutePolicyRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/GetPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/GetPolicyRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -171,6 +173,24 @@ public class GetPolicyRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/PutPolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/enrich/PutPolicyRequest.java
@@ -38,6 +38,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -305,6 +307,21 @@ public class PutPolicyRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlDeleteRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlDeleteRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -151,6 +153,21 @@ public class EqlDeleteRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlGetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlGetRequest.java
@@ -224,6 +224,21 @@ public class EqlGetRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/EqlSearchRequest.java
@@ -821,6 +821,21 @@ public class EqlSearchRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/GetEqlStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/eql/GetEqlStatusRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class GetEqlStatusRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/features/GetFeaturesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/features/GetFeaturesRequest.java
@@ -75,6 +75,11 @@ public class GetFeaturesRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/features/ResetFeaturesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/features/ResetFeaturesRequest.java
@@ -74,6 +74,11 @@ public class ResetFeaturesRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/fleet/FleetSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/fleet/FleetSearchRequest.java
@@ -2186,6 +2186,21 @@ public class FleetSearchRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/graph/ExploreRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/graph/ExploreRequest.java
@@ -459,6 +459,21 @@ public class ExploreRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/DeleteLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/DeleteLifecycleRequest.java
@@ -228,6 +228,21 @@ public class DeleteLifecycleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/ExplainLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/ExplainLifecycleRequest.java
@@ -292,6 +292,21 @@ public class ExplainLifecycleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetIlmStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetIlmStatusRequest.java
@@ -74,6 +74,11 @@ public class GetIlmStatusRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/GetLifecycleRequest.java
@@ -235,6 +235,24 @@ public class GetLifecycleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MigrateToDataTiersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MigrateToDataTiersRequest.java
@@ -37,6 +37,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -231,6 +232,11 @@ public class MigrateToDataTiersRequest extends RequestBase implements JsonpSeria
 			request -> {
 				return "/_ilm/migrate_to_data_tiers";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MoveToStepRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/MoveToStepRequest.java
@@ -39,6 +39,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -246,6 +248,21 @@ public class MoveToStepRequest extends RequestBase implements JsonpSerializable 
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/PutLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/PutLifecycleRequest.java
@@ -292,6 +292,21 @@ public class PutLifecycleRequest extends RequestBase implements JsonpSerializabl
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RemovePolicyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RemovePolicyRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class RemovePolicyRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RetryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/RetryRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class RetryRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StartIlmRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StartIlmRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -164,6 +165,11 @@ public class StartIlmRequest extends RequestBase {
 			request -> {
 				return "/_ilm/start";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StopIlmRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ilm/StopIlmRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -165,6 +166,11 @@ public class StopIlmRequest extends RequestBase {
 			request -> {
 				return "/_ilm/stop";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AddBlockRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AddBlockRequest.java
@@ -352,6 +352,24 @@ public class AddBlockRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _block = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _block;
+
+				if (propsSet == (_index | _block)) {
+					params.put("index", request.index);
+					params.put("block", request.block.jsonValue());
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AnalyzeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/AnalyzeRequest.java
@@ -42,7 +42,9 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -605,6 +607,24 @@ public class AnalyzeRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.index() != null)
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ClearCacheRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ClearCacheRequest.java
@@ -421,6 +421,24 @@ public class ClearCacheRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloneIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloneIndexRequest.java
@@ -440,6 +440,24 @@ public class CloneIndexRequest extends RequestBase implements JsonpSerializable 
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _target = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _target;
+
+				if (propsSet == (_index | _target)) {
+					params.put("index", request.index);
+					params.put("target", request.target);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloseIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CloseIndexRequest.java
@@ -406,6 +406,21 @@ public class CloseIndexRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateDataStreamRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -159,6 +161,21 @@ public class CreateDataStreamRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/CreateIndexRequest.java
@@ -459,6 +459,21 @@ public class CreateIndexRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DataStreamsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DataStreamsStatsRequest.java
@@ -207,6 +207,24 @@ public class DataStreamsStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteAliasRequest.java
@@ -301,6 +301,28 @@ public class DeleteAliasRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+				propsSet |= _index;
+
+				if (propsSet == (_index | _name)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index | _name)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteDataLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteDataLifecycleRequest.java
@@ -283,6 +283,21 @@ public class DeleteDataLifecycleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteDataStreamRequest.java
@@ -209,6 +209,21 @@ public class DeleteDataStreamRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexRequest.java
@@ -370,6 +370,21 @@ public class DeleteIndexRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteIndexTemplateRequest.java
@@ -248,6 +248,21 @@ public class DeleteIndexTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DeleteTemplateRequest.java
@@ -227,6 +227,21 @@ public class DeleteTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DiskUsageRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DiskUsageRequest.java
@@ -343,6 +343,21 @@ public class DiskUsageRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DownsampleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/DownsampleRequest.java
@@ -39,6 +39,8 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -229,6 +231,24 @@ public class DownsampleRequest extends RequestBase implements JsonpSerializable 
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _targetIndex = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _targetIndex;
+				propsSet |= _index;
+
+				if (propsSet == (_index | _targetIndex)) {
+					params.put("index", request.index);
+					params.put("targetIndex", request.targetIndex);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsAliasRequest.java
@@ -371,6 +371,28 @@ public class ExistsAliasRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index | _name)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsIndexTemplateRequest.java
@@ -191,6 +191,21 @@ public class ExistsIndexTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsRequest.java
@@ -365,6 +365,21 @@ public class ExistsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExistsTemplateRequest.java
@@ -258,6 +258,21 @@ public class ExistsTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExplainDataLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ExplainDataLifecycleRequest.java
@@ -232,6 +232,21 @@ public class ExplainDataLifecycleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FieldUsageStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FieldUsageStatsRequest.java
@@ -447,6 +447,21 @@ public class FieldUsageStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FlushRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/FlushRequest.java
@@ -351,6 +351,24 @@ public class FlushRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ForcemergeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ForcemergeRequest.java
@@ -387,6 +387,24 @@ public class ForcemergeRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetAliasRequest.java
@@ -384,6 +384,34 @@ public class GetAliasRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index | _name)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetDataLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetDataLifecycleRequest.java
@@ -247,6 +247,21 @@ public class GetDataLifecycleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetDataStreamRequest.java
@@ -246,6 +246,24 @@ public class GetDataStreamRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetFieldMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetFieldMappingRequest.java
@@ -402,6 +402,28 @@ public class GetFieldMappingRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _fields = 1 << 1;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+				propsSet |= _fields;
+
+				if (propsSet == (_fields)) {
+					params.put("fields", request.fields.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index | _fields)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("fields", request.fields.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexRequest.java
@@ -435,6 +435,21 @@ public class GetIndexRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndexTemplateRequest.java
@@ -281,6 +281,24 @@ public class GetIndexTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndicesSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetIndicesSettingsRequest.java
@@ -471,6 +471,34 @@ public class GetIndicesSettingsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index | _name)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetMappingRequest.java
@@ -363,6 +363,24 @@ public class GetMappingRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/GetTemplateRequest.java
@@ -275,6 +275,24 @@ public class GetTemplateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/IndicesStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/IndicesStatsRequest.java
@@ -563,6 +563,34 @@ public class IndicesStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _metric = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.metric()))
+					propsSet |= _metric;
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_metric)) {
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_index | _metric)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/MigrateToDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/MigrateToDataStreamRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -153,6 +155,21 @@ public class MigrateToDataStreamRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ModifyDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ModifyDataStreamRequest.java
@@ -201,6 +201,11 @@ public class ModifyDataStreamRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/OpenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/OpenRequest.java
@@ -420,6 +420,21 @@ public class OpenRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PromoteDataStreamRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PromoteDataStreamRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class PromoteDataStreamRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutAliasRequest.java
@@ -511,6 +511,28 @@ public class PutAliasRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+				final int _index = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+				propsSet |= _index;
+
+				if (propsSet == (_index | _name)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("name", request.name);
+				}
+				if (propsSet == (_index | _name)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutDataLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutDataLifecycleRequest.java
@@ -379,6 +379,21 @@ public class PutDataLifecycleRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndexTemplateRequest.java
@@ -545,6 +545,21 @@ public class PutIndexTemplateRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndicesSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutIndicesSettingsRequest.java
@@ -478,6 +478,24 @@ public class PutIndicesSettingsRequest extends RequestBase implements JsonpSeria
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutMappingRequest.java
@@ -975,6 +975,21 @@ public class PutMappingRequest extends RequestBase implements JsonpSerializable 
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/PutTemplateRequest.java
@@ -600,6 +600,21 @@ public class PutTemplateRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RecoveryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RecoveryRequest.java
@@ -232,6 +232,24 @@ public class RecoveryRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RefreshRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RefreshRequest.java
@@ -293,6 +293,24 @@ public class RefreshRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ReloadSearchAnalyzersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ReloadSearchAnalyzersRequest.java
@@ -267,6 +267,21 @@ public class ReloadSearchAnalyzersRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ResolveIndexRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ResolveIndexRequest.java
@@ -228,6 +228,21 @@ public class ResolveIndexRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RolloverRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/RolloverRequest.java
@@ -588,6 +588,28 @@ public class RolloverRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _newIndex = 1 << 0;
+				final int _alias = 1 << 1;
+
+				int propsSet = 0;
+
+				if (request.newIndex() != null)
+					propsSet |= _newIndex;
+				propsSet |= _alias;
+
+				if (propsSet == (_alias)) {
+					params.put("alias", request.alias);
+				}
+				if (propsSet == (_alias | _newIndex)) {
+					params.put("alias", request.alias);
+					params.put("newIndex", request.newIndex);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SegmentsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SegmentsRequest.java
@@ -319,6 +319,24 @@ public class SegmentsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShardStoresRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShardStoresRequest.java
@@ -316,6 +316,24 @@ public class ShardStoresRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShrinkRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ShrinkRequest.java
@@ -438,6 +438,24 @@ public class ShrinkRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _target = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _target;
+
+				if (propsSet == (_index | _target)) {
+					params.put("index", request.index);
+					params.put("target", request.target);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateIndexTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateIndexTemplateRequest.java
@@ -663,6 +663,21 @@ public class SimulateIndexTemplateRequest extends RequestBase implements JsonpSe
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateTemplateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateTemplateRequest.java
@@ -319,6 +319,24 @@ public class SimulateTemplateRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SplitRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SplitRequest.java
@@ -438,6 +438,24 @@ public class SplitRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+				final int _target = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+				propsSet |= _target;
+
+				if (propsSet == (_index | _target)) {
+					params.put("index", request.index);
+					params.put("target", request.target);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UnfreezeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UnfreezeRequest.java
@@ -374,6 +374,21 @@ public class UnfreezeRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UpdateAliasesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/UpdateAliasesRequest.java
@@ -38,6 +38,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -277,6 +278,11 @@ public class UpdateAliasesRequest extends RequestBase implements JsonpSerializab
 			request -> {
 				return "/_aliases";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ValidateQueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ValidateQueryRequest.java
@@ -627,6 +627,24 @@ public class ValidateQueryRequest extends RequestBase implements JsonpSerializab
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/DeletePipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/DeletePipelineRequest.java
@@ -220,6 +220,21 @@ public class DeletePipelineRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GeoIpStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GeoIpStatsRequest.java
@@ -74,6 +74,11 @@ public class GeoIpStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GetPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/GetPipelineRequest.java
@@ -221,6 +221,24 @@ public class GetPipelineRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/ProcessorGrokRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/ProcessorGrokRequest.java
@@ -74,6 +74,11 @@ public class ProcessorGrokRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/PutPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/PutPipelineRequest.java
@@ -555,6 +555,21 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/SimulateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ingest/SimulateRequest.java
@@ -305,6 +305,24 @@ public class SimulateRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/DeleteLicenseRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/DeleteLicenseRequest.java
@@ -74,6 +74,11 @@ public class DeleteLicenseRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetBasicStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetBasicStatusRequest.java
@@ -75,6 +75,11 @@ public class GetBasicStatusRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetLicenseRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetLicenseRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -181,6 +182,11 @@ public class GetLicenseRequest extends RequestBase {
 			request -> {
 				return "/_license";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetTrialStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/GetTrialStatusRequest.java
@@ -75,6 +75,11 @@ public class GetTrialStatusRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostRequest.java
@@ -37,6 +37,7 @@ import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -259,6 +260,11 @@ public class PostRequest extends RequestBase implements JsonpSerializable {
 			request -> {
 				return "/_license";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartBasicRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartBasicRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -141,6 +142,11 @@ public class PostStartBasicRequest extends RequestBase {
 			request -> {
 				return "/_license/start_basic";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartTrialRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/license/PostStartTrialRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -159,6 +160,11 @@ public class PostStartTrialRequest extends RequestBase {
 			request -> {
 				return "/_license/start_trial";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/DeletePipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/DeletePipelineRequest.java
@@ -38,6 +38,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -147,6 +149,21 @@ public class DeletePipelineRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/GetPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/GetPipelineRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -166,6 +168,23 @@ public class GetPipelineRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/PutPipelineRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/logstash/PutPipelineRequest.java
@@ -41,6 +41,8 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -201,6 +203,21 @@ public class PutPipelineRequest extends RequestBase implements JsonpSerializable
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/DeprecationsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/DeprecationsRequest.java
@@ -35,6 +35,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -157,6 +159,24 @@ public class DeprecationsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.index() != null)
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/GetFeatureUpgradeStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/GetFeatureUpgradeStatusRequest.java
@@ -75,6 +75,11 @@ public class GetFeatureUpgradeStatusRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/PostFeatureUpgradeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/migration/PostFeatureUpgradeRequest.java
@@ -75,6 +75,11 @@ public class PostFeatureUpgradeRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ClearTrainedModelDeploymentCacheRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ClearTrainedModelDeploymentCacheRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -153,6 +155,21 @@ public class ClearTrainedModelDeploymentCacheRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/CloseJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/CloseJobRequest.java
@@ -40,6 +40,8 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -305,6 +307,21 @@ public class CloseJobRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarEventRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarEventRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -174,6 +176,24 @@ public class DeleteCalendarEventRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _eventId = 1 << 0;
+				final int _calendarId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _eventId;
+				propsSet |= _calendarId;
+
+				if (propsSet == (_calendarId | _eventId)) {
+					params.put("calendarId", request.calendarId);
+					params.put("eventId", request.eventId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarJobRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -192,6 +194,24 @@ public class DeleteCalendarJobRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _calendarId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _calendarId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_calendarId | _jobId)) {
+					params.put("calendarId", request.calendarId);
+					params.put("jobId", request.jobId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteCalendarRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class DeleteCalendarRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _calendarId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _calendarId;
+
+				if (propsSet == (_calendarId)) {
+					params.put("calendarId", request.calendarId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDataFrameAnalyticsRequest.java
@@ -217,6 +217,21 @@ public class DeleteDataFrameAnalyticsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteDatafeedRequest.java
@@ -183,6 +183,21 @@ public class DeleteDatafeedRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteExpiredDataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteExpiredDataRequest.java
@@ -39,6 +39,8 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Float;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -271,6 +273,24 @@ public class DeleteExpiredDataRequest extends RequestBase implements JsonpSerial
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.jobId() != null)
+					propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteFilterRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteFilterRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class DeleteFilterRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _filterId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _filterId;
+
+				if (propsSet == (_filterId)) {
+					params.put("filterId", request.filterId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteForecastRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteForecastRequest.java
@@ -271,6 +271,28 @@ public class DeleteForecastRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+				final int _forecastId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+				if (request.forecastId() != null)
+					propsSet |= _forecastId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				if (propsSet == (_jobId | _forecastId)) {
+					params.put("jobId", request.jobId);
+					params.put("forecastId", request.forecastId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteJobRequest.java
@@ -242,6 +242,21 @@ public class DeleteJobRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteModelSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteModelSnapshotRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -177,6 +179,24 @@ public class DeleteModelSnapshotRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _snapshotId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _snapshotId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId | _snapshotId)) {
+					params.put("jobId", request.jobId);
+					params.put("snapshotId", request.snapshotId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelAliasRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -178,6 +180,24 @@ public class DeleteTrainedModelAliasRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelAlias = 1 << 0;
+				final int _modelId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _modelAlias;
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId | _modelAlias)) {
+					params.put("modelId", request.modelId);
+					params.put("modelAlias", request.modelAlias);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/DeleteTrainedModelRequest.java
@@ -178,6 +178,21 @@ public class DeleteTrainedModelRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EstimateModelMemoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EstimateModelMemoryRequest.java
@@ -326,6 +326,11 @@ public class EstimateModelMemoryRequest extends RequestBase implements JsonpSeri
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EvaluateDataFrameRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/EvaluateDataFrameRequest.java
@@ -252,6 +252,11 @@ public class EvaluateDataFrameRequest extends RequestBase implements JsonpSerial
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ExplainDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ExplainDataFrameAnalyticsRequest.java
@@ -39,6 +39,8 @@ import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -547,6 +549,24 @@ public class ExplainDataFrameAnalyticsRequest extends RequestBase implements Jso
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/FlushJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/FlushJobRequest.java
@@ -40,6 +40,8 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -342,6 +344,21 @@ public class FlushJobRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ForecastRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ForecastRequest.java
@@ -39,6 +39,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -299,6 +301,21 @@ public class ForecastRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetBucketsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetBucketsRequest.java
@@ -548,6 +548,28 @@ public class GetBucketsRequest extends RequestBase implements JsonpSerializable 
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+				final int _timestamp = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+				if (request.timestamp() != null)
+					propsSet |= _timestamp;
+
+				if (propsSet == (_jobId | _timestamp)) {
+					params.put("jobId", request.jobId);
+					params.put("timestamp", request.timestamp.toString());
+				}
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarEventsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarEventsRequest.java
@@ -295,6 +295,21 @@ public class GetCalendarEventsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _calendarId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _calendarId;
+
+				if (propsSet == (_calendarId)) {
+					params.put("calendarId", request.calendarId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCalendarsRequest.java
@@ -292,6 +292,24 @@ public class GetCalendarsRequest extends RequestBase implements JsonpSerializabl
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _calendarId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.calendarId() != null)
+					propsSet |= _calendarId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_calendarId)) {
+					params.put("calendarId", request.calendarId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCategoriesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetCategoriesRequest.java
@@ -346,6 +346,28 @@ public class GetCategoriesRequest extends RequestBase implements JsonpSerializab
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _categoryId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				if (request.categoryId() != null)
+					propsSet |= _categoryId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId | _categoryId)) {
+					params.put("jobId", request.jobId);
+					params.put("categoryId", request.categoryId);
+				}
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsRequest.java
@@ -304,6 +304,24 @@ public class GetDataFrameAnalyticsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDataFrameAnalyticsStatsRequest.java
@@ -300,6 +300,24 @@ public class GetDataFrameAnalyticsStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedStatsRequest.java
@@ -239,6 +239,24 @@ public class GetDatafeedStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.datafeedId()))
+					propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetDatafeedsRequest.java
@@ -266,6 +266,24 @@ public class GetDatafeedsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.datafeedId()))
+					propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetFiltersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetFiltersRequest.java
@@ -227,6 +227,24 @@ public class GetFiltersRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _filterId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.filterId()))
+					propsSet |= _filterId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_filterId)) {
+					params.put("filterId", request.filterId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetInfluencersRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetInfluencersRequest.java
@@ -445,6 +445,21 @@ public class GetInfluencersRequest extends RequestBase implements JsonpSerializa
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobStatsRequest.java
@@ -212,6 +212,24 @@ public class GetJobStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.jobId() != null)
+					propsSet |= _jobId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetJobsRequest.java
@@ -261,6 +261,24 @@ public class GetJobsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.jobId()))
+					propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetMemoryStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetMemoryStatsRequest.java
@@ -273,6 +273,24 @@ public class GetMemoryStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.nodeId() != null)
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotUpgradeStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotUpgradeStatsRequest.java
@@ -237,6 +237,24 @@ public class GetModelSnapshotUpgradeStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _snapshotId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _snapshotId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId | _snapshotId)) {
+					params.put("jobId", request.jobId);
+					params.put("snapshotId", request.snapshotId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetModelSnapshotsRequest.java
@@ -450,6 +450,28 @@ public class GetModelSnapshotsRequest extends RequestBase implements JsonpSerial
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _snapshotId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				if (request.snapshotId() != null)
+					propsSet |= _snapshotId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId | _snapshotId)) {
+					params.put("jobId", request.jobId);
+					params.put("snapshotId", request.snapshotId);
+				}
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetOverallBucketsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetOverallBucketsRequest.java
@@ -42,6 +42,8 @@ import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -448,6 +450,21 @@ public class GetOverallBucketsRequest extends RequestBase implements JsonpSerial
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetRecordsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetRecordsRequest.java
@@ -478,6 +478,21 @@ public class GetRecordsRequest extends RequestBase implements JsonpSerializable 
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsRequest.java
@@ -373,6 +373,24 @@ public class GetTrainedModelsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.modelId() != null)
+					propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/GetTrainedModelsStatsRequest.java
@@ -279,6 +279,24 @@ public class GetTrainedModelsStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.modelId()))
+					propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferTrainedModelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/InferTrainedModelRequest.java
@@ -338,6 +338,24 @@ public class InferTrainedModelRequest extends RequestBase implements JsonpSerial
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/MlInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/MlInfoRequest.java
@@ -79,6 +79,11 @@ public class MlInfoRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/OpenJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/OpenJobRequest.java
@@ -39,6 +39,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -220,6 +222,21 @@ public class OpenJobRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostCalendarEventsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostCalendarEventsRequest.java
@@ -38,7 +38,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -244,6 +246,21 @@ public class PostCalendarEventsRequest extends RequestBase implements JsonpSeria
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _calendarId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _calendarId;
+
+				if (propsSet == (_calendarId)) {
+					params.put("calendarId", request.calendarId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostDataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PostDataRequest.java
@@ -309,6 +309,21 @@ public class PostDataRequest<TData> extends RequestBase implements JsonpSerializ
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDataFrameAnalyticsRequest.java
@@ -38,6 +38,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -239,6 +241,24 @@ public class PreviewDataFrameAnalyticsRequest extends RequestBase implements Jso
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PreviewDatafeedRequest.java
@@ -362,6 +362,24 @@ public class PreviewDatafeedRequest extends RequestBase implements JsonpSerializ
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.datafeedId() != null)
+					propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarJobRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -175,6 +177,24 @@ public class PutCalendarJobRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _calendarId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _calendarId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_calendarId | _jobId)) {
+					params.put("calendarId", request.calendarId);
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutCalendarRequest.java
@@ -38,7 +38,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -257,6 +259,21 @@ public class PutCalendarRequest extends RequestBase implements JsonpSerializable
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _calendarId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _calendarId;
+
+				if (propsSet == (_calendarId)) {
+					params.put("calendarId", request.calendarId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDataFrameAnalyticsRequest.java
@@ -40,6 +40,7 @@ import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -677,6 +678,21 @@ public class PutDataFrameAnalyticsRequest extends RequestBase implements JsonpSe
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutDatafeedRequest.java
@@ -1087,6 +1087,21 @@ public class PutDatafeedRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutFilterRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutFilterRequest.java
@@ -38,7 +38,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -265,6 +267,21 @@ public class PutFilterRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _filterId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _filterId;
+
+				if (propsSet == (_filterId)) {
+					params.put("filterId", request.filterId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutJobRequest.java
@@ -42,7 +42,9 @@ import java.lang.Boolean;
 import java.lang.Long;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -870,6 +872,21 @@ public class PutJobRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelAliasRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelAliasRequest.java
@@ -221,6 +221,24 @@ public class PutTrainedModelAliasRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelAlias = 1 << 0;
+				final int _modelId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _modelAlias;
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId | _modelAlias)) {
+					params.put("modelId", request.modelId);
+					params.put("modelAlias", request.modelAlias);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelDefinitionPartRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelDefinitionPartRequest.java
@@ -40,6 +40,8 @@ import java.lang.Integer;
 import java.lang.Long;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -304,6 +306,24 @@ public class PutTrainedModelDefinitionPartRequest extends RequestBase implements
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _part = 1 << 0;
+				final int _modelId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _part;
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId | _part)) {
+					params.put("modelId", request.modelId);
+					params.put("part", String.valueOf(request.part));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelRequest.java
@@ -576,6 +576,21 @@ public class PutTrainedModelRequest extends RequestBase implements JsonpSerializ
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelVocabularyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/PutTrainedModelVocabularyRequest.java
@@ -38,7 +38,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -281,6 +283,21 @@ public class PutTrainedModelVocabularyRequest extends RequestBase implements Jso
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ResetJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ResetJobRequest.java
@@ -206,6 +206,21 @@ public class ResetJobRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/RevertModelSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/RevertModelSnapshotRequest.java
@@ -39,6 +39,8 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -253,6 +255,24 @@ public class RevertModelSnapshotRequest extends RequestBase implements JsonpSeri
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _snapshotId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _snapshotId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId | _snapshotId)) {
+					params.put("jobId", request.jobId);
+					params.put("snapshotId", request.snapshotId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/SetUpgradeModeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/SetUpgradeModeRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -184,6 +185,11 @@ public class SetUpgradeModeRequest extends RequestBase {
 			request -> {
 				return "/_ml/set_upgrade_mode";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDataFrameAnalyticsRequest.java
@@ -205,6 +205,21 @@ public class StartDataFrameAnalyticsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartDatafeedRequest.java
@@ -40,6 +40,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -304,6 +306,21 @@ public class StartDatafeedRequest extends RequestBase implements JsonpSerializab
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartTrainedModelDeploymentRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StartTrainedModelDeploymentRequest.java
@@ -384,6 +384,21 @@ public class StartTrainedModelDeploymentRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDataFrameAnalyticsRequest.java
@@ -272,6 +272,21 @@ public class StopDataFrameAnalyticsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopDatafeedRequest.java
@@ -40,6 +40,8 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -292,6 +294,21 @@ public class StopDatafeedRequest extends RequestBase implements JsonpSerializabl
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopTrainedModelDeploymentRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/StopTrainedModelDeploymentRequest.java
@@ -220,6 +220,21 @@ public class StopTrainedModelDeploymentRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _modelId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _modelId;
+
+				if (propsSet == (_modelId)) {
+					params.put("modelId", request.modelId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDataFrameAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDataFrameAnalyticsRequest.java
@@ -40,6 +40,8 @@ import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -332,6 +334,21 @@ public class UpdateDataFrameAnalyticsRequest extends RequestBase implements Json
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDatafeedRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateDatafeedRequest.java
@@ -1076,6 +1076,21 @@ public class UpdateDatafeedRequest extends RequestBase implements JsonpSerializa
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _datafeedId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _datafeedId;
+
+				if (propsSet == (_datafeedId)) {
+					params.put("datafeedId", request.datafeedId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateFilterRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateFilterRequest.java
@@ -38,7 +38,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -311,6 +313,21 @@ public class UpdateFilterRequest extends RequestBase implements JsonpSerializabl
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _filterId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _filterId;
+
+				if (propsSet == (_filterId)) {
+					params.put("filterId", request.filterId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateJobRequest.java
@@ -42,6 +42,7 @@ import java.lang.Boolean;
 import java.lang.Long;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -853,6 +854,21 @@ public class UpdateJobRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _jobId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId)) {
+					params.put("jobId", request.jobId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateModelSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpdateModelSnapshotRequest.java
@@ -39,6 +39,8 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -276,6 +278,24 @@ public class UpdateModelSnapshotRequest extends RequestBase implements JsonpSeri
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _snapshotId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _snapshotId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId | _snapshotId)) {
+					params.put("jobId", request.jobId);
+					params.put("snapshotId", request.snapshotId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpgradeJobSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/UpgradeJobSnapshotRequest.java
@@ -253,6 +253,24 @@ public class UpgradeJobSnapshotRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _snapshotId = 1 << 0;
+				final int _jobId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _snapshotId;
+				propsSet |= _jobId;
+
+				if (propsSet == (_jobId | _snapshotId)) {
+					params.put("jobId", request.jobId);
+					params.put("snapshotId", request.snapshotId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateDetectorRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateDetectorRequest.java
@@ -162,6 +162,11 @@ public class ValidateDetectorRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ml/ValidateRequest.java
@@ -425,6 +425,11 @@ public class ValidateRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/monitoring/BulkRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/monitoring/BulkRequest.java
@@ -307,6 +307,24 @@ public class BulkRequest extends RequestBase implements NdJsonpSerializable, Jso
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _type = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.type() != null)
+					propsSet |= _type;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_type)) {
+					params.put("type", request.type);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ClearRepositoriesMeteringArchiveRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ClearRepositoriesMeteringArchiveRequest.java
@@ -37,7 +37,9 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Long;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -203,6 +205,24 @@ public class ClearRepositoriesMeteringArchiveRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _maxArchiveVersion = 1 << 0;
+				final int _nodeId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _maxArchiveVersion;
+				propsSet |= _nodeId;
+
+				if (propsSet == (_nodeId | _maxArchiveVersion)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("maxArchiveVersion", String.valueOf(request.maxArchiveVersion));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/GetRepositoriesMeteringInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/GetRepositoriesMeteringInfoRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -174,6 +176,21 @@ public class GetRepositoriesMeteringInfoRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _nodeId;
+
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/HotThreadsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/HotThreadsRequest.java
@@ -429,6 +429,24 @@ public class HotThreadsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesInfoRequest.java
@@ -341,6 +341,34 @@ public class NodesInfoRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _metric = 1 << 0;
+				final int _nodeId = 1 << 1;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.metric()))
+					propsSet |= _metric;
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_metric)) {
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_nodeId | _metric)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesStatsRequest.java
@@ -667,6 +667,48 @@ public class NodesStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _metric = 1 << 0;
+				final int _indexMetric = 1 << 1;
+				final int _nodeId = 1 << 2;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.metric()))
+					propsSet |= _metric;
+				if (ApiTypeHelper.isDefined(request.indexMetric()))
+					propsSet |= _indexMetric;
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_metric)) {
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_nodeId | _metric)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_metric | _indexMetric)) {
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("indexMetric",
+							request.indexMetric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_nodeId | _metric | _indexMetric)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("indexMetric",
+							request.indexMetric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesUsageRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/NodesUsageRequest.java
@@ -278,6 +278,34 @@ public class NodesUsageRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _metric = 1 << 0;
+				final int _nodeId = 1 << 1;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.metric()))
+					propsSet |= _metric;
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_metric)) {
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == (_nodeId | _metric)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+					params.put("metric", request.metric.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ReloadSecureSettingsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/ReloadSecureSettingsRequest.java
@@ -272,6 +272,24 @@ public class ReloadSecureSettingsRequest extends RequestBase implements JsonpSer
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/DeleteQueryRulesetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/DeleteQueryRulesetRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -143,6 +145,21 @@ public class DeleteQueryRulesetRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _rulesetId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _rulesetId;
+
+				if (propsSet == (_rulesetId)) {
+					params.put("rulesetId", request.rulesetId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/GetQueryRulesetRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/GetQueryRulesetRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -143,6 +145,21 @@ public class GetQueryRulesetRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _rulesetId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _rulesetId;
+
+				if (propsSet == (_rulesetId)) {
+					params.put("rulesetId", request.rulesetId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/ListRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/ListRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -158,6 +159,11 @@ public class ListRequest extends RequestBase {
 			request -> {
 				return "/_query_rules";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/PutRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/query_ruleset/PutRequest.java
@@ -39,6 +39,8 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -198,6 +200,21 @@ public class PutRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _rulesetId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _rulesetId;
+
+				if (propsSet == (_rulesetId)) {
+					params.put("rulesetId", request.rulesetId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/DeleteJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/DeleteJobRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class DeleteJobRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetJobsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetJobsRequest.java
@@ -35,6 +35,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -153,6 +155,24 @@ public class GetJobsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupCapsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupCapsRequest.java
@@ -35,6 +35,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -156,6 +158,24 @@ public class GetRollupCapsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupIndexCapsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/GetRollupIndexCapsRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -165,6 +167,21 @@ public class GetRollupIndexCapsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/PutJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/PutJobRequest.java
@@ -40,6 +40,7 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -555,6 +556,21 @@ public class PutJobRequest extends RequestBase implements JsonpSerializable {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/RollupSearchRequest.java
@@ -41,6 +41,7 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -319,6 +320,21 @@ public class RollupSearchRequest extends RequestBase implements JsonpSerializabl
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _index;
+
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StartJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StartJobRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -143,6 +145,21 @@ public class StartJobRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StopJobRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/rollup/StopJobRequest.java
@@ -216,6 +216,21 @@ public class StopJobRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/DeleteBehavioralAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/DeleteBehavioralAnalyticsRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class DeleteBehavioralAnalyticsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/DeleteSearchApplicationRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/DeleteSearchApplicationRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class DeleteSearchApplicationRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/GetBehavioralAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/GetBehavioralAnalyticsRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -169,6 +171,24 @@ public class GetBehavioralAnalyticsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/GetSearchApplicationRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/GetSearchApplicationRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class GetSearchApplicationRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/ListRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/ListRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -186,6 +187,11 @@ public class ListRequest extends RequestBase {
 			request -> {
 				return "/_application/search_application";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/PutBehavioralAnalyticsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/PutBehavioralAnalyticsRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -145,6 +147,21 @@ public class PutBehavioralAnalyticsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/PutRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/PutRequest.java
@@ -231,6 +231,21 @@ public class PutRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/SearchApplicationSearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/search_application/SearchApplicationSearchRequest.java
@@ -39,6 +39,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -224,6 +225,21 @@ public class SearchApplicationSearchRequest extends RequestBase implements Jsonp
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/CacheStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/CacheStatsRequest.java
@@ -212,6 +212,24 @@ public class CacheStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/ClearCacheRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/ClearCacheRequest.java
@@ -324,6 +324,24 @@ public class ClearCacheRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/MountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/MountRequest.java
@@ -445,6 +445,24 @@ public class MountRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _repository = 1 << 0;
+				final int _snapshot = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _repository;
+				propsSet |= _snapshot;
+
+				if (propsSet == (_repository | _snapshot)) {
+					params.put("repository", request.repository);
+					params.put("snapshot", request.snapshot);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/SearchableSnapshotsStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/searchable_snapshots/SearchableSnapshotsStatsRequest.java
@@ -200,6 +200,24 @@ public class SearchableSnapshotsStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _index = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.index()))
+					propsSet |= _index;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_index)) {
+					params.put("index", request.index.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ActivateUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ActivateUserProfileRequest.java
@@ -249,6 +249,11 @@ public class ActivateUserProfileRequest extends RequestBase implements JsonpSeri
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/AuthenticateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/AuthenticateRequest.java
@@ -79,6 +79,11 @@ public class AuthenticateRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ChangePasswordRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ChangePasswordRequest.java
@@ -296,6 +296,24 @@ public class ChangePasswordRequest extends RequestBase implements JsonpSerializa
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _username = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.username() != null)
+					propsSet |= _username;
+
+				if (propsSet == (_username)) {
+					params.put("username", request.username);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearApiKeyCacheRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearApiKeyCacheRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -169,6 +171,21 @@ public class ClearApiKeyCacheRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _ids = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _ids;
+
+				if (propsSet == (_ids)) {
+					params.put("ids", request.ids.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedPrivilegesRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class ClearCachedPrivilegesRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _application = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _application;
+
+				if (propsSet == (_application)) {
+					params.put("application", request.application);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRealmsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRealmsRequest.java
@@ -206,6 +206,21 @@ public class ClearCachedRealmsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _realms = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _realms;
+
+				if (propsSet == (_realms)) {
+					params.put("realms", request.realms.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRolesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedRolesRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -162,6 +164,21 @@ public class ClearCachedRolesRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedServiceTokensRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ClearCachedServiceTokensRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -221,6 +223,27 @@ public class ClearCachedServiceTokensRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _service = 1 << 0;
+				final int _namespace = 1 << 1;
+				final int _name = 1 << 2;
+
+				int propsSet = 0;
+
+				propsSet |= _service;
+				propsSet |= _namespace;
+				propsSet |= _name;
+
+				if (propsSet == (_namespace | _service | _name)) {
+					params.put("namespace", request.namespace);
+					params.put("service", request.service);
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateApiKeyRequest.java
@@ -40,6 +40,7 @@ import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -400,6 +401,11 @@ public class CreateApiKeyRequest extends RequestBase implements JsonpSerializabl
 			request -> {
 				return "/_security/api_key";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateServiceTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/CreateServiceTokenRequest.java
@@ -272,6 +272,32 @@ public class CreateServiceTokenRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _service = 1 << 0;
+				final int _namespace = 1 << 1;
+				final int _name = 1 << 2;
+
+				int propsSet = 0;
+
+				propsSet |= _service;
+				propsSet |= _namespace;
+				if (request.name() != null)
+					propsSet |= _name;
+
+				if (propsSet == (_namespace | _service | _name)) {
+					params.put("namespace", request.namespace);
+					params.put("service", request.service);
+					params.put("name", request.name);
+				}
+				if (propsSet == (_namespace | _service)) {
+					params.put("namespace", request.namespace);
+					params.put("service", request.service);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeletePrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeletePrivilegesRequest.java
@@ -226,6 +226,24 @@ public class DeletePrivilegesRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _application = 1 << 0;
+				final int _name = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _application;
+				propsSet |= _name;
+
+				if (propsSet == (_application | _name)) {
+					params.put("application", request.application);
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleMappingRequest.java
@@ -182,6 +182,21 @@ public class DeleteRoleMappingRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteRoleRequest.java
@@ -181,6 +181,21 @@ public class DeleteRoleRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteServiceTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteServiceTokenRequest.java
@@ -240,6 +240,27 @@ public class DeleteServiceTokenRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _service = 1 << 0;
+				final int _namespace = 1 << 1;
+				final int _name = 1 << 2;
+
+				int propsSet = 0;
+
+				propsSet |= _service;
+				propsSet |= _namespace;
+				propsSet |= _name;
+
+				if (propsSet == (_namespace | _service | _name)) {
+					params.put("namespace", request.namespace);
+					params.put("service", request.service);
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DeleteUserRequest.java
@@ -181,6 +181,21 @@ public class DeleteUserRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _username = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _username;
+
+				if (propsSet == (_username)) {
+					params.put("username", request.username);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserProfileRequest.java
@@ -181,6 +181,21 @@ public class DisableUserProfileRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _uid = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _uid;
+
+				if (propsSet == (_uid)) {
+					params.put("uid", request.uid);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserRequest.java
@@ -182,6 +182,21 @@ public class DisableUserRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _username = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _username;
+
+				if (propsSet == (_username)) {
+					params.put("username", request.username);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserProfileRequest.java
@@ -181,6 +181,21 @@ public class EnableUserProfileRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _uid = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _uid;
+
+				if (propsSet == (_uid)) {
+					params.put("uid", request.uid);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserRequest.java
@@ -182,6 +182,21 @@ public class EnableUserRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _username = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _username;
+
+				if (propsSet == (_username)) {
+					params.put("username", request.username);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnrollKibanaRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnrollKibanaRequest.java
@@ -75,6 +75,11 @@ public class EnrollKibanaRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnrollNodeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnrollNodeRequest.java
@@ -74,6 +74,11 @@ public class EnrollNodeRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetApiKeyRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -298,6 +299,11 @@ public class GetApiKeyRequest extends RequestBase {
 			request -> {
 				return "/_security/api_key";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetBuiltinPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetBuiltinPrivilegesRequest.java
@@ -76,6 +76,11 @@ public class GetBuiltinPrivilegesRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetPrivilegesRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -208,6 +210,31 @@ public class GetPrivilegesRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _application = 1 << 0;
+				final int _name = 1 << 1;
+
+				int propsSet = 0;
+
+				if (request.application() != null)
+					propsSet |= _application;
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_application)) {
+					params.put("application", request.application);
+				}
+				if (propsSet == (_application | _name)) {
+					params.put("application", request.application);
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleMappingRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -181,6 +183,24 @@ public class GetRoleMappingRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetRoleRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -174,6 +176,24 @@ public class GetRoleRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceAccountsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceAccountsRequest.java
@@ -35,6 +35,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -201,6 +203,31 @@ public class GetServiceAccountsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _service = 1 << 0;
+				final int _namespace = 1 << 1;
+
+				int propsSet = 0;
+
+				if (request.service() != null)
+					propsSet |= _service;
+				if (request.namespace() != null)
+					propsSet |= _namespace;
+
+				if (propsSet == (_namespace | _service)) {
+					params.put("namespace", request.namespace);
+					params.put("service", request.service);
+				}
+				if (propsSet == (_namespace)) {
+					params.put("namespace", request.namespace);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceCredentialsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetServiceCredentialsRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -174,6 +176,24 @@ public class GetServiceCredentialsRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _service = 1 << 0;
+				final int _namespace = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _service;
+				propsSet |= _namespace;
+
+				if (propsSet == (_namespace | _service)) {
+					params.put("namespace", request.namespace);
+					params.put("service", request.service);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetTokenRequest.java
@@ -308,6 +308,11 @@ public class GetTokenRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserPrivilegesRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -190,6 +191,11 @@ public class GetUserPrivilegesRequest extends RequestBase {
 			request -> {
 				return "/_security/user/_privileges";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserProfileRequest.java
@@ -212,6 +212,21 @@ public class GetUserProfileRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _uid = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _uid;
+
+				if (propsSet == (_uid)) {
+					params.put("uid", request.uid.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GetUserRequest.java
@@ -204,6 +204,24 @@ public class GetUserRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _username = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.username()))
+					propsSet |= _username;
+
+				if (propsSet == (_username)) {
+					params.put("username", request.username.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GrantApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/GrantApiKeyRequest.java
@@ -364,6 +364,11 @@ public class GrantApiKeyRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesRequest.java
@@ -40,7 +40,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -347,6 +349,24 @@ public class HasPrivilegesRequest extends RequestBase implements JsonpSerializab
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _user = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.user() != null)
+					propsSet |= _user;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_user)) {
+					params.put("user", request.user);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesUserProfileRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/HasPrivilegesUserProfileRequest.java
@@ -226,6 +226,11 @@ public class HasPrivilegesUserProfileRequest extends RequestBase implements Json
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateApiKeyRequest.java
@@ -382,6 +382,11 @@ public class InvalidateApiKeyRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateTokenRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/InvalidateTokenRequest.java
@@ -254,6 +254,11 @@ public class InvalidateTokenRequest extends RequestBase implements JsonpSerializ
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutPrivilegesRequest.java
@@ -40,6 +40,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -226,6 +227,11 @@ public class PutPrivilegesRequest extends RequestBase implements JsonpSerializab
 			request -> {
 				return "/_security/privilege";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleMappingRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleMappingRequest.java
@@ -412,6 +412,21 @@ public class PutRoleMappingRequest extends RequestBase implements JsonpSerializa
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutRoleRequest.java
@@ -609,6 +609,21 @@ public class PutRoleRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutUserRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/PutUserRequest.java
@@ -446,6 +446,21 @@ public class PutUserRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _username = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _username;
+
+				if (propsSet == (_username)) {
+					params.put("username", request.username);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/QueryApiKeysRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/QueryApiKeysRequest.java
@@ -41,6 +41,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -431,6 +432,11 @@ public class QueryApiKeysRequest extends RequestBase implements JsonpSerializabl
 			request -> {
 				return "/_security/_query/api_key";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlAuthenticateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlAuthenticateRequest.java
@@ -257,6 +257,11 @@ public class SamlAuthenticateRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlCompleteLogoutRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlCompleteLogoutRequest.java
@@ -295,6 +295,11 @@ public class SamlCompleteLogoutRequest extends RequestBase implements JsonpSeria
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlInvalidateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlInvalidateRequest.java
@@ -256,6 +256,11 @@ public class SamlInvalidateRequest extends RequestBase implements JsonpSerializa
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlLogoutRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlLogoutRequest.java
@@ -205,6 +205,11 @@ public class SamlLogoutRequest extends RequestBase implements JsonpSerializable 
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlPrepareAuthenticationRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlPrepareAuthenticationRequest.java
@@ -251,6 +251,11 @@ public class SamlPrepareAuthenticationRequest extends RequestBase implements Jso
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlServiceProviderMetadataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SamlServiceProviderMetadataRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -147,6 +149,21 @@ public class SamlServiceProviderMetadataRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _realmName = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _realmName;
+
+				if (propsSet == (_realmName)) {
+					params.put("realmName", request.realmName);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SuggestUserProfilesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/SuggestUserProfilesRequest.java
@@ -322,6 +322,11 @@ public class SuggestUserProfilesRequest extends RequestBase implements JsonpSeri
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateApiKeyRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateApiKeyRequest.java
@@ -39,6 +39,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -341,6 +342,21 @@ public class UpdateApiKeyRequest extends RequestBase implements JsonpSerializabl
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateUserProfileDataRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/UpdateUserProfileDataRequest.java
@@ -376,6 +376,21 @@ public class UpdateUserProfileDataRequest extends RequestBase implements JsonpSe
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _uid = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _uid;
+
+				if (propsSet == (_uid)) {
+					params.put("uid", request.uid);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/DeleteNodeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/DeleteNodeRequest.java
@@ -207,6 +207,21 @@ public class DeleteNodeRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _nodeId;
+
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/GetNodeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/GetNodeRequest.java
@@ -231,6 +231,24 @@ public class GetNodeRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.nodeId()))
+					propsSet |= _nodeId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/PutNodeRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/shutdown/PutNodeRequest.java
@@ -397,6 +397,21 @@ public class PutNodeRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _nodeId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _nodeId;
+
+				if (propsSet == (_nodeId)) {
+					params.put("nodeId", request.nodeId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/DeleteLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/DeleteLifecycleRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class DeleteLifecycleRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _policyId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _policyId;
+
+				if (propsSet == (_policyId)) {
+					params.put("policyId", request.policyId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/ExecuteLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/ExecuteLifecycleRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class ExecuteLifecycleRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _policyId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _policyId;
+
+				if (propsSet == (_policyId)) {
+					params.put("policyId", request.policyId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/ExecuteRetentionRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/ExecuteRetentionRequest.java
@@ -75,6 +75,11 @@ public class ExecuteRetentionRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetLifecycleRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -170,6 +172,24 @@ public class GetLifecycleRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _policyId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.policyId()))
+					propsSet |= _policyId;
+
+				if (propsSet == (_policyId)) {
+					params.put("policyId", request.policyId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetSlmStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetSlmStatusRequest.java
@@ -74,6 +74,11 @@ public class GetSlmStatusRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/GetStatsRequest.java
@@ -75,6 +75,11 @@ public class GetStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/PutLifecycleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/PutLifecycleRequest.java
@@ -448,6 +448,21 @@ public class PutLifecycleRequest extends RequestBase implements JsonpSerializabl
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _policyId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _policyId;
+
+				if (propsSet == (_policyId)) {
+					params.put("policyId", request.policyId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/StartSlmRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/StartSlmRequest.java
@@ -74,6 +74,11 @@ public class StartSlmRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/StopSlmRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/slm/StopSlmRequest.java
@@ -74,6 +74,11 @@ public class StopSlmRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CleanupRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CleanupRepositoryRequest.java
@@ -222,6 +222,21 @@ public class CleanupRepositoryRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CloneSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CloneSnapshotRequest.java
@@ -323,6 +323,27 @@ public class CloneSnapshotRequest extends RequestBase implements JsonpSerializab
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _targetSnapshot = 1 << 0;
+				final int _repository = 1 << 1;
+				final int _snapshot = 1 << 2;
+
+				int propsSet = 0;
+
+				propsSet |= _targetSnapshot;
+				propsSet |= _repository;
+				propsSet |= _snapshot;
+
+				if (propsSet == (_repository | _snapshot | _targetSnapshot)) {
+					params.put("repository", request.repository);
+					params.put("snapshot", request.snapshot);
+					params.put("targetSnapshot", request.targetSnapshot);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateRepositoryRequest.java
@@ -368,6 +368,21 @@ public class CreateRepositoryRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/CreateSnapshotRequest.java
@@ -572,6 +572,24 @@ public class CreateSnapshotRequest extends RequestBase implements JsonpSerializa
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _repository = 1 << 0;
+				final int _snapshot = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _repository;
+				propsSet |= _snapshot;
+
+				if (propsSet == (_repository | _snapshot)) {
+					params.put("repository", request.repository);
+					params.put("snapshot", request.snapshot);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteRepositoryRequest.java
@@ -239,6 +239,21 @@ public class DeleteRepositoryRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/DeleteSnapshotRequest.java
@@ -211,6 +211,24 @@ public class DeleteSnapshotRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _repository = 1 << 0;
+				final int _snapshot = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _repository;
+				propsSet |= _snapshot;
+
+				if (propsSet == (_repository | _snapshot)) {
+					params.put("repository", request.repository);
+					params.put("snapshot", request.snapshot);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetRepositoryRequest.java
@@ -236,6 +236,24 @@ public class GetRepositoryRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.name()))
+					propsSet |= _name;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_name)) {
+					params.put("name", request.name.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetSnapshotRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/GetSnapshotRequest.java
@@ -619,6 +619,24 @@ public class GetSnapshotRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _repository = 1 << 0;
+				final int _snapshot = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _repository;
+				propsSet |= _snapshot;
+
+				if (propsSet == (_repository | _snapshot)) {
+					params.put("repository", request.repository);
+					params.put("snapshot", request.snapshot.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/RestoreRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/RestoreRequest.java
@@ -614,6 +614,24 @@ public class RestoreRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _repository = 1 << 0;
+				final int _snapshot = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _repository;
+				propsSet |= _snapshot;
+
+				if (propsSet == (_repository | _snapshot)) {
+					params.put("repository", request.repository);
+					params.put("snapshot", request.snapshot);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/SnapshotStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/SnapshotStatusRequest.java
@@ -279,6 +279,31 @@ public class SnapshotStatusRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _repository = 1 << 0;
+				final int _snapshot = 1 << 1;
+
+				int propsSet = 0;
+
+				if (request.repository() != null)
+					propsSet |= _repository;
+				if (ApiTypeHelper.isDefined(request.snapshot()))
+					propsSet |= _snapshot;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_repository)) {
+					params.put("repository", request.repository);
+				}
+				if (propsSet == (_repository | _snapshot)) {
+					params.put("repository", request.repository);
+					params.put("snapshot", request.snapshot.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/VerifyRepositoryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/snapshot/VerifyRepositoryRequest.java
@@ -221,6 +221,21 @@ public class VerifyRepositoryRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _name = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _name;
+
+				if (propsSet == (_name)) {
+					params.put("name", request.name);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/ClearCursorRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/ClearCursorRequest.java
@@ -160,6 +160,11 @@ public class ClearCursorRequest extends RequestBase implements JsonpSerializable
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/DeleteAsyncRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/DeleteAsyncRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class DeleteAsyncRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncRequest.java
@@ -283,6 +283,21 @@ public class GetAsyncRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncStatusRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/GetAsyncStatusRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class GetAsyncStatusRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/QueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/QueryRequest.java
@@ -43,6 +43,7 @@ import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -809,6 +810,11 @@ public class QueryRequest extends RequestBase implements JsonpSerializable {
 			request -> {
 				return "/_sql";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/TranslateRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/sql/TranslateRequest.java
@@ -257,6 +257,11 @@ public class TranslateRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/ssl/CertificatesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/ssl/CertificatesRequest.java
@@ -75,6 +75,11 @@ public class CertificatesRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/DeleteSynonymRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/DeleteSynonymRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -143,6 +145,21 @@ public class DeleteSynonymRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/DeleteSynonymRuleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/DeleteSynonymRuleRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -172,6 +174,24 @@ public class DeleteSynonymRuleRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _ruleId = 1 << 0;
+				final int _setId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _ruleId;
+				propsSet |= _setId;
+
+				if (propsSet == (_setId | _ruleId)) {
+					params.put("setId", request.setId);
+					params.put("ruleId", request.ruleId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/GetSynonymRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/GetSynonymRequest.java
@@ -201,6 +201,21 @@ public class GetSynonymRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/GetSynonymRuleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/GetSynonymRuleRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -172,6 +174,24 @@ public class GetSynonymRuleRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _ruleId = 1 << 0;
+				final int _setId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _ruleId;
+				propsSet |= _setId;
+
+				if (propsSet == (_setId | _ruleId)) {
+					params.put("setId", request.setId);
+					params.put("ruleId", request.ruleId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/GetSynonymsSetsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/GetSynonymsSetsRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Integer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -161,6 +162,11 @@ public class GetSynonymsSetsRequest extends RequestBase {
 			request -> {
 				return "/_synonyms";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/PutSynonymRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/PutSynonymRequest.java
@@ -38,7 +38,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -233,6 +235,21 @@ public class PutSynonymRequest extends RequestBase implements JsonpSerializable 
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/PutSynonymRuleRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/synonyms/PutSynonymRuleRequest.java
@@ -38,7 +38,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -246,6 +248,24 @@ public class PutSynonymRuleRequest extends RequestBase implements JsonpSerializa
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _ruleId = 1 << 0;
+				final int _setId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _ruleId;
+				propsSet |= _setId;
+
+				if (propsSet == (_setId | _ruleId)) {
+					params.put("setId", request.setId);
+					params.put("ruleId", request.ruleId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/CancelRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/CancelRequest.java
@@ -303,6 +303,24 @@ public class CancelRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _taskId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.taskId() != null)
+					propsSet |= _taskId;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_taskId)) {
+					params.put("taskId", request.taskId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/GetTasksRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/GetTasksRequest.java
@@ -209,6 +209,21 @@ public class GetTasksRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _taskId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _taskId;
+
+				if (propsSet == (_taskId)) {
+					params.put("taskId", request.taskId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/ListRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/tasks/ListRequest.java
@@ -37,6 +37,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -381,6 +382,11 @@ public class ListRequest extends RequestBase {
 			request -> {
 				return "/_tasks";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/DeleteTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/DeleteTransformRequest.java
@@ -217,6 +217,21 @@ public class DeleteTransformRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformRequest.java
@@ -314,6 +314,25 @@ public class GetTransformRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.transformId()))
+					propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId",
+							request.transformId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/GetTransformStatsRequest.java
@@ -315,6 +315,22 @@ public class GetTransformStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId",
+							request.transformId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PreviewTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PreviewTransformRequest.java
@@ -621,6 +621,24 @@ public class PreviewTransformRequest extends RequestBase implements JsonpSeriali
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.transformId() != null)
+					propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PutTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/PutTransformRequest.java
@@ -717,6 +717,21 @@ public class PutTransformRequest extends RequestBase implements JsonpSerializabl
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/ResetTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/ResetTransformRequest.java
@@ -186,6 +186,21 @@ public class ResetTransformRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/ScheduleNowTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/ScheduleNowTransformRequest.java
@@ -190,6 +190,21 @@ public class ScheduleNowTransformRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StartTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StartTransformRequest.java
@@ -241,6 +241,21 @@ public class StartTransformRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StopTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/StopTransformRequest.java
@@ -335,6 +335,21 @@ public class StopTransformRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpdateTransformRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpdateTransformRequest.java
@@ -606,6 +606,21 @@ public class UpdateTransformRequest extends RequestBase implements JsonpSerializ
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _transformId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _transformId;
+
+				if (propsSet == (_transformId)) {
+					params.put("transformId", request.transformId);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpgradeTransformsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/transform/UpgradeTransformsRequest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -180,6 +181,11 @@ public class UpgradeTransformsRequest extends RequestBase {
 			request -> {
 				return "/_transform/_upgrade";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/AckWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/AckWatchRequest.java
@@ -36,7 +36,9 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -200,6 +202,28 @@ public class AckWatchRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _watchId = 1 << 0;
+				final int _actionId = 1 << 1;
+
+				int propsSet = 0;
+
+				propsSet |= _watchId;
+				if (ApiTypeHelper.isDefined(request.actionId()))
+					propsSet |= _actionId;
+
+				if (propsSet == (_watchId)) {
+					params.put("watchId", request.watchId);
+				}
+				if (propsSet == (_watchId | _actionId)) {
+					params.put("watchId", request.watchId);
+					params.put("actionId", request.actionId.stream().map(v -> v).collect(Collectors.joining(",")));
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ActivateWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ActivateWatchRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -145,6 +147,21 @@ public class ActivateWatchRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _watchId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _watchId;
+
+				if (propsSet == (_watchId)) {
+					params.put("watchId", request.watchId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeactivateWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeactivateWatchRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -146,6 +148,21 @@ public class DeactivateWatchRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _watchId = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _watchId;
+
+				if (propsSet == (_watchId)) {
+					params.put("watchId", request.watchId);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeleteWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/DeleteWatchRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -144,6 +146,21 @@ public class DeleteWatchRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ExecuteWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/ExecuteWatchRequest.java
@@ -532,6 +532,24 @@ public class ExecuteWatchRequest extends RequestBase implements JsonpSerializabl
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				if (request.id() != null)
+					propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				if (propsSet == 0) {
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/GetWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/GetWatchRequest.java
@@ -36,6 +36,8 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -142,6 +144,21 @@ public class GetWatchRequest extends RequestBase {
 				}
 				throw SimpleEndpoint.noPathTemplateFound("path");
 
+			},
+
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/PutWatchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/PutWatchRequest.java
@@ -562,6 +562,21 @@ public class PutWatchRequest extends RequestBase implements JsonpSerializable {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _id = 1 << 0;
+
+				int propsSet = 0;
+
+				propsSet |= _id;
+
+				if (propsSet == (_id)) {
+					params.put("id", request.id);
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/QueryWatchesRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/QueryWatchesRequest.java
@@ -371,6 +371,11 @@ public class QueryWatchesRequest extends RequestBase implements JsonpSerializabl
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/StartWatcherRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/StartWatcherRequest.java
@@ -74,6 +74,11 @@ public class StartWatcherRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/StopWatcherRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/StopWatcherRequest.java
@@ -74,6 +74,11 @@ public class StopWatcherRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
+			},
+
 			// Request parameters
 			request -> {
 				return Collections.emptyMap();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/WatcherStatsRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/watcher/WatcherStatsRequest.java
@@ -200,6 +200,25 @@ public class WatcherStatsRequest extends RequestBase {
 
 			},
 
+			// Path parameters
+			request -> {
+				Map<String, String> params = new HashMap<>();
+				final int _metric = 1 << 0;
+
+				int propsSet = 0;
+
+				if (ApiTypeHelper.isDefined(request.metric()))
+					propsSet |= _metric;
+
+				if (propsSet == 0) {
+				}
+				if (propsSet == (_metric)) {
+					params.put("metric",
+							request.metric.stream().map(v -> v.jsonValue()).collect(Collectors.joining(",")));
+				}
+				return params;
+			},
+
 			// Request parameters
 			request -> {
 				Map<String, String> params = new HashMap<>();

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackInfoRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackInfoRequest.java
@@ -36,6 +36,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,6 +209,11 @@ public class XpackInfoRequest extends RequestBase {
 			request -> {
 				return "/_xpack";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackUsageRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/xpack/XpackUsageRequest.java
@@ -34,6 +34,7 @@ import co.elastic.clients.transport.Endpoint;
 import co.elastic.clients.transport.endpoints.SimpleEndpoint;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -146,6 +147,11 @@ public class XpackUsageRequest extends RequestBase {
 			request -> {
 				return "/_xpack/usage";
 
+			},
+
+			// Path parameters
+			request -> {
+				return Collections.emptyMap();
 			},
 
 			// Request parameters

--- a/java-client/src/main/java/co/elastic/clients/transport/Endpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/Endpoint.java
@@ -57,6 +57,13 @@ public interface Endpoint<RequestT, ResponseT, ErrorT> {
   String requestUrl(RequestT request);
 
   /**
+   * Get the path parameters for a request.
+   */
+  default Map<String, String> pathParameters(RequestT request)  {
+    return Collections.emptyMap();
+  }
+
+  /**
    * Get the query parameters for a request.
    */
   default Map<String, String> queryParameters(RequestT request) {
@@ -104,6 +111,7 @@ public interface Endpoint<RequestT, ResponseT, ErrorT> {
           this.id(),
           this::method,
           this::requestUrl,
+          this::pathParameters,
           this::queryParameters,
           this::headers,
           this::body,

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryEndpoint.java
@@ -29,12 +29,14 @@ public class BinaryEndpoint<RequestT> extends EndpointBase<RequestT, BinaryRespo
         Function<RequestT, String> method,
         Function<RequestT, String> requestUrl,
         Function<RequestT,
+            Map<String, String>> pathParameters,
+        Function<RequestT,
             Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
         Function<RequestT, Object> body,
         Object ignored // same number of arguments as SimpleEndpoint
     ) {
-        super(id, method, requestUrl, queryParameters, headers, body);
+        super(id, method, requestUrl, pathParameters, queryParameters, headers, body);
     }
 
     public BinaryEndpoint(
@@ -42,12 +44,14 @@ public class BinaryEndpoint<RequestT> extends EndpointBase<RequestT, BinaryRespo
         Function<RequestT, String> method,
         Function<RequestT, String> requestUrl,
         Function<RequestT,
+            Map<String, String>> pathParameters,
+        Function<RequestT,
             Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
         boolean hasRequestBody,
         Object ignored // same number of arguments as SimpleEndpoint
     ) {
-        super(id, method, requestUrl, queryParameters, headers, hasRequestBody ? returnSelf() : returnNull());
+        super(id, method, requestUrl, pathParameters, queryParameters, headers, hasRequestBody ? returnSelf() : returnNull());
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/BooleanEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/BooleanEndpoint.java
@@ -29,12 +29,14 @@ public class BooleanEndpoint<RequestT> extends EndpointBase<RequestT, BooleanRes
         Function<RequestT, String> method,
         Function<RequestT, String> requestUrl,
         Function<RequestT,
+            Map<String, String>> pathParameters,
+        Function<RequestT,
             Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
         boolean hasRequestBody,
         Object ignored // same number of arguments as SimpleEndpoint
     ) {
-        super(id, method, requestUrl, queryParameters, headers, hasRequestBody ? returnSelf() : returnNull());
+        super(id, method, requestUrl, pathParameters, queryParameters, headers, hasRequestBody ? returnSelf() : returnNull());
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/DelegatingJsonEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/DelegatingJsonEndpoint.java
@@ -49,6 +49,11 @@ public class DelegatingJsonEndpoint<Req, Res, Err> implements JsonEndpoint<Req, 
     }
 
     @Override
+    public Map<String, String> pathParameters(Req request) {
+        return endpoint.pathParameters(request);
+    }
+
+    @Override
     public Map<String, String> queryParameters(Req request) {
         return endpoint.queryParameters(request);
     }

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/EndpointBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/EndpointBase.java
@@ -66,6 +66,7 @@ public class EndpointBase<RequestT, ResponseT> implements Endpoint<RequestT, Res
     protected final String id;
     protected final Function<RequestT, String> method;
     protected final Function<RequestT, String> requestUrl;
+    protected final Function<RequestT, Map<String, String>> pathParameters;
     protected final Function<RequestT, Map<String, String>> queryParameters;
     protected final Function<RequestT, Map<String, String>> headers;
     protected final Function<RequestT, Object> body;
@@ -74,6 +75,7 @@ public class EndpointBase<RequestT, ResponseT> implements Endpoint<RequestT, Res
         String id,
         Function<RequestT, String> method,
         Function<RequestT, String> requestUrl,
+        Function<RequestT, Map<String, String>> pathParameters,
         Function<RequestT, Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
         Function<RequestT, Object> body
@@ -81,6 +83,7 @@ public class EndpointBase<RequestT, ResponseT> implements Endpoint<RequestT, Res
         this.id = id;
         this.method = method;
         this.requestUrl = requestUrl;
+        this.pathParameters = pathParameters;
         this.queryParameters = queryParameters;
         this.headers = headers;
         this.body = body;
@@ -99,6 +102,11 @@ public class EndpointBase<RequestT, ResponseT> implements Endpoint<RequestT, Res
     @Override
     public String requestUrl(RequestT request) {
         return this.requestUrl.apply(request);
+    }
+
+    @Override
+    public Map<String, String> pathParameters(RequestT request) {
+        return this.pathParameters.apply(request);
     }
 
     @Override
@@ -135,6 +143,7 @@ public class EndpointBase<RequestT, ResponseT> implements Endpoint<RequestT, Res
             id,
             method,
             requestUrl,
+            pathParameters,
             queryParameters,
             headers,
             body,

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
@@ -35,12 +35,13 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
         String id,
         Function<RequestT, String> method,
         Function<RequestT, String> requestUrl,
+        Function<RequestT, Map<String, String>> pathParameters,
         Function<RequestT, Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
         Function<RequestT, Object> body,
         JsonpDeserializer<ResponseT> responseParser
     ) {
-        super(id, method, requestUrl, queryParameters, headers, body);
+        super(id, method, requestUrl, pathParameters, queryParameters, headers, body);
         this.responseParser = responseParser;
     }
 
@@ -48,6 +49,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
         String id,
         Function<RequestT, String> method,
         Function<RequestT, String> requestUrl,
+        Function<RequestT, Map<String, String>> pathParameters,
         Function<RequestT, Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
         boolean hasResponseBody,
@@ -57,6 +59,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
             id,
             method,
             requestUrl,
+            pathParameters,
             queryParameters,
             headers,
             hasResponseBody ? returnSelf() : returnNull(),
@@ -81,6 +84,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
             id,
             method,
             requestUrl,
+            pathParameters,
             queryParameters,
             headers,
             body,

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleJsonEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleJsonEndpoint.java
@@ -34,11 +34,13 @@ public class SimpleJsonEndpoint<RequestT, ResponseT> extends SimpleEndpoint<Requ
         Function<RequestT, String> method,
         Function<RequestT, String> requestUrl,
         Function<RequestT,
-        Map<String, String>> queryParameters,
+            Map<String, String>> pathParameters,
+        Function<RequestT,
+            Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
         boolean hasRequestBody,
         JsonpDeserializer<ResponseT> responseParser
     ) {
-        super(id, method, requestUrl, queryParameters, headers, hasRequestBody, responseParser);
+        super(id, method, requestUrl, pathParameters, queryParameters, headers, hasRequestBody, responseParser);
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/transport/instrumentation/Instrumentation.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/instrumentation/Instrumentation.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.instrumentation;
+
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import co.elastic.clients.transport.http.TransportHttpClient;
+
+/**
+ * Instrumentation for an Elasticsearch client. It allows creating a {@link Instrumentation.Context} for each request,
+ * with callbacks for the various stages of request and response processing.
+ */
+public interface Instrumentation {
+
+    /**
+     * Create a context for a given request and the corresponding endpoint.
+     */
+    <TRequest> Context newContext(TRequest request, Endpoint<TRequest, ?, ?> endpoint);
+
+    /**
+     * A context with lifecycle callbacks for the various stages of request and response processing. Must be {@link #close()}d.
+     */
+    interface Context extends AutoCloseable {
+
+        /**
+         * Sets this context (or the underlying abstraction) as the current thread's scope, so that neste call can
+         * nest child contexts.
+         */
+        ThreadScope makeCurrent();
+
+        /**
+         * Called once the initial API request has been serialized and the http request has been prepared.
+         */
+        void beforeSendingHttpRequest(TransportHttpClient.Request httpRequest, TransportOptions options);
+
+        /**
+         * Called after the http response has been received, and before analyzing it.
+         */
+        void afterReceivingHttpResponse(TransportHttpClient.Response httpResponse);
+
+        /**
+         * Called after the http response has been deserialized
+         */
+        <TResponse> void afterDecodingApiResponse(TResponse apiResponse);
+
+        /**
+         * Called when any stage of request processing caused a failure.
+         */
+        void recordException(Throwable thr);
+
+        @Override
+        void close();
+    }
+
+    /**
+     * A thread scope. Closing it will detach the scope from the current thread.
+     */
+    interface ThreadScope extends AutoCloseable {
+        @Override
+        void close();
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/transport/instrumentation/NoopInstrumentation.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/instrumentation/NoopInstrumentation.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.instrumentation;
+
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import co.elastic.clients.transport.http.TransportHttpClient;
+
+/**
+ * A no-operation instrumentation. Used when no instrumentation has been set. It can also be used to
+ * bypass OpenTelemetry automatic discovery.
+ */
+public class NoopInstrumentation implements Instrumentation {
+
+    public static NoopInstrumentation INSTANCE = new NoopInstrumentation();
+
+    private NoopInstrumentation() {}
+
+    @Override
+    public <TRequest> Context newContext(TRequest request, Endpoint<TRequest, ?, ?> endpoint) {
+        return CONTEXT;
+    }
+
+    private static final NoopContext CONTEXT = new NoopContext();
+    private static final NoopScope SCOPE = new NoopScope();
+
+    private static class NoopContext implements Instrumentation.Context {
+        @Override
+        public ThreadScope makeCurrent() {
+            return SCOPE;
+        }
+
+        @Override
+        public void beforeSendingHttpRequest(TransportHttpClient.Request httpRequest, TransportOptions options) {}
+
+        @Override
+        public void afterReceivingHttpResponse(TransportHttpClient.Response httpResponse) {}
+
+        @Override
+        public <TResponse> void afterDecodingApiResponse(TResponse apiResponse) {}
+
+        @Override
+        public void recordException(Throwable thr) {}
+
+        @Override
+        public void close() {}
+    }
+
+    private static class NoopScope implements Instrumentation.ThreadScope {
+        @Override
+        public void close() {}
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearch.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearch.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.instrumentation;
+
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import co.elastic.clients.transport.Version;
+import co.elastic.clients.transport.http.TransportHttpClient;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.annotation.Nullable;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An OpenTelemetry instrumentation for the Elasticsearch client.
+ *
+ * @see <a href="https://opentelemetry.io/docs/specs/semconv/database/elasticsearch/">OpenTelemetry semantic conventions
+ *      for Elasticsearch</a>
+ */
+
+public class OpenTelemetryForElasticsearch implements Instrumentation {
+
+    private static final Set<String> SEARCH_ENDPOINTS = new HashSet<>(Arrays.asList(
+        "render_search_template",
+        "terms_enum",
+        "msearch_template",
+        "eql.search",
+        "msearch",
+        "search_template",
+        "async_search.submit",
+        "search"
+    ));
+
+    private static final AttributeKey<String> ATTR_DB_SYSTEM = AttributeKey.stringKey("db.system");
+    private static final AttributeKey<String> ATTR_DB_OPERATION = AttributeKey.stringKey("db.operation");
+    private static final AttributeKey<String> ATTR_DB_STATEMENT = AttributeKey.stringKey("db.statement");
+    // Use Semantic Convention keys once opentelemetry-semconv is stable
+    //private static final AttributeKey<String> ATTR_DB_SYSTEM = SemanticAttributes.DB_SYSTEM;
+    //private static final AttributeKey<String> ATTR_DB_OPERATION = SemanticAttributes.DB_OPERATION;
+    //private static final AttributeKey<String> ATTR_DB_STATEMENT = SemanticAttributes.DB_STATEMENT;
+
+    private static final AttributeKey<String> ATTR_HTTP_REQUEST_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> ATTR_URL_FULL = AttributeKey.stringKey("url.full");
+    private static final AttributeKey<String> ATTR_SERVER_ADDRESS = AttributeKey.stringKey("server.address");
+    private static final AttributeKey<Long> ATTR_SERVER_PORT = AttributeKey.longKey("server.port");
+
+    // Caching attributes keys to avoid unnecessary memory allocation
+    private static final Map<String, AttributeKey<String>> attributesKeyCache = new ConcurrentHashMap<>();
+
+    private static final String PATH_PART_PREFIX = "db.elasticsearch.path_parts.";
+
+    // these reflect the config options in the OTel Java agent
+    private static final boolean INSTRUMENTATION_ENABLED = Boolean.parseBoolean(
+        ConfigUtil.getConfigOption("otel.instrumentation.elasticsearch.enabled", "true")
+    );
+
+    private static final boolean CAPTURE_SEARCH_BODY = Boolean.parseBoolean(
+        ConfigUtil.getConfigOption("otel.instrumentation.elasticsearch.capture-search-query", "false")
+    );
+
+    private static final Log logger = LogFactory.getLog(OpenTelemetryForElasticsearch.class);
+
+    private final Tracer tracer;
+    private final boolean captureSearchBody;
+
+    /**
+     * Creates an OpenTelemetry instrumentation based on systems settings:
+     * <ul>
+     *     <li>{@code otel.instrumentation.elasticsearch.enabled} system property or
+     *     {@code OTEL_INSTRUMENTATION_ELASTICSEARCH_ENABLED} environnement variable: if {@code true} instrumentation is enabled.
+     *     Defaults to {@code true}.
+     *     </li>
+     *     <li>{@code otel.instrumentation.elasticsearch.capture-search-query} system property or
+     *     {@code OTEL_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY} environment variable: if {@code true} the request body
+     *     of search requests will be captured. Defaults to {@code false}.
+     *     </li>
+     * </ul>
+     *
+     * @return an instrumentation, or {@code null} if instrumentation is disabled or no OTel agent has been configured.
+     */
+    public static @Nullable OpenTelemetryForElasticsearch getDefault() {
+
+        // See https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/#configuring-the-agent
+        boolean enabled = Boolean.parseBoolean(
+            ConfigUtil.getConfigOption("otel.instrumentation.elasticsearch.enabled", "true")
+        );
+
+        if (!enabled) {
+            return null;
+        }
+
+        OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+        if (openTelemetry == OpenTelemetry.noop()) {
+            // Do not waste time with noop impls that do have a cost, even if marginal
+            return null;
+        }
+
+        boolean captureSearchBody = Boolean.parseBoolean(
+            ConfigUtil.getConfigOption("otel.instrumentation.elasticsearch.capture-search-query", "false")
+        );
+
+        return new OpenTelemetryForElasticsearch(openTelemetry, captureSearchBody);
+    }
+
+    /**
+     * Creates an OpenTelemetry instrumentation.
+     *
+     * @param openTelemetry the OpenTelemetry implementation
+     * @param captureSearchBody should search requests bodies be captured?
+     */
+    public OpenTelemetryForElasticsearch(OpenTelemetry openTelemetry, boolean captureSearchBody) {
+        Version version = Version.VERSION;
+
+        this.tracer = openTelemetry.tracerBuilder("elasticsearch-api")
+            .setInstrumentationVersion(version == null ? "unknown" : version.toString())
+            .setSchemaUrl("https://opentelemetry.io/schemas/1.21.0")
+            .build();
+
+        this.captureSearchBody = captureSearchBody;
+    }
+
+    @Override
+    public <TRequest> Context newContext(TRequest request, Endpoint<TRequest, ?, ?> endpoint) {
+        return new OTelContext(request, endpoint);
+    }
+
+    private boolean shouldCaptureBody(Span span, String endpointId) {
+        return captureSearchBody && span.isRecording() && SEARCH_ENDPOINTS.contains(endpointId);
+    }
+
+    //---------------------------------------------------------------------------------------------
+
+    class OTelContext implements Instrumentation.Context {
+
+        private final Span span;
+        private String endpointId;
+        private String pathAndQuery = null;
+
+        <TRequest> OTelContext(TRequest request, Endpoint<TRequest, ?, ?> endpoint) {
+
+            // calling the instrumentation class should never throw an exception
+            Span span;
+            String endpointId;
+            try {
+                endpointId = endpoint.id();
+                if (endpointId.startsWith("es/")) {
+                    endpointId = endpointId.substring(3);
+                }
+                this.endpointId = endpointId;
+
+                span = tracer.spanBuilder(endpointId).setSpanKind(SpanKind.CLIENT).startSpan();
+                if (span.isRecording()) {
+                    span.setAttribute(ATTR_DB_SYSTEM, "elasticsearch");
+                    span.setAttribute(ATTR_DB_OPERATION, endpointId);
+                    span.setAttribute(ATTR_HTTP_REQUEST_METHOD, endpoint.method(request));
+
+                    for (Map.Entry<String, String> pathParamEntry : endpoint.pathParameters(request).entrySet()) {
+                        AttributeKey<String> attributeKey = attributesKeyCache.computeIfAbsent(pathParamEntry.getKey(),
+                            (key) -> AttributeKey.stringKey(PATH_PART_PREFIX + key));
+                        span.setAttribute(attributeKey, pathParamEntry.getValue());
+                    }
+                }
+            } catch (RuntimeException e) {
+                logger.debug("Failed creating an OpenTelemetry span for endpoint '" + endpoint.id() + "'.", e);
+                span = Span.getInvalid();
+            }
+
+            this.span = span;
+        }
+
+        @Override
+        public void beforeSendingHttpRequest(TransportHttpClient.Request httpRequest, TransportOptions options) {
+            // calling the instrumentation class should never throw an exception
+            try {
+
+                this.pathAndQuery = pathAndQuery(httpRequest, options);
+
+                span.setAttribute(ATTR_HTTP_REQUEST_METHOD, httpRequest.method());
+                Iterable<ByteBuffer> body = httpRequest.body();
+                if (body != null && shouldCaptureBody(span, endpointId)) {
+                    StringBuilder sb = new StringBuilder();
+                    for (ByteBuffer buf: body) {
+                        buf.mark();
+                        sb.append(StandardCharsets.UTF_8.decode(buf));
+                        buf.reset();
+                    }
+                    span.setAttribute(ATTR_DB_STATEMENT, sb.toString());
+                }
+            } catch (Exception e) {
+                logger.debug("Failed reading HTTP body content for an OpenTelemetry span.", e);
+            }
+        }
+
+        @Override
+        public void afterReceivingHttpResponse(TransportHttpClient.Response httpResponse) {
+            // calling the instrumentation class should never throw an exception
+            try {
+                if (span.isRecording()) {
+                    URI uri = httpResponse.node().uri();
+                    String fullUrl = uri.resolve(pathAndQuery).toString();
+
+                    span.setAttribute(ATTR_URL_FULL, fullUrl);
+                    span.setAttribute(ATTR_SERVER_PORT, uri.getPort());
+                    span.setAttribute(ATTR_SERVER_ADDRESS, uri.getHost());
+                }
+            } catch (RuntimeException e) {
+                logger.debug("Failed capturing response information for the OpenTelemetry span.", e);
+                // ignore
+            }
+        }
+
+        @Override
+        public <TResponse> void afterDecodingApiResponse(TResponse apiResponse) {
+            // Nothing
+        }
+
+        @Override
+        public void recordException(Throwable throwable) {
+            span.setStatus(StatusCode.ERROR, throwable.getMessage());
+            span.recordException(throwable);
+        }
+
+        @Override
+        public void close() {
+            span.end();
+        }
+
+        @Override
+        public ThreadScope makeCurrent() {
+            return new OTelScope(this.span);
+        }
+    }
+
+    //---------------------------------------------------------------------------------------------
+
+    class OTelScope implements Instrumentation.ThreadScope {
+
+        private final Scope scope;
+
+        OTelScope(Span span) {
+            this.scope = span.makeCurrent();
+        }
+
+        @Override
+        public void close() {
+            this.scope.close();
+        }
+    }
+
+    //---------------------------------------------------------------------------------------------
+
+    private String pathAndQuery(TransportHttpClient.Request request, TransportOptions options) {
+
+        String path = request.path();
+        path = path.length() > 0 && path.charAt(0) == '/' ? path.substring(1) : path;
+
+        Map<String, String> requestParams = request.queryParams();
+        Map<String, String> optionsParams = options == null ? Collections.emptyMap() : options.queryParameters();
+
+        Map<String, String> allParams;
+        if (requestParams.isEmpty()) {
+            allParams = optionsParams;
+        } else if (optionsParams.isEmpty()) {
+            allParams = requestParams;
+        } else {
+            allParams = new HashMap<>(requestParams);
+            allParams.putAll(optionsParams);
+        }
+
+        if (allParams.isEmpty()) {
+            return path;
+        }
+
+        StringBuilder sb = new StringBuilder(path);
+        char sep = '?';
+        for (Map.Entry<String, String> e: allParams.entrySet()) {
+            sb.append(sep);
+            sep = '&';
+            try {
+                sb.append(URLEncoder.encode(e.getKey(), "UTF-8"));
+                sb.append('=');
+                sb.append(URLEncoder.encode(e.getValue(), "UTF-8"));
+            } catch (UnsupportedEncodingException ex) {
+                // Should not happen
+                throw new RuntimeException(ex);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Borrowed from io.opentelemetry.api.internal.ConfigUtil
+     */
+    private static final class ConfigUtil {
+        /**
+         * Find a configuration option first as a JVM system property, and second as an environment variable
+         */
+        private static String getConfigOption(String key, String defaultValue) {
+            String normalizedKey = normalizePropertyKey(key);
+            String systemProperty = System.getProperties().entrySet().stream()
+                .filter(entry -> normalizedKey.equals(normalizePropertyKey(entry.getKey().toString())))
+                .map(entry -> entry.getValue().toString())
+                .findFirst()
+                .orElse(null);
+            if (systemProperty != null) {
+                return systemProperty;
+            }
+            return System.getenv().entrySet().stream()
+                .filter(entry -> normalizedKey.equals(normalizeEnvironmentVariableKey(entry.getKey())))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(defaultValue);
+        }
+
+        /**
+         * Normalize an environment variable key by converting to lower case and replacing "_" with ".".
+         */
+        private static String normalizeEnvironmentVariableKey(String key) {
+            return key.toLowerCase(Locale.ROOT).replace("_", ".");
+        }
+
+        /**
+         * Normalize a property key by converting to lower case and replacing "-" with ".".
+         */
+        private static String normalizePropertyKey(String key) {
+            return key.toLowerCase(Locale.ROOT).replace("-", ".");
+        }
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientTransport.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest_client/RestClientTransport.java
@@ -21,8 +21,8 @@ package co.elastic.clients.transport.rest_client;
 
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransportBase;
+import co.elastic.clients.transport.instrumentation.Instrumentation;
 import org.elasticsearch.client.RestClient;
-
 
 public class RestClientTransport extends ElasticsearchTransportBase {
 
@@ -33,7 +33,12 @@ public class RestClientTransport extends ElasticsearchTransportBase {
     }
 
     public RestClientTransport(RestClient restClient, JsonpMapper jsonpMapper, RestClientOptions options) {
-        super(new RestClientHttpClient(restClient), options, jsonpMapper);
+        super(new RestClientHttpClient(restClient), options, jsonpMapper, null);
+        this.restClient = restClient;
+    }
+
+    public RestClientTransport(RestClient restClient, JsonpMapper jsonpMapper, RestClientOptions options, Instrumentation instrumentation) {
+        super(new RestClientHttpClient(restClient), options, jsonpMapper, instrumentation);
         this.restClient = restClient;
     }
 

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/api/FooOptRequest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/api/FooOptRequest.java
@@ -264,6 +264,7 @@ public class FooOptRequest implements JsonpSerializable {
       r -> "/foo",
       SimpleEndpoint.emptyMap(),
       SimpleEndpoint.emptyMap(),
+      SimpleEndpoint.emptyMap(),
       true,
       FooResponse.PARSER
     ) {

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/api/FooRequest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/api/FooRequest.java
@@ -304,6 +304,7 @@ public class FooRequest implements JsonpSerializable {
       r -> "/foo",
       SimpleEndpoint.emptyMap(),
       SimpleEndpoint.emptyMap(),
+      SimpleEndpoint.emptyMap(),
       true,
       FooResponse.PARSER
     );

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/generics/GenericClass.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/experiments/generics/GenericClass.java
@@ -107,12 +107,13 @@ public class GenericClass<GenParam> implements JsonpSerializable {
             "genclass",
             // Request method
             request -> "GET",
-
             // Request path
             request -> "/genclass",
-
+            // Path parameters
+            SimpleEndpoint.emptyMap(),
             // Request parameters
             SimpleEndpoint.emptyMap(),
+            // Headers
             SimpleEndpoint.emptyMap(),
             true,
             GenericClass.parser(genParamDeserializer)

--- a/java-client/src/test/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearchTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearchTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.transport.instrumentation;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.json.JsonpUtils;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.sun.net.httpserver.HttpServer;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class OpenTelemetryForElasticsearchTest {
+    private static final String INDEX = "test-index";
+    private static final String DOC_ID = "1234567";
+    private static final String DOC_RESPONSE = "{\n" +
+            "  \"_index\": \"" + INDEX + "\",\n" +
+            "  \"_id\": \"" + DOC_ID + "\",\n" +
+            "  \"_version\": 1,\n" +
+            "  \"_seq_no\": 0,\n" +
+            "  \"_primary_term\": 1,\n" +
+            "  \"found\": true,\n" +
+            "  \"_source\": {\n" +
+            "    \"@timestamp\": \"2099-11-15T14:12:12\",\n" +
+            "    \"message\": \"GET /search HTTP/1.1 200 1070000\"\n" +
+            "  }\n" +
+            "}";
+    private static final String SEARCH_RESPONSE = "{\n" +
+            "  \"took\": 5,\n" +
+            "  \"timed_out\": false,\n" +
+            "  \"_shards\": {\n" +
+            "    \"total\": 1,\n" +
+            "    \"successful\": 1,\n" +
+            "    \"skipped\": 0,\n" +
+            "    \"failed\": 0\n" +
+            "  },\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\n" +
+            "      \"value\": 1,\n" +
+            "      \"relation\": \"eq\"\n" +
+            "    },\n" +
+            "    \"max_score\": 1.3862942,\n" +
+            "    \"hits\": [\n" +
+            "      {\n" +
+            "        \"_index\": \"" + INDEX + "\",\n" +
+            "        \"_id\": \"" + DOC_ID + "\",\n" +
+            "        \"_score\": 1.3862942,\n" +
+            "        \"_source\": {\n" +
+            "           \"@timestamp\": \"2099-11-15T14:12:12\",\n" +
+            "           \"message\": \"GET /search HTTP/1.1 200 1070000\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  }\n" +
+            "}";
+    public static final String DB_OPERATION = "db.operation";
+    public static final String URL_FULL = "url.full";
+    public static final String SERVER_ADDRESS = "server.address";
+    public static final String SERVER_PORT = "server.port";
+    // has been renamed in 1.21 from http.method - see https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.21.0
+    public static final String HTTP_REQUEST_METHOD = "http.request.method";
+    private static HttpServer httpServer;
+    private static MockSpanExporter spanExporter;
+    private static OpenTelemetry openTelemetry;
+    private static RestClient restClient;
+    private static RestClientTransport transport;
+    private static ElasticsearchClient client;
+    private static ElasticsearchAsyncClient asyncClient;
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        setupOTel();
+        setupHttpServer();
+        setupClient();
+    }
+
+    @AfterAll
+    public static void cleanUp() throws IOException {
+        httpServer.stop(0);
+        transport.close();
+    }
+
+    private static void setupClient() {
+        restClient =
+                RestClient.builder(new HttpHost(httpServer.getAddress().getAddress(), httpServer.getAddress().getPort())).build();
+
+        Instrumentation instrumentation = new OpenTelemetryForElasticsearch(openTelemetry, false);
+
+        transport = new RestClientTransport(restClient, new JacksonJsonpMapper(), null, instrumentation);
+
+        client = new ElasticsearchClient(transport);
+        asyncClient = new ElasticsearchAsyncClient(transport);
+    }
+
+    private static void setupHttpServer() throws IOException {
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+
+        // handler for GetRequest
+        httpServer.createContext("/" + INDEX + "/_doc/" + DOC_ID, exchange -> {
+            exchange.getResponseHeaders().set("X-Elastic-Product", "Elasticsearch");
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().write(DOC_RESPONSE.getBytes());
+            exchange.close();
+        });
+
+        // handler for SearchRequest
+        httpServer.createContext("/" + INDEX + "/_search", exchange -> {
+            exchange.getResponseHeaders().set("X-Elastic-Product", "Elasticsearch");
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().write(SEARCH_RESPONSE.getBytes());
+            exchange.close();
+        });
+
+        httpServer.start();
+    }
+
+    private static void setupOTel() {
+        Resource resource = Resource.getDefault()
+                .merge(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "es-api-test")));
+
+        spanExporter = new MockSpanExporter();
+
+        SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .setResource(resource)
+                .build();
+
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(sdkTracerProvider)
+                .build();
+    }
+
+    @BeforeEach
+    public void reset() {
+        spanExporter.reset();
+    }
+
+    @Test
+    public void testGetRequest() throws IOException, InterruptedException {
+        client.get(r -> r.index(INDEX).id(DOC_ID).refresh(true), Object.class);
+        Assertions.assertEquals(spanExporter.getSpans().size(), 1);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertEquals("get", span.getName());
+        Assertions.assertEquals("get", span.getAttributes().get(AttributeKey.stringKey(DB_OPERATION)));
+        Assertions.assertEquals("GET", span.getAttributes().get(AttributeKey.stringKey(HTTP_REQUEST_METHOD)));
+        Assertions.assertEquals("elasticsearch", span.getAttributes().get(SemanticAttributes.DB_SYSTEM));
+
+        String url = "http://" + httpServer.getAddress().getHostName() + ":" + httpServer.getAddress().getPort() +
+            "/" + INDEX + "/_doc/" + DOC_ID + "?refresh=true";
+        Assertions.assertEquals(url, span.getAttributes().get(AttributeKey.stringKey(URL_FULL)));
+        Assertions.assertEquals(httpServer.getAddress().getHostName(), span.getAttributes().get(AttributeKey.stringKey(SERVER_ADDRESS)));
+        Assertions.assertEquals(httpServer.getAddress().getPort(), span.getAttributes().get(AttributeKey.longKey(SERVER_PORT)));
+
+        // Path parts
+        Assertions.assertEquals(DOC_ID, span.getAttributes().get(AttributeKey.stringKey("db.elasticsearch.path_parts.id")));
+    }
+
+    @Test
+    public void testSearchRequest() throws IOException, InterruptedException {
+        // A client that will capture requests
+        ElasticsearchClient client = new ElasticsearchClient(new RestClientTransport(
+            restClient, this.client._jsonpMapper(), null, new OpenTelemetryForElasticsearch(openTelemetry, true))
+        );
+        SearchRequest req = SearchRequest.of(r -> r.index(INDEX).query(q -> q.term(t -> t.field("x").value("y"))));
+        String queryAsString = JsonpUtils.toJsonString(req, client._jsonpMapper());
+        client.search(req, Object.class);
+        Assertions.assertEquals(spanExporter.getSpans().size(), 1);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertEquals("search", span.getName());
+        Assertions.assertEquals(queryAsString, span.getAttributes().get(SemanticAttributes.DB_STATEMENT));
+    }
+
+    @Test
+    public void testAsyncSearchRequest() throws IOException, InterruptedException, TimeoutException, ExecutionException {
+        Query query = Query.of(q -> q.term(t -> t.field("x").value("y")));
+        Future future = asyncClient.search(r -> r.index(INDEX).query(query), Object.class);
+        future.get(2, TimeUnit.SECONDS);
+        spanExporter.awaitNumSpans(1, 2000);
+        Assertions.assertEquals(spanExporter.getSpans().size(), 1);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertEquals("search", span.getName());
+
+        // We're not capturing bodies by default
+        Assertions.assertNull(span.getAttributes().get(SemanticAttributes.DB_STATEMENT));
+    }
+
+    private static class MockSpanExporter implements SpanExporter {
+
+        private final List<SpanData> spans = new ArrayList();
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            this.spans.addAll(spans);
+            synchronized (this) {
+                notifyAll();
+            }
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            spans.clear();
+            return CompletableResultCode.ofSuccess();
+        }
+
+        public List<SpanData> getSpans() {
+            return spans;
+        }
+
+        public void reset() {
+            spans.clear();
+        }
+
+        public synchronized void awaitNumSpans(int num, long timeoutMillis) throws InterruptedException {
+            while(spans.size() < num){
+                wait(timeoutMillis);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport #588 to branch 8.10

Adds an instrumentation API with request & response lifecycle callbacks, and an implementation based on OpenTelemetry that is used by default.

To be able to implement the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/database/elasticsearch/#url-path-parts), this PR also adds a `pathParameters` method to `Endpoint` that provides access to the values in URL template placeholders.