### PR TITLE
Fix field_masking_span to span_field_masking

### DIFF
--- a/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
+++ b/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
@@ -38,7 +38,6 @@ import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Object;
-import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -164,7 +163,7 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 
 		SpanContaining("span_containing"),
 
-		FieldMaskingSpan("field_masking_span"),
+		SpanFieldMasking("span_field_masking"),
 
 		SpanFirst("span_first"),
 
@@ -976,21 +975,21 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 	}
 
 	/**
-	 * Is this variant instance of kind {@code field_masking_span}?
+	 * Is this variant instance of kind {@code span_field_masking}?
 	 */
-	public boolean isFieldMaskingSpan() {
-		return _kind == Kind.FieldMaskingSpan;
+	public boolean isSpanFieldMasking() {
+		return _kind == Kind.SpanFieldMasking;
 	}
 
 	/**
-	 * Get the {@code field_masking_span} variant value.
+	 * Get the {@code span_field_masking} variant value.
 	 *
 	 * @throws IllegalStateException
-	 *             if the current variant is not of the {@code field_masking_span}
+	 *             if the current variant is not of the {@code span_field_masking}
 	 *             kind.
 	 */
-	public SpanFieldMaskingQuery fieldMaskingSpan() {
-		return TaggedUnionUtils.get(this, Kind.FieldMaskingSpan);
+	public SpanFieldMaskingQuery spanFieldMasking() {
+		return TaggedUnionUtils.get(this, Kind.SpanFieldMasking);
 	}
 
 	/**
@@ -1742,15 +1741,15 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 			return this.spanContaining(fn.apply(new SpanContainingQuery.Builder()).build());
 		}
 
-		public ObjectBuilder<Query> fieldMaskingSpan(SpanFieldMaskingQuery v) {
-			this._kind = Kind.FieldMaskingSpan;
+		public ObjectBuilder<Query> spanFieldMasking(SpanFieldMaskingQuery v) {
+			this._kind = Kind.SpanFieldMasking;
 			this._value = v;
 			return this;
 		}
 
-		public ObjectBuilder<Query> fieldMaskingSpan(
+		public ObjectBuilder<Query> spanFieldMasking(
 				Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
-			return this.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+			return this.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		}
 
 		public ObjectBuilder<Query> spanFirst(SpanFirstQuery v) {
@@ -1973,7 +1972,7 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 		op.add(Builder::shape, ShapeQuery._DESERIALIZER, "shape");
 		op.add(Builder::simpleQueryString, SimpleQueryStringQuery._DESERIALIZER, "simple_query_string");
 		op.add(Builder::spanContaining, SpanContainingQuery._DESERIALIZER, "span_containing");
-		op.add(Builder::fieldMaskingSpan, SpanFieldMaskingQuery._DESERIALIZER, "field_masking_span");
+		op.add(Builder::spanFieldMasking, SpanFieldMaskingQuery._DESERIALIZER, "span_field_masking");
 		op.add(Builder::spanFirst, SpanFirstQuery._DESERIALIZER, "span_first");
 		op.add(Builder::spanMulti, SpanMultiTermQuery._DESERIALIZER, "span_multi");
 		op.add(Builder::spanNear, SpanNearQuery._DESERIALIZER, "span_near");

--- a/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/QueryBuilders.java
+++ b/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/QueryBuilders.java
@@ -770,21 +770,21 @@ public class QueryBuilders {
 	}
 
 	/**
-	 * Creates a builder for the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a builder for the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code Query} variant.
 	 */
-	public static SpanFieldMaskingQuery.Builder fieldMaskingSpan() {
+	public static SpanFieldMaskingQuery.Builder spanFieldMasking() {
 		return new SpanFieldMaskingQuery.Builder();
 	}
 
 	/**
-	 * Creates a Query of the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a Query of the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code Query} variant.
 	 */
-	public static Query fieldMaskingSpan(
+	public static Query spanFieldMasking(
 			Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
 		Query.Builder builder = new Query.Builder();
-		builder.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+		builder.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		return builder.build();
 	}
 

--- a/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanFieldMaskingQuery.java
+++ b/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanFieldMaskingQuery.java
@@ -28,9 +28,7 @@ import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
-import java.util.Objects;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 //----------------------------------------------------------------
 //       THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
@@ -80,7 +78,7 @@ public class SpanFieldMaskingQuery extends QueryBase implements SpanQueryVariant
 	 */
 	@Override
 	public SpanQuery.Kind _spanQueryKind() {
-		return SpanQuery.Kind.FieldMaskingSpan;
+		return SpanQuery.Kind.SpanFieldMasking;
 	}
 
 	/**
@@ -88,7 +86,7 @@ public class SpanFieldMaskingQuery extends QueryBase implements SpanQueryVariant
 	 */
 	@Override
 	public Query.Kind _queryKind() {
-		return Query.Kind.FieldMaskingSpan;
+		return Query.Kind.SpanFieldMasking;
 	}
 
 	/**

--- a/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
+++ b/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
@@ -34,9 +34,7 @@ import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Object;
-import java.util.Objects;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 //----------------------------------------------------------------
 //       THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
@@ -73,7 +71,7 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, Object>, JsonpSeri
 	public enum Kind implements JsonEnum {
 		SpanContaining("span_containing"),
 
-		FieldMaskingSpan("field_masking_span"),
+		SpanFieldMasking("span_field_masking"),
 
 		SpanFirst("span_first"),
 
@@ -155,21 +153,21 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, Object>, JsonpSeri
 	}
 
 	/**
-	 * Is this variant instance of kind {@code field_masking_span}?
+	 * Is this variant instance of kind {@code span_field_masking}?
 	 */
-	public boolean isFieldMaskingSpan() {
-		return _kind == Kind.FieldMaskingSpan;
+	public boolean isSpanFieldMasking() {
+		return _kind == Kind.SpanFieldMasking;
 	}
 
 	/**
-	 * Get the {@code field_masking_span} variant value.
+	 * Get the {@code span_field_masking} variant value.
 	 *
 	 * @throws IllegalStateException
-	 *             if the current variant is not of the {@code field_masking_span}
+	 *             if the current variant is not of the {@code span_field_masking}
 	 *             kind.
 	 */
-	public SpanFieldMaskingQuery fieldMaskingSpan() {
-		return TaggedUnionUtils.get(this, Kind.FieldMaskingSpan);
+	public SpanFieldMaskingQuery spanFieldMasking() {
+		return TaggedUnionUtils.get(this, Kind.SpanFieldMasking);
 	}
 
 	/**
@@ -347,15 +345,15 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, Object>, JsonpSeri
 			return this.spanContaining(fn.apply(new SpanContainingQuery.Builder()).build());
 		}
 
-		public ObjectBuilder<SpanQuery> fieldMaskingSpan(SpanFieldMaskingQuery v) {
-			this._kind = Kind.FieldMaskingSpan;
+		public ObjectBuilder<SpanQuery> spanFieldMasking(SpanFieldMaskingQuery v) {
+			this._kind = Kind.SpanFieldMasking;
 			this._value = v;
 			return this;
 		}
 
-		public ObjectBuilder<SpanQuery> fieldMaskingSpan(
+		public ObjectBuilder<SpanQuery> spanFieldMasking(
 				Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
-			return this.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+			return this.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		}
 
 		public ObjectBuilder<SpanQuery> spanFirst(SpanFirstQuery v) {
@@ -450,7 +448,7 @@ public class SpanQuery implements TaggedUnion<SpanQuery.Kind, Object>, JsonpSeri
 	protected static void setupSpanQueryDeserializer(ObjectDeserializer<Builder> op) {
 
 		op.add(Builder::spanContaining, SpanContainingQuery._DESERIALIZER, "span_containing");
-		op.add(Builder::fieldMaskingSpan, SpanFieldMaskingQuery._DESERIALIZER, "field_masking_span");
+		op.add(Builder::spanFieldMasking, SpanFieldMaskingQuery._DESERIALIZER, "span_field_masking");
 		op.add(Builder::spanFirst, SpanFirstQuery._DESERIALIZER, "span_first");
 		op.add(Builder::spanGap, SpanGapQuery._DESERIALIZER, "span_gap");
 		op.add(Builder::spanMulti, SpanMultiTermQuery._DESERIALIZER, "span_multi");

--- a/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQueryBuilders.java
+++ b/java-client-serverless/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQueryBuilders.java
@@ -64,21 +64,21 @@ public class SpanQueryBuilders {
 	}
 
 	/**
-	 * Creates a builder for the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a builder for the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code SpanQuery} variant.
 	 */
-	public static SpanFieldMaskingQuery.Builder fieldMaskingSpan() {
+	public static SpanFieldMaskingQuery.Builder spanFieldMasking() {
 		return new SpanFieldMaskingQuery.Builder();
 	}
 
 	/**
-	 * Creates a SpanQuery of the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a SpanQuery of the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code SpanQuery} variant.
 	 */
-	public static SpanQuery fieldMaskingSpan(
+	public static SpanQuery spanFieldMasking(
 			Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
 		SpanQuery.Builder builder = new SpanQuery.Builder();
-		builder.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+		builder.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		return builder.build();
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/Query.java
@@ -38,7 +38,6 @@ import co.elastic.clients.util.TaggedUnionUtils;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.Object;
-import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -164,7 +163,7 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 
 		SpanContaining("span_containing"),
 
-		FieldMaskingSpan("field_masking_span"),
+		SpanFieldMasking("span_field_masking"),
 
 		SpanFirst("span_first"),
 
@@ -976,21 +975,21 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 	}
 
 	/**
-	 * Is this variant instance of kind {@code field_masking_span}?
+	 * Is this variant instance of kind {@code span_field_masking}?
 	 */
-	public boolean isFieldMaskingSpan() {
-		return _kind == Kind.FieldMaskingSpan;
+	public boolean isSpanFieldMasking() {
+		return _kind == Kind.SpanFieldMasking;
 	}
 
 	/**
-	 * Get the {@code field_masking_span} variant value.
+	 * Get the {@code span_field_masking} variant value.
 	 *
 	 * @throws IllegalStateException
-	 *             if the current variant is not of the {@code field_masking_span}
+	 *             if the current variant is not of the {@code span_field_masking}
 	 *             kind.
 	 */
-	public SpanFieldMaskingQuery fieldMaskingSpan() {
-		return TaggedUnionUtils.get(this, Kind.FieldMaskingSpan);
+	public SpanFieldMaskingQuery spanFieldMasking() {
+		return TaggedUnionUtils.get(this, Kind.SpanFieldMasking);
 	}
 
 	/**
@@ -1742,15 +1741,15 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 			return this.spanContaining(fn.apply(new SpanContainingQuery.Builder()).build());
 		}
 
-		public ObjectBuilder<Query> fieldMaskingSpan(SpanFieldMaskingQuery v) {
-			this._kind = Kind.FieldMaskingSpan;
+		public ObjectBuilder<Query> spanFieldMasking(SpanFieldMaskingQuery v) {
+			this._kind = Kind.SpanFieldMasking;
 			this._value = v;
 			return this;
 		}
 
-		public ObjectBuilder<Query> fieldMaskingSpan(
+		public ObjectBuilder<Query> spanFieldMasking(
 				Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
-			return this.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+			return this.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		}
 
 		public ObjectBuilder<Query> spanFirst(SpanFirstQuery v) {
@@ -1973,7 +1972,7 @@ public class Query implements OpenTaggedUnion<Query.Kind, Object>, AggregationVa
 		op.add(Builder::shape, ShapeQuery._DESERIALIZER, "shape");
 		op.add(Builder::simpleQueryString, SimpleQueryStringQuery._DESERIALIZER, "simple_query_string");
 		op.add(Builder::spanContaining, SpanContainingQuery._DESERIALIZER, "span_containing");
-		op.add(Builder::fieldMaskingSpan, SpanFieldMaskingQuery._DESERIALIZER, "field_masking_span");
+		op.add(Builder::spanFieldMasking, SpanFieldMaskingQuery._DESERIALIZER, "span_field_masking");
 		op.add(Builder::spanFirst, SpanFirstQuery._DESERIALIZER, "span_first");
 		op.add(Builder::spanMulti, SpanMultiTermQuery._DESERIALIZER, "span_multi");
 		op.add(Builder::spanNear, SpanNearQuery._DESERIALIZER, "span_near");

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/QueryBuilders.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/QueryBuilders.java
@@ -770,21 +770,21 @@ public class QueryBuilders {
 	}
 
 	/**
-	 * Creates a builder for the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a builder for the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code Query} variant.
 	 */
-	public static SpanFieldMaskingQuery.Builder fieldMaskingSpan() {
+	public static SpanFieldMaskingQuery.Builder spanFieldMasking() {
 		return new SpanFieldMaskingQuery.Builder();
 	}
 
 	/**
-	 * Creates a Query of the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a Query of the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code Query} variant.
 	 */
-	public static Query fieldMaskingSpan(
+	public static Query spanFieldMasking(
 			Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
 		Query.Builder builder = new Query.Builder();
-		builder.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+		builder.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		return builder.build();
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanFieldMaskingQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanFieldMaskingQuery.java
@@ -28,9 +28,7 @@ import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import jakarta.json.stream.JsonGenerator;
 import java.lang.String;
-import java.util.Objects;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 //----------------------------------------------------------------
 //       THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
@@ -88,7 +86,7 @@ public class SpanFieldMaskingQuery extends QueryBase implements SpanQueryVariant
 	 */
 	@Override
 	public Query.Kind _queryKind() {
-		return Query.Kind.FieldMaskingSpan;
+		return Query.Kind.SpanFieldMasking;
 	}
 
 	/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanFieldMaskingQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanFieldMaskingQuery.java
@@ -80,7 +80,7 @@ public class SpanFieldMaskingQuery extends QueryBase implements SpanQueryVariant
 	 */
 	@Override
 	public SpanQuery.Kind _spanQueryKind() {
-		return SpanQuery.Kind.FieldMaskingSpan;
+		return SpanQuery.Kind.SpanFieldMasking;
 	}
 
 	/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
@@ -74,7 +74,7 @@ public class SpanQuery implements OpenTaggedUnion<SpanQuery.Kind, Object>, Jsonp
 	public enum Kind implements JsonEnum {
 		SpanContaining("span_containing"),
 
-		FieldMaskingSpan("field_masking_span"),
+		SpanFieldMasking("span_field_masking"),
 
 		SpanFirst("span_first"),
 
@@ -163,8 +163,8 @@ public class SpanQuery implements OpenTaggedUnion<SpanQuery.Kind, Object>, Jsonp
 	/**
 	 * Is this variant instance of kind {@code field_masking_span}?
 	 */
-	public boolean isFieldMaskingSpan() {
-		return _kind == Kind.FieldMaskingSpan;
+	public boolean isSpanFieldMasking() {
+		return _kind == Kind.SpanFieldMasking;
 	}
 
 	/**
@@ -174,8 +174,8 @@ public class SpanQuery implements OpenTaggedUnion<SpanQuery.Kind, Object>, Jsonp
 	 *             if the current variant is not of the {@code field_masking_span}
 	 *             kind.
 	 */
-	public SpanFieldMaskingQuery fieldMaskingSpan() {
-		return TaggedUnionUtils.get(this, Kind.FieldMaskingSpan);
+	public SpanFieldMaskingQuery spanFieldMasking() {
+		return TaggedUnionUtils.get(this, Kind.SpanFieldMasking);
 	}
 
 	/**
@@ -383,15 +383,15 @@ public class SpanQuery implements OpenTaggedUnion<SpanQuery.Kind, Object>, Jsonp
 			return this.spanContaining(fn.apply(new SpanContainingQuery.Builder()).build());
 		}
 
-		public ObjectBuilder<SpanQuery> fieldMaskingSpan(SpanFieldMaskingQuery v) {
-			this._kind = Kind.FieldMaskingSpan;
+		public ObjectBuilder<SpanQuery> spanFieldMasking(SpanFieldMaskingQuery v) {
+			this._kind = Kind.SpanFieldMasking;
 			this._value = v;
 			return this;
 		}
 
-		public ObjectBuilder<SpanQuery> fieldMaskingSpan(
+		public ObjectBuilder<SpanQuery> spanFieldMasking(
 				Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
-			return this.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+			return this.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		}
 
 		public ObjectBuilder<SpanQuery> spanFirst(SpanFirstQuery v) {
@@ -502,7 +502,7 @@ public class SpanQuery implements OpenTaggedUnion<SpanQuery.Kind, Object>, Jsonp
 	protected static void setupSpanQueryDeserializer(ObjectDeserializer<Builder> op) {
 
 		op.add(Builder::spanContaining, SpanContainingQuery._DESERIALIZER, "span_containing");
-		op.add(Builder::fieldMaskingSpan, SpanFieldMaskingQuery._DESERIALIZER, "field_masking_span");
+		op.add(Builder::spanFieldMasking, SpanFieldMaskingQuery._DESERIALIZER, "field_masking_span");
 		op.add(Builder::spanFirst, SpanFirstQuery._DESERIALIZER, "span_first");
 		op.add(Builder::spanGap, SpanGapQuery._DESERIALIZER, "span_gap");
 		op.add(Builder::spanMulti, SpanMultiTermQuery._DESERIALIZER, "span_multi");

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQuery.java
@@ -161,17 +161,17 @@ public class SpanQuery implements OpenTaggedUnion<SpanQuery.Kind, Object>, Jsonp
 	}
 
 	/**
-	 * Is this variant instance of kind {@code field_masking_span}?
+	 * Is this variant instance of kind {@code span_field_masking}?
 	 */
 	public boolean isSpanFieldMasking() {
 		return _kind == Kind.SpanFieldMasking;
 	}
 
 	/**
-	 * Get the {@code field_masking_span} variant value.
+	 * Get the {@code span_field_masking} variant value.
 	 *
 	 * @throws IllegalStateException
-	 *             if the current variant is not of the {@code field_masking_span}
+	 *             if the current variant is not of the {@code span_field_masking}
 	 *             kind.
 	 */
 	public SpanFieldMaskingQuery spanFieldMasking() {
@@ -502,7 +502,7 @@ public class SpanQuery implements OpenTaggedUnion<SpanQuery.Kind, Object>, Jsonp
 	protected static void setupSpanQueryDeserializer(ObjectDeserializer<Builder> op) {
 
 		op.add(Builder::spanContaining, SpanContainingQuery._DESERIALIZER, "span_containing");
-		op.add(Builder::spanFieldMasking, SpanFieldMaskingQuery._DESERIALIZER, "field_masking_span");
+		op.add(Builder::spanFieldMasking, SpanFieldMaskingQuery._DESERIALIZER, "span_field_masking");
 		op.add(Builder::spanFirst, SpanFirstQuery._DESERIALIZER, "span_first");
 		op.add(Builder::spanGap, SpanGapQuery._DESERIALIZER, "span_gap");
 		op.add(Builder::spanMulti, SpanMultiTermQuery._DESERIALIZER, "span_multi");

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQueryBuilders.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQueryBuilders.java
@@ -67,7 +67,7 @@ public class SpanQueryBuilders {
 	 * Creates a builder for the {@link SpanFieldMaskingQuery field_masking_span}
 	 * {@code SpanQuery} variant.
 	 */
-	public static SpanFieldMaskingQuery.Builder fieldMaskingSpan() {
+	public static SpanFieldMaskingQuery.Builder spanFieldMasking() {
 		return new SpanFieldMaskingQuery.Builder();
 	}
 
@@ -75,10 +75,10 @@ public class SpanQueryBuilders {
 	 * Creates a SpanQuery of the {@link SpanFieldMaskingQuery field_masking_span}
 	 * {@code SpanQuery} variant.
 	 */
-	public static SpanQuery fieldMaskingSpan(
+	public static SpanQuery spanFieldMasking(
 			Function<SpanFieldMaskingQuery.Builder, ObjectBuilder<SpanFieldMaskingQuery>> fn) {
 		SpanQuery.Builder builder = new SpanQuery.Builder();
-		builder.fieldMaskingSpan(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
+		builder.spanFieldMasking(fn.apply(new SpanFieldMaskingQuery.Builder()).build());
 		return builder.build();
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQueryBuilders.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/SpanQueryBuilders.java
@@ -64,7 +64,7 @@ public class SpanQueryBuilders {
 	}
 
 	/**
-	 * Creates a builder for the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a builder for the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code SpanQuery} variant.
 	 */
 	public static SpanFieldMaskingQuery.Builder spanFieldMasking() {
@@ -72,7 +72,7 @@ public class SpanQueryBuilders {
 	}
 
 	/**
-	 * Creates a SpanQuery of the {@link SpanFieldMaskingQuery field_masking_span}
+	 * Creates a SpanQuery of the {@link SpanFieldMaskingQuery span_field_masking}
 	 * {@code SpanQuery} variant.
 	 */
 	public static SpanQuery spanFieldMasking(


### PR DESCRIPTION
`field_masking_span` has been deprecated since ES8.0 in favor of `span_field_masking.` Ref: https://github.com/elastic/elasticsearch/pull/74718/files 

This change is not reflected in Java API causing exception in ES >= 8.0:
`deprecated fields not supported here but got [field_masking_span] which has been replaced with [span_field_masking]`

The following PR fix but also refactor `FieldMaskingSpan*` classes into `SpanFieldMasking*` classes probably causing some API breaks 