### PR TITLE
Add misc improvements to the framework

### DIFF
--- a/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/ElasticsearchException.java
+++ b/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/ElasticsearchException.java
@@ -19,6 +19,10 @@
 
 package co.elastic.clients.elasticsearch._types;
 
+import co.elastic.clients.transport.http.TransportHttpClient;
+
+import javax.annotation.Nullable;
+
 /**
  * Exception thrown by API client methods when Elasticsearch could not accept or
  * process a request.
@@ -31,11 +35,18 @@ public class ElasticsearchException extends RuntimeException {
 
 	private final ErrorResponse response;
 	private final String endpointId;
+	@Nullable
+	private final TransportHttpClient.Response httpResponse;
 
-	public ElasticsearchException(String endpointId, ErrorResponse response) {
+	public ElasticsearchException(String endpointId, ErrorResponse response, @Nullable TransportHttpClient.Response httpResponse) {
 		super("[" + endpointId + "] failed: [" + response.error().type() + "] " + response.error().reason());
 		this.response = response;
 		this.endpointId = endpointId;
+		this.httpResponse = httpResponse;
+	}
+
+	public ElasticsearchException(String endpointId, ErrorResponse response) {
+		this(endpointId, response, null);
 	}
 
 	/**
@@ -65,5 +76,13 @@ public class ElasticsearchException extends RuntimeException {
 	 */
 	public int status() {
 		return this.response.status();
+	}
+
+	/**
+	 * The underlying http response, if available.
+	 */
+	@Nullable
+	public TransportHttpClient.Response httpResponse() {
+		return this.httpResponse;
 	}
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/ElasticsearchException.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/ElasticsearchException.java
@@ -19,6 +19,10 @@
 
 package co.elastic.clients.elasticsearch._types;
 
+import co.elastic.clients.transport.http.TransportHttpClient;
+
+import javax.annotation.Nullable;
+
 /**
  * Exception thrown by API client methods when Elasticsearch could not accept or
  * process a request.
@@ -31,11 +35,18 @@ public class ElasticsearchException extends RuntimeException {
 
 	private final ErrorResponse response;
 	private final String endpointId;
+	@Nullable
+	private final TransportHttpClient.Response httpResponse;
 
-	public ElasticsearchException(String endpointId, ErrorResponse response) {
+	public ElasticsearchException(String endpointId, ErrorResponse response, @Nullable TransportHttpClient.Response httpResponse) {
 		super("[" + endpointId + "] failed: [" + response.error().type() + "] " + response.error().reason());
 		this.response = response;
 		this.endpointId = endpointId;
+		this.httpResponse = httpResponse;
+	}
+
+	public ElasticsearchException(String endpointId, ErrorResponse response) {
+		this(endpointId, response, null);
 	}
 
 	/**
@@ -65,5 +76,13 @@ public class ElasticsearchException extends RuntimeException {
 	 */
 	public int status() {
 		return this.response.status();
+	}
+
+	/**
+	 * The underlying http response, if available.
+	 */
+	@Nullable
+	public TransportHttpClient.Response httpResponse() {
+		return this.httpResponse;
 	}
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/FieldValue.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/FieldValue.java
@@ -33,6 +33,7 @@ import co.elastic.clients.util.ObjectBuilder;
 import co.elastic.clients.util.ObjectBuilderBase;
 import co.elastic.clients.util.TaggedUnion;
 import co.elastic.clients.util.TaggedUnionUtils;
+import jakarta.json.Json;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
@@ -67,6 +68,10 @@ public class FieldValue implements TaggedUnion<FieldValue.Kind, Object>, JsonpSe
 
 	public static FieldValue of(JsonData value) {
 		return new FieldValue(Kind.Any, value);
+	}
+
+	public static FieldValue of(Object value) {
+		return of(JsonData.of(value));
 	}
 
 	public static final FieldValue NULL = new FieldValue(Kind.Null, null);

--- a/java-client/src/main/java/co/elastic/clients/json/BufferingJsonGenerator.java
+++ b/java-client/src/main/java/co/elastic/clients/json/BufferingJsonGenerator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+
+public interface BufferingJsonGenerator extends JsonGenerator {
+
+    /**
+     * Close this generator and return the buffered content.
+     */
+    JsonData getJsonData();
+
+    /**
+     * Close this generator and return the buffered content as a parser.
+     */
+    JsonParser getParser();
+
+    void copyValue(JsonParser parser);
+}

--- a/java-client/src/main/java/co/elastic/clients/json/BufferingJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/BufferingJsonpMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+/**
+ * A Jsonp mapper that has the additional capability of being able to buffer events.
+ */
+public interface BufferingJsonpMapper extends JsonpMapper {
+
+    BufferingJsonGenerator createBufferingGenerator();
+}

--- a/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonpMapper.java
@@ -45,6 +45,11 @@ public abstract class DelegatingJsonpMapper implements JsonpMapper {
     }
 
     @Override
+    public <T> T deserialize(JsonParser parser, Type type, JsonParser.Event event) {
+        return mapper.deserialize(parser, type, event);
+    }
+
+    @Override
     public <T> void serialize(T value, JsonGenerator generator) {
         mapper.serialize(value, generator);
     }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
@@ -110,7 +110,7 @@ public interface JsonpDeserializer<V> {
 
             @Override
             public T deserialize(JsonParser parser, JsonpMapper mapper, JsonParser.Event event) {
-                throw new UnsupportedOperationException();
+                return mapper.deserialize(parser, type, event);
             }
         };
     }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpMapper.java
@@ -55,6 +55,18 @@ public interface JsonpMapper {
     <T> T deserialize(JsonParser parser, Type type);
 
     /**
+     * Deserialize an object, given its class and the current event the parser is at.
+     */
+    default <T> T deserialize(JsonParser parser, Class<T> clazz, JsonParser.Event event) {
+        return deserialize(parser, (Type)clazz, event);
+    }
+
+    /**
+     * Deserialize an object, given its type and the current event the parser is at.
+     */
+    <T> T deserialize(JsonParser parser, Type type, JsonParser.Event event);
+
+    /**
      * Serialize an object.
      */
     <T> void serialize(T value, JsonGenerator generator);

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpMapperBase.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpMapperBase.java
@@ -61,23 +61,44 @@ public abstract class JsonpMapperBase implements JsonpMapper {
         return this;
     }
 
+    //----- Deserialization
+
     @Override
     public <T> T deserialize(JsonParser parser, Type type) {
-        JsonpDeserializer<T> deserializer = findDeserializer(type);
-        if (deserializer != null) {
-            return deserializer.deserialize(parser, this);
-        }
-
         @SuppressWarnings("unchecked")
-        T result = (T)getDefaultDeserializer(type).deserialize(parser, this);
+        T result = (T)getDeserializer(type).deserialize(parser, this);
         return result;
     }
 
+    @Override
+    public <T> T deserialize(JsonParser parser, Type type, JsonParser.Event event) {
+        @SuppressWarnings("unchecked")
+        T result = (T)getDeserializer(type).deserialize(parser, this, event);
+        return result;
+    }
+
+    private <T> JsonpDeserializer<T> getDeserializer(Type type) {
+        JsonpDeserializer<T> deserializer = findDeserializer(type);
+        if (deserializer != null) {
+            return deserializer;
+        }
+
+        @SuppressWarnings("unchecked")
+        JsonpDeserializer<T> result = getDefaultDeserializer(type);
+        return result;
+    }
+
+    /**
+     * Find a built-in deserializer for a given class, if any.
+     */
     @Nullable
     public static <T> JsonpDeserializer<T> findDeserializer(Class<T> clazz) {
         return findDeserializer((Type)clazz);
     }
 
+    /**
+     * Find a built-in deserializer for a given type, if any.
+     */
     @Nullable
     @SuppressWarnings("unchecked")
     public static <T> JsonpDeserializer<T> findDeserializer(Type type) {
@@ -100,6 +121,8 @@ public abstract class JsonpMapperBase implements JsonpMapper {
 
         return null;
     }
+
+    //----- Serialization
 
     @Nullable
     @SuppressWarnings("unchecked")

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
@@ -412,10 +412,10 @@ public class JsonpUtils {
         return dest;
     }
 
-    public static String toJsonString(JsonpSerializable value, JsonpMapper mapper) {
+    public static String toJsonString(Object value, JsonpMapper mapper) {
         StringWriter writer = new StringWriter();
         JsonGenerator generator = mapper.jsonProvider().createGenerator(writer);
-        value.serialize(generator, mapper);
+        mapper.serialize(value, generator);
         generator.close();
         return writer.toString();
     }

--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -342,7 +342,7 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
                     try (JsonParser parser = mapper.jsonProvider().createParser(content)) {
                         ErrorT error = errorDeserializer.deserialize(parser, mapper);
                         // TODO: have the endpoint provide the exception constructor
-                        throw new ElasticsearchException(endpoint.id(), (ErrorResponse) error);
+                        throw new ElasticsearchException(endpoint.id(), (ErrorResponse) error, clientResp);
                     }
                 } catch(JsonException | MissingRequiredPropertyException errorEx) {
                     // Could not decode exception, try the response type

--- a/java-client/src/main/java/co/elastic/clients/transport/Endpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/Endpoint.java
@@ -19,12 +19,15 @@
 
 package co.elastic.clients.transport;
 
+import co.elastic.clients.ApiClient;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.transport.endpoints.BinaryEndpoint;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * An endpoint links requests and responses to HTTP protocol encoding. It also defines the error response
@@ -117,5 +120,21 @@ public interface Endpoint<RequestT, ResponseT, ErrorT> {
           this::body,
           null
       );
+  }
+
+  default ResponseT call(RequestT request, Transport transport) throws IOException {
+      return transport.performRequest(request, this, null);
+  }
+
+  default ResponseT call(RequestT request, ApiClient<?, ?> client) throws IOException {
+    return client._transport().performRequest(request, this, null);
+  }
+
+  default CompletableFuture<ResponseT> callAsync(RequestT request, Transport transport) throws IOException {
+    return transport.performRequestAsync(request, this, null);
+  }
+
+  default CompletableFuture<ResponseT> callAsync(RequestT request, ApiClient<?, ?> client) throws IOException {
+    return client._transport().performRequestAsync(request, this, null);
   }
 }

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryDataResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/BinaryDataResponse.java
@@ -20,6 +20,7 @@
 package co.elastic.clients.transport.endpoints;
 
 import co.elastic.clients.util.BinaryData;
+import co.elastic.clients.util.ByteArrayBinaryData;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,5 +50,9 @@ public class BinaryDataResponse implements BinaryResponse {
 
     @Override
     public void close() throws IOException {
+    }
+
+    public static BinaryDataResponse of(byte[] data, String contentType) {
+        return new BinaryDataResponse(new ByteArrayBinaryData(data, contentType));
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/util/ByteArrayBinaryData.java
+++ b/java-client/src/main/java/co/elastic/clients/util/ByteArrayBinaryData.java
@@ -43,14 +43,14 @@ public class ByteArrayBinaryData implements BinaryData {
     private final int length;
     private final String contentType;
 
-    ByteArrayBinaryData(byte[] bytes, int offset, int length, String contentType) {
+    public ByteArrayBinaryData(byte[] bytes, int offset, int length, String contentType) {
         this.contentType = contentType;
         this.bytes = bytes;
         this.offset = offset;
         this.length = length;
     }
 
-    ByteArrayBinaryData(byte[] bytes, String contentType) {
+    public ByteArrayBinaryData(byte[] bytes, String contentType) {
         this.contentType = contentType;
         this.bytes = bytes;
         this.offset = 0;

--- a/java-client/src/test/java/co/elastic/clients/json/jackson/JacksonMapperTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/jackson/JacksonMapperTest.java
@@ -23,14 +23,19 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.testkit.ModelTestCase;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 public class JacksonMapperTest extends ModelTestCase {
 
@@ -71,5 +76,27 @@ public class JacksonMapperTest extends ModelTestCase {
                 return res;
             }
         }
+    }
+
+    @Test
+    public void testSingleValueAsList() {
+        JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+
+        String json = "{\"_index\":\"foo\",\"_id\":\"1\",\"_source\":{\"emp_no\":42,\"job_positions\":\"SWE\"}}";
+
+        Hit<EmpData> testDataHit = fromJson(json,
+            Hit.createHitDeserializer(JsonpDeserializer.of(EmpData.class)),
+            jsonpMapper
+        );
+        EmpData data = testDataHit.source();
+        assertEquals(42, data.empNo);
+        assertEquals(Collections.singletonList("SWE"), data.jobPositions);
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class EmpData {
+        public int empNo;
+        public List<String> jobPositions;
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/testkit/MockHttpClient.java
+++ b/java-client/src/test/java/co/elastic/clients/testkit/MockHttpClient.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.testkit;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransportBase;
+import co.elastic.clients.transport.TransportException;
+import co.elastic.clients.transport.TransportOptions;
+import co.elastic.clients.transport.http.TransportHttpClient;
+import co.elastic.clients.util.BinaryData;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockHttpClient implements TransportHttpClient {
+
+    private static final Response NotFound = new MockResponse(404, null);
+
+    Map<String, Response> responses = new ConcurrentHashMap<>();
+
+    public MockHttpClient add(String path, String contentType, byte[] data) {
+        responses.put(path, new MockResponse(200, BinaryData.of(data, contentType)));
+        return this;
+    }
+
+    public MockHttpClient add(String path, String contentType, String text) {
+        responses.put(path, new MockResponse(200, BinaryData.of(text.getBytes(StandardCharsets.UTF_8), contentType)));
+        return this;
+    }
+
+    public ElasticsearchClient client() {
+        return client(new ModelTestCase() {}.mapper);
+    }
+
+    public ElasticsearchClient client(JsonpMapper mapper) {
+        return new ElasticsearchClient(new ElasticsearchTransportBase(this, null, mapper) {
+            @Override
+            public void close() throws IOException {
+                super.close();
+            }
+        });
+    }
+
+
+    @Override
+    public Response performRequest(
+        String endpointId, @Nullable TransportHttpClient.Node node, Request request, TransportOptions option
+    ) throws IOException {
+        Response response = responses.get(request.path());
+
+        if (response == null) {
+            throw new TransportException(NotFound, "Not found", endpointId);
+        }
+
+        return response;
+    }
+
+    @Override
+    public CompletableFuture<Response> performRequestAsync(
+        String endpointId, @Nullable TransportHttpClient.Node node, Request request, TransportOptions options
+    ) {
+        CompletableFuture<Response> result = new CompletableFuture<>();
+        try {
+            Response response = performRequest(endpointId, node, request, options);
+            result.complete(response);
+        } catch (Exception e) {
+            result.completeExceptionally(e);
+        }
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    private static class MockResponse implements TransportHttpClient.Response {
+
+        private final int statusCode;
+        private final BinaryData body;
+        private final Map<String, String> headers;
+
+        MockResponse(int statusCode, BinaryData body) {
+            this.statusCode = statusCode;
+            this.headers = new HashMap<>();
+            this.body = body;
+
+            if (body != null) {
+                headers.put("content-type", body.contentType());
+            }
+            headers.put("x-elastic-product", "Elasticsearch");
+        }
+
+        @Override
+        public Node node() {
+            return null;
+        }
+
+        @Override
+        public int statusCode() {
+            return statusCode;
+        }
+
+        @Nullable
+        @Override
+        public String header(String name) {
+            return headers.get(name.toLowerCase());
+        }
+
+        @Override
+        public List<String> headers(String name) {
+            String header = header(name);
+            return header == null ? null : Collections.singletonList(header);
+        }
+
+        @Nullable
+        @Override
+        public BinaryData body() throws IOException {
+            return body;
+        }
+
+        @Nullable
+        @Override
+        public Object originalResponse() {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a number of improvements and bugfixes to the JSON and utility classes:

JSON framework:

* A new `BufferingJsonpMapper` allows the creation of `JsonGenerator` that store JSON events in a buffer that can be replayed. This is useful to efficiently create synthetic JSON documents.
* An additional `JsonpMapper.deserialize` method variant accepts the current JSON event. Fixes #741
* The Jackson implementation of `JsonpMapper` now enables the `ACCEPT_SINGLE_VALUE_AS_ARRAY` deserialization feature. This allows single values in a JSON stream to be considered as a single-value collection.

API & transport framework:

* `ElasticsearchException` now holds the low level http response, so that the application can inspect the details of the error.
* Endpoints now have a `call` methods, to make calling endpoints programmatically easier. This is for advanced use, as an applicaition will normally use the `ElasticsearchClient` that hides endpoint objects.
* A `BinaryDataResponse` can now easily be created from a byte array.

Test framework:

* The `ElasticsearchTestServer` now tries to contact an Elasticsearch server running on `http://elastic:changeme@localhost:9200` before spawning a container.
* A `MockHttpClient` has been added that allows writing integration-like tests without requiring a running server. This is an alternative to using `com.sun.net.httpserver.HttpServer` when we want to rest http response decoding but don't need to test the network layer.

