### PR TITLE
Updated getting-started.asciidoc - Updated tag for delete index.

### DIFF
--- a/docs/getting-started.asciidoc
+++ b/docs/getting-started.asciidoc
@@ -158,7 +158,7 @@ include-tagged::{doc-tests-src}/usage/IndexingTest.java[single-doc-delete]
 
 ["source","java"]
 --------------------------------------------------
-include-tagged::{doc-tests-src}/usage/IndexingTest.java[create-products-index]
+include-tagged::{doc-tests-src}/usage/IndexingTest.java[delete-products-index]
 --------------------------------------------------
 
 


### PR DESCRIPTION
Delete index was showing create index code palette so replaced tag delete-products-index in the place of create-products-index.