### PR TITLE
Fix: Primitive type attribute for `primaryTerm` and `seqNo`

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/WriteResponseBase.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/WriteResponseBase.java
@@ -54,11 +54,11 @@ public abstract class WriteResponseBase implements JsonpSerializable {
 
 	private final String index;
 
-	private final long primaryTerm;
+	private final Long primaryTerm;
 
 	private final Result result;
 
-	private final long seqNo;
+	private final Long seqNo;
 
 	private final ShardStatistics shards;
 


### PR DESCRIPTION
## Short description
This PR fixes the error reported into issues #657 and #655 

## List of changes proposed in this pull request
- Changed `primaryTerm` and `seqNo` type from primitive `long` to `Long` as Java object class.
Since these two attributes could be `null` in some cases, the previous implementation did not allowed due to the primitive long type.