### PR TITLE
[DOCS] Adds compatibility matrix to docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ of the getting started documentation.
 Refer to the [Connecting section](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html#_connecting)
 of the getting started documentation.
 
+## Compatibility
+
+The Elasticsearch client is compatible with currently maintained Java versions.
+
+The Java client is forward compatible; meaning that the client supports
+communicating with greater or equal minor versions of Elasticsearch without
+breaking. It does not mean that the client automatically supports new features
+of newer Elasticsearch versions; it is only possible after a release of a new
+client version. For example, a 8.12 client version won't automatically support
+the new features of the 8.13 version of Elasticsearch, the 8.13 client version
+is required for that. Elasticsearch language clients are only backwards
+compatible with default distributions and without guarantees made.
+
+| Elasticsearch Version | Elasticsearch-Java Branch | Supported |
+| --------------------- | ------------------------- | --------- |
+| main                  | main                      |           |
+| 8.x                   | 8.x                       | 8.x       |
+| 7.x                   | 7.x                       | 7.17      |
+
 ## Usage
 
 - [Creating an index](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html#_creating_an_index)

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -20,7 +20,19 @@ provides strongly typed requests and responses for all {es} APIs.
 [discrete]
 === Elasticsearch server compatibility policy
 
-The {es} Java client is forward compatible; meaning that the client supports 
-communicating with greater or equal minor versions of {es}. {es} language 
-clients are only backwards compatible with default distributions and without 
-guarantees made.
+The {es} Java client is forward compatible; meaning that the client supports
+communicating with greater or equal minor versions of {es} without breaking. It
+does not mean that the client automatically supports new features of newer
+{es} versions; it is only possible after a release of a new client version. For
+example, a 8.12 client version won't automatically support the new features of
+the 8.13 version of {es}, the 8.13 client version is required for that. {es}
+language clients are only backwards compatible with default distributions and
+without guarantees made.
+
+|===
+| Elasticsearch Version | Elasticsearch-Java Branch | Supported
+
+| main                  | main                      | 
+| 8.x                   | 8.x                       | 8.x
+| 7.x                   | 7.x                       | 7.17
+|===


### PR DESCRIPTION
## Overview

This PR adds a compatibility matrix to the Introduction section of the Java book and the repo README.

### Preview

[Version compatibility](https://elasticsearch-java_bk_749.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-api-client/master/introduction.html#_elasticsearch_server_compatibility_policy)