### PR TITLE
Fixed typo in docs

### DIFF
--- a/docs/getting-started.asciidoc
+++ b/docs/getting-started.asciidoc
@@ -158,7 +158,7 @@ include-tagged::{doc-tests-src}/usage/IndexingTest.java[single-doc-delete]
 
 ["source","java"]
 --------------------------------------------------
-include-tagged::{doc-tests-src}/usage/IndexingTest.java[create-products-index]
+include-tagged::{doc-tests-src}/usage/IndexingTest.java[delete-products-index]
 --------------------------------------------------
 
 


### PR DESCRIPTION
This [delete code snipped](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html#_deleting_an_index)  links to a create snippet instead. 