### PR TITLE
[docs fix typo] getting-started.asciidoc

### DIFF
--- a/docs/getting-started.asciidoc
+++ b/docs/getting-started.asciidoc
@@ -158,7 +158,7 @@ include-tagged::{doc-tests-src}/usage/IndexingTest.java[single-doc-delete]
 
 ["source","java"]
 --------------------------------------------------
-include-tagged::{doc-tests-src}/usage/IndexingTest.java[create-products-index]
+include-tagged::{doc-tests-src}/usage/IndexingTest.java[delete-products-index]
 --------------------------------------------------
 
 


### PR DESCRIPTION
Fix typo in issue #687

Switch from 'create' to 'delete'.
Please feel free to point out any mistakes if there are any.
thanks!