### PR TITLE
Add improvements to response _DESERIALIZER

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateIndexTemplateResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/SimulateIndexTemplateResponse.java
@@ -61,6 +61,6 @@ public class SimulateIndexTemplateResponse {
 	public static final SimulateIndexTemplateResponse _INSTANCE = new SimulateIndexTemplateResponse();
 
 	public static final JsonpDeserializer<SimulateIndexTemplateResponse> _DESERIALIZER = JsonpDeserializer
-			.fixedValue(SimulateIndexTemplateResponse._INSTANCE);
+			.emptyObject(SimulateIndexTemplateResponse._INSTANCE);
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ChangePasswordResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/ChangePasswordResponse.java
@@ -61,6 +61,6 @@ public class ChangePasswordResponse {
 	public static final ChangePasswordResponse _INSTANCE = new ChangePasswordResponse();
 
 	public static final JsonpDeserializer<ChangePasswordResponse> _DESERIALIZER = JsonpDeserializer
-			.fixedValue(ChangePasswordResponse._INSTANCE);
+			.emptyObject(ChangePasswordResponse._INSTANCE);
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/DisableUserResponse.java
@@ -60,6 +60,6 @@ public class DisableUserResponse {
 	public static final DisableUserResponse _INSTANCE = new DisableUserResponse();
 
 	public static final JsonpDeserializer<DisableUserResponse> _DESERIALIZER = JsonpDeserializer
-			.fixedValue(DisableUserResponse._INSTANCE);
+			.emptyObject(DisableUserResponse._INSTANCE);
 
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserResponse.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/security/EnableUserResponse.java
@@ -60,6 +60,6 @@ public class EnableUserResponse {
 	public static final EnableUserResponse _INSTANCE = new EnableUserResponse();
 
 	public static final JsonpDeserializer<EnableUserResponse> _DESERIALIZER = JsonpDeserializer
-			.fixedValue(EnableUserResponse._INSTANCE);
+			.emptyObject(EnableUserResponse._INSTANCE);
 
 }


### PR DESCRIPTION
This PR adds a number of enhancements to several response classes.

co.elastic.clients.elasticsearch.security:

- `DisableUserResponse`
- `EnableUserResponse`
- `ChangePasswordResponse`
  

co.elastic.clients.elasticsearch.indices:

- `SimulateIndexTemplateResponse`

For the response that returns an empty object, or has a possibility according to the server-side code, _DESERIALIZER should use `emptyObject(T)` from the JsonpDeserializer.

For more detailed specifications regarding this PR, please refer to https://github.com/elastic/elasticsearch-java/issues/718#issuecomment-2027988172.