### PR TITLE
Otel docs updates

### DIFF
--- a/docs/setup/open-telemetry.asciidoc
+++ b/docs/setup/open-telemetry.asciidoc
@@ -5,7 +5,7 @@ You can use https://opentelemetry.io/[OpenTelemetry] to monitor the performance 
 The Java API Client comes with built-in OpenTelemetry instrumentation that emits https://www.elastic.co/guide/en/apm/guide/current/apm-distributed-tracing.html[distributed tracing spans] by default.
 With that, applications https://opentelemetry.io/docs/instrumentation/java/manual/[instrumented with OpenTelemetry] or running the https://opentelemetry.io/docs/instrumentation/java/automatic/[OpenTelemetry Java Agent] are inherently enriched with additional spans that contain insightful information about the execution of the {es} requests.
 
-The native instrumentation in the Java API Client follows the https://opentelemetry.io/docs/specs/semconv/database/elasticsearch/[OpenTelemetry Semantic Conventions for {es}]. In particular, the instrumentation in the client covers the logical {es} request layer, thus, creates a single span per request the service executes against the Java API Client. The following image shows a resulting trace in which three different {es} requests are executed, i.e. an `index`, `get` and a search `request`:
+The native instrumentation in the Java API Client follows the https://opentelemetry.io/docs/specs/semconv/database/elasticsearch/[OpenTelemetry Semantic Conventions for {es}]. In particular, the instrumentation in the client covers the logical layer of {es} requests. A single span per request is created that is processed by the service through the Java API Client. The following image shows a trace that records the handling of three different {es} requests: an `index`, `get` and a search `request`:
 
 [role="screenshot"]
 image::images/otel-waterfall-instrumented-without-http.jpg[alt="Distributed trace with {es} spans",align="center"]
@@ -24,6 +24,7 @@ The first node is unavailable and results in an HTTP error, while the retry to t
 
 [discrete]
 ==== Setup the OpenTelemetry instrumentation
+
 When using the https://opentelemetry.io/docs/instrumentation/java/manual[OpenTelemetry Java SDK manually] or using the https://opentelemetry.io/docs/instrumentation/java/automatic/[OpenTelemetry Java Agent], the Java API Client's OpenTelemetry instrumentation is enabled by default and uses the _globally_ registered OpenTelemetry SDK instance (i.e. `GlobalOpenTelemetry`). So, if you don't use a custom, local OpenTelemetry SDK instance, there is no explicit setup required to use the Java API Client's OpenTelemetry instrumentation.
 
 [discrete]
@@ -57,7 +58,7 @@ With this configuration option you can enable (default) or disable the built-in 
 [discrete]
 ===== Capture search request bodies
 
-Per default, the built-in OpenTelemetry instrumentation does not capture request bodies because of data privacy reasons. You can use this option to enable capturing of search queries from the the request bodies of {es} search requests in case you wish to capture this information, regardless.
+Per default, the built-in OpenTelemetry instrumentation does not capture request bodies due to data privacy considerations. You can use this option to enable capturing of search queries from the the request bodies of {es} search requests in case you wish to gather this information regardless.
 
 **Default:** `false`
 
@@ -68,6 +69,7 @@ Per default, the built-in OpenTelemetry instrumentation does not capture request
 
 [discrete]
 ==== Overhead
+
 The OpenTelemetry instrumentation (as any other monitoring approach) may come with a little overhead on CPU, memory and/or latency. The overhead may only occur when the instrumentation is enabled (default) and an OpenTelemetry SDK (or an OpenTelemetry Agent) is active in the target application. In case that either the instrumentation is disabled or no OpenTelemetry SDK (or OpenTelemetry Agent) is active with the target application, there is no monitoring overhead expected when using the client. 
 
 Even when the instrumentation is enabled and is being actively used (by an OpenTelemetry SDK), in the vast majority of cases the overhead is very small and negligible. In edge cases in which there is a noticable overhead the <<opentelemetry-config-enable,instrumentation can be explicitly disabled>> to eliminate any potential overhead effect of the instrumentation. 

--- a/docs/setup/open-telemetry.asciidoc
+++ b/docs/setup/open-telemetry.asciidoc
@@ -1,26 +1,26 @@
 [[opentelemetry]]
 === Using OpenTelemetry
 
-You can use https://opentelemetry.io/[OpenTelemetry] to monitor the performance and behavior of your Elasticsearch requests through the Java API Client.
+You can use https://opentelemetry.io/[OpenTelemetry] to monitor the performance and behavior of your {es} requests through the Java API Client.
 The Java API Client comes with built-in OpenTelemetry instrumentation that emits https://www.elastic.co/guide/en/apm/guide/current/apm-distributed-tracing.html[distributed tracing spans] by default.
-With that, applications https://opentelemetry.io/docs/instrumentation/java/manual/[instrumented with OpenTelemetry] or running the https://opentelemetry.io/docs/instrumentation/java/automatic/[OpenTelemetry Java Agent] are inherently enriched with additional spans that contain insightful information about the execution of the Elasticsearch requests. 
+With that, applications https://opentelemetry.io/docs/instrumentation/java/manual/[instrumented with OpenTelemetry] or running the https://opentelemetry.io/docs/instrumentation/java/automatic/[OpenTelemetry Java Agent] are inherently enriched with additional spans that contain insightful information about the execution of the {es} requests.
 
-The native instrumentation in the Java API Client follows the https://opentelemetry.io/docs/specs/semconv/database/elasticsearch/[OpenTelemetry Semantic Conventions for Elasticsearch]. In particular, the instrumentation in the client covers the logical Elasticsearch request layer, thus, creates a single span per request the service executes against the Java API Client. The following image shows a resulting trace in which three different Elasticsearch requests are executed, i.e. an `index`, `get` and a search `request`:
-
-[role="screenshot"]
-image::images/otel-waterfall-instrumented-without-http.jpg[alt="Distributed trace with Elasticsearch spans",align="center"]
-
-Usually, OpenTelemetry agents and auto-instrumentation modules come with instrumentation support for HTTP-level communication. In this case, in addition to the logical Elasticsearch client requests, spans will be captured for the physical HTTP requests emitted by the client. The following image shows a trace with both, Elasticsearch spans (in blue) and the corresponding HTTP-level spans (in red):
+The native instrumentation in the Java API Client follows the https://opentelemetry.io/docs/specs/semconv/database/elasticsearch/[OpenTelemetry Semantic Conventions for {es}]. In particular, the instrumentation in the client covers the logical {es} request layer, thus, creates a single span per request the service executes against the Java API Client. The following image shows a resulting trace in which three different {es} requests are executed, i.e. an `index`, `get` and a search `request`:
 
 [role="screenshot"]
-image::images/otel-waterfall-instrumented.jpg[alt="Distributed trace with Elasticsearch and HTTP spans",align="center"]
+image::images/otel-waterfall-instrumented-without-http.jpg[alt="Distributed trace with {es} spans",align="center"]
 
-Advanced Java API Client behavior such as nodes round-robin and request retries are revealed through the combination of logical Elasticsearch spans and the physical HTTP spans. The following example shows an `index` request in a scenario with two Elasticsearch nodes:
+Usually, OpenTelemetry agents and auto-instrumentation modules come with instrumentation support for HTTP-level communication. In this case, in addition to the logical {es} client requests, spans will be captured for the physical HTTP requests emitted by the client. The following image shows a trace with both, {es} spans (in blue) and the corresponding HTTP-level spans (in red):
+
+[role="screenshot"]
+image::images/otel-waterfall-instrumented.jpg[alt="Distributed trace with {es} and HTTP spans",align="center"]
+
+Advanced Java API Client behavior such as nodes round-robin and request retries are revealed through the combination of logical {es} spans and the physical HTTP spans. The following example shows an `index` request in a scenario with two {es} nodes:
 
 [role="screenshot"]
 image::images/otel-waterfall-retries.jpg[alt="Distributed trace with request retries",align="center"]
 
-The first node is unavailable and results in an HTTP error, while the retry to the second node succeeds. Both HTTP requests are subsumed by the logical Elasticsearch request span (in blue).
+The first node is unavailable and results in an HTTP error, while the retry to the second node succeeds. Both HTTP requests are subsumed by the logical {es} request span (in blue).
 
 [discrete]
 ==== Setup the OpenTelemetry instrumentation
@@ -57,7 +57,7 @@ With this configuration option you can enable (default) or disable the built-in 
 [discrete]
 ===== Capture search request bodies
 
-Per default, the built-in OpenTelemetry instrumentation does not capture request bodies because of data privacy reasons. You can use this option to enable capturing of search queries from the the request bodies of Elasticsearch search requests in case you wish to capture this information, regardless.
+Per default, the built-in OpenTelemetry instrumentation does not capture request bodies because of data privacy reasons. You can use this option to enable capturing of search queries from the the request bodies of {es} search requests in case you wish to capture this information, regardless.
 
 **Default:** `false`
 


### PR DESCRIPTION
@szabosteve kindly did a review of the docs I wrote to accompany my native OpenTelemetry implementation in the ES Ruby client. I used many of the docs from this repo to write that one, so I'm applying some of the changes here as well.

Here is the commit from the ruby repo: https://github.com/elastic/elasticsearch-ruby/pull/2179/commits/bb7b6123bc154355d5631b4bfb3c6c62955c6a0c 


cc @AlexanderWert 