### PR TITLE
Update Jackson version

### DIFF
--- a/docs/getting-started.asciidoc
+++ b/docs/getting-started.asciidoc
@@ -23,7 +23,7 @@ show usage with Jackson.
 --------------------------------------------------
 dependencies {
     implementation 'co.elastic.clients:elasticsearch-java:{version}'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 --------------------------------------------------
 
@@ -47,7 +47,7 @@ dependencies:
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.3</version>
+      <version>2.17.0</version>
     </dependency>
 
   </dependencies>

--- a/docs/setup/installation.asciidoc
+++ b/docs/setup/installation.asciidoc
@@ -25,7 +25,7 @@ available at https://snapshots.elastic.co/maven/.
 --------------------------------------------------
 dependencies {
     implementation 'co.elastic.clients:elasticsearch-java:{version}'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 --------------------------------------------------
 
@@ -50,7 +50,7 @@ dependencies:
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.3</version>
+      <version>2.17.0</version>
     </dependency>
 
   </dependencies>

--- a/example-transports/build.gradle.kts
+++ b/example-transports/build.gradle.kts
@@ -33,7 +33,7 @@ java {
 
 
 dependencies {
-    val jacksonVersion = "2.13.3"
+    val jacksonVersion = "2.17.0"
 
     api("io.netty", "netty-codec-http", "4.1.93.Final")
 

--- a/java-client-serverless/build.gradle.kts
+++ b/java-client-serverless/build.gradle.kts
@@ -192,7 +192,7 @@ publishing {
 
 dependencies {
     val elasticsearchVersion = "8.10.0"
-    val jacksonVersion = "2.13.3"
+    val jacksonVersion = "2.17.0"
     val openTelemetryVersion = "1.29.0"
 
     // Apache 2.0

--- a/java-client-serverless/docs/getting-started.mdx
+++ b/java-client-serverless/docs/getting-started.mdx
@@ -27,7 +27,7 @@ You can add the Elasticsearch Serverless Java client to your Java project using 
 ```groovy
 dependencies {
     implementation 'co.elastic.clients:elasticsearch-java-serverless:1.0.0-20231031'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 ```
 
@@ -48,7 +48,7 @@ In the `pom.xml` of your project, add the following dependencies:
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.17.0</version>
         </dependency>
 
     </dependencies>

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -188,7 +188,7 @@ dependencies {
     // Compile and test with the last 7.x version to make sure transition scenarios where
     // the Java API client coexists with a 7.x HLRC work fine
     val elasticsearchVersion = "8.10.0"
-    val jacksonVersion = "2.13.3"
+    val jacksonVersion = "2.17.0"
     val openTelemetryVersion = "1.29.0"
 
     // Apache 2.0


### PR DESCRIPTION
Update to the latest Jackson version. It is still an optional dependency that users have to add to their project to use the `JacksonJsonpMapper`.