### PR TITLE
Update rest-client version

### DIFF
--- a/java-client-serverless/build.gradle.kts
+++ b/java-client-serverless/build.gradle.kts
@@ -191,7 +191,7 @@ publishing {
 }
 
 dependencies {
-    val elasticsearchVersion = "8.9.0"
+    val elasticsearchVersion = "8.10.0"
     val jacksonVersion = "2.13.3"
     val openTelemetryVersion = "1.29.0"
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -187,7 +187,7 @@ publishing {
 dependencies {
     // Compile and test with the last 7.x version to make sure transition scenarios where
     // the Java API client coexists with a 7.x HLRC work fine
-    val elasticsearchVersion = "7.17.7"
+    val elasticsearchVersion = "8.10.0"
     val jacksonVersion = "2.13.3"
     val openTelemetryVersion = "1.29.0"
 

--- a/java-client/src/main/java/co/elastic/clients/transport/rest_client/SafeResponseConsumer.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest_client/SafeResponseConsumer.java
@@ -47,13 +47,10 @@ public class SafeResponseConsumer<T> implements HttpAsyncResponseConsumer<T> {
     /**
      * Same as {@code RequestOptions.DEFAULT} with a safe consumer factory
      */
-    public static final RequestOptions DEFAULT_REQUEST_OPTIONS;
-
-    static {
-        RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
-        builder.setHttpAsyncResponseConsumerFactory(DEFAULT_FACTORY);
-        DEFAULT_REQUEST_OPTIONS = builder.build();
-    }
+    public static final RequestOptions DEFAULT_REQUEST_OPTIONS = RequestOptions.DEFAULT
+            .toBuilder()
+            .setHttpAsyncResponseConsumerFactory(DEFAULT_FACTORY)
+            .build();
 
     public SafeResponseConsumer(HttpAsyncResponseConsumer<T> delegate) {
         this.delegate = delegate;


### PR DESCRIPTION
We used rest-client version 7.x for compilation in the early days of version 8. Time to update do a recent version.