### PR TITLE
Fix documentation error in getting-started.asciidoc

### DIFF
--- a/docs/getting-started.asciidoc
+++ b/docs/getting-started.asciidoc
@@ -158,7 +158,7 @@ include-tagged::{doc-tests-src}/usage/IndexingTest.java[single-doc-delete]
 
 ["source","java"]
 --------------------------------------------------
-include-tagged::{doc-tests-src}/usage/IndexingTest.java[create-products-index]
+include-tagged::{doc-tests-src}/usage/IndexingTest.java[delete-products-index]
 --------------------------------------------------
 
 


### PR DESCRIPTION
Corrected the code snippet labeled [create-products-index] to [delete-products-index] in getting-started.asciidoc. The original code incorrectly referred to creating an index instead of deleting it.