### PR TITLE
FIxes from spec 2597

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/Aggregate.java
@@ -82,7 +82,7 @@ public class Aggregate implements OpenTaggedUnion<Aggregate.Kind, Object>, Jsonp
 
 		Avg("avg"),
 
-		BoxPlot("box_plot"),
+		Boxplot("boxplot"),
 
 		BucketMetricValue("bucket_metric_value"),
 
@@ -328,20 +328,20 @@ public class Aggregate implements OpenTaggedUnion<Aggregate.Kind, Object>, Jsonp
 	}
 
 	/**
-	 * Is this variant instance of kind {@code box_plot}?
+	 * Is this variant instance of kind {@code boxplot}?
 	 */
-	public boolean isBoxPlot() {
-		return _kind == Kind.BoxPlot;
+	public boolean isBoxplot() {
+		return _kind == Kind.Boxplot;
 	}
 
 	/**
-	 * Get the {@code box_plot} variant value.
+	 * Get the {@code boxplot} variant value.
 	 *
 	 * @throws IllegalStateException
-	 *             if the current variant is not of the {@code box_plot} kind.
+	 *             if the current variant is not of the {@code boxplot} kind.
 	 */
-	public BoxPlotAggregate boxPlot() {
-		return TaggedUnionUtils.get(this, Kind.BoxPlot);
+	public BoxPlotAggregate boxplot() {
+		return TaggedUnionUtils.get(this, Kind.Boxplot);
 	}
 
 	/**
@@ -1540,15 +1540,15 @@ public class Aggregate implements OpenTaggedUnion<Aggregate.Kind, Object>, Jsonp
 			return this.avg(fn.apply(new AvgAggregate.Builder()).build());
 		}
 
-		public ObjectBuilder<Aggregate> boxPlot(BoxPlotAggregate v) {
-			this._kind = Kind.BoxPlot;
+		public ObjectBuilder<Aggregate> boxplot(BoxPlotAggregate v) {
+			this._kind = Kind.Boxplot;
 			this._value = v;
 			return this;
 		}
 
-		public ObjectBuilder<Aggregate> boxPlot(
+		public ObjectBuilder<Aggregate> boxplot(
 				Function<BoxPlotAggregate.Builder, ObjectBuilder<BoxPlotAggregate>> fn) {
-			return this.boxPlot(fn.apply(new BoxPlotAggregate.Builder()).build());
+			return this.boxplot(fn.apply(new BoxPlotAggregate.Builder()).build());
 		}
 
 		public ObjectBuilder<Aggregate> bucketMetricValue(BucketMetricValueAggregate v) {
@@ -2285,7 +2285,7 @@ public class Aggregate implements OpenTaggedUnion<Aggregate.Kind, Object>, Jsonp
 		deserializers.put("adjacency_matrix", AdjacencyMatrixAggregate._DESERIALIZER);
 		deserializers.put("auto_date_histogram", AutoDateHistogramAggregate._DESERIALIZER);
 		deserializers.put("avg", AvgAggregate._DESERIALIZER);
-		deserializers.put("box_plot", BoxPlotAggregate._DESERIALIZER);
+		deserializers.put("boxplot", BoxPlotAggregate._DESERIALIZER);
 		deserializers.put("bucket_metric_value", BucketMetricValueAggregate._DESERIALIZER);
 		deserializers.put("cardinality", CardinalityAggregate._DESERIALIZER);
 		deserializers.put("children", ChildrenAggregate._DESERIALIZER);

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/AggregateBuilders.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/AggregateBuilders.java
@@ -100,20 +100,20 @@ public class AggregateBuilders {
 	}
 
 	/**
-	 * Creates a builder for the {@link BoxPlotAggregate box_plot} {@code Aggregate}
+	 * Creates a builder for the {@link BoxPlotAggregate boxplot} {@code Aggregate}
 	 * variant.
 	 */
-	public static BoxPlotAggregate.Builder boxPlot() {
+	public static BoxPlotAggregate.Builder boxplot() {
 		return new BoxPlotAggregate.Builder();
 	}
 
 	/**
-	 * Creates a Aggregate of the {@link BoxPlotAggregate box_plot}
-	 * {@code Aggregate} variant.
+	 * Creates a Aggregate of the {@link BoxPlotAggregate boxplot} {@code Aggregate}
+	 * variant.
 	 */
-	public static Aggregate boxPlot(Function<BoxPlotAggregate.Builder, ObjectBuilder<BoxPlotAggregate>> fn) {
+	public static Aggregate boxplot(Function<BoxPlotAggregate.Builder, ObjectBuilder<BoxPlotAggregate>> fn) {
 		Aggregate.Builder builder = new Aggregate.Builder();
-		builder.boxPlot(fn.apply(new BoxPlotAggregate.Builder()).build());
+		builder.boxplot(fn.apply(new BoxPlotAggregate.Builder()).build());
 		return builder.build();
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/BoxPlotAggregate.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/BoxPlotAggregate.java
@@ -124,7 +124,7 @@ public class BoxPlotAggregate extends AggregateBase implements AggregateVariant 
 	 */
 	@Override
 	public Aggregate.Kind _aggregateKind() {
-		return Aggregate.Kind.BoxPlot;
+		return Aggregate.Kind.Boxplot;
 	}
 
 	/**

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/TermsBucketBase.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/aggregations/TermsBucketBase.java
@@ -57,31 +57,31 @@ import javax.annotation.Nullable;
 
 public abstract class TermsBucketBase extends MultiBucketBase {
 	@Nullable
-	private final Long docCountError;
+	private final Long docCountErrorUpperBound;
 
 	// ---------------------------------------------------------------------------------------------
 
 	protected TermsBucketBase(AbstractBuilder<?> builder) {
 		super(builder);
 
-		this.docCountError = builder.docCountError;
+		this.docCountErrorUpperBound = builder.docCountErrorUpperBound;
 
 	}
 
 	/**
-	 * API name: {@code doc_count_error}
+	 * API name: {@code doc_count_error_upper_bound}
 	 */
 	@Nullable
-	public final Long docCountError() {
-		return this.docCountError;
+	public final Long docCountErrorUpperBound() {
+		return this.docCountErrorUpperBound;
 	}
 
 	protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
 		super.serializeInternal(generator, mapper);
-		if (this.docCountError != null) {
-			generator.writeKey("doc_count_error");
-			generator.write(this.docCountError);
+		if (this.docCountErrorUpperBound != null) {
+			generator.writeKey("doc_count_error_upper_bound");
+			generator.write(this.docCountErrorUpperBound);
 
 		}
 
@@ -91,13 +91,13 @@ public abstract class TermsBucketBase extends MultiBucketBase {
 			extends
 				MultiBucketBase.AbstractBuilder<BuilderT> {
 		@Nullable
-		private Long docCountError;
+		private Long docCountErrorUpperBound;
 
 		/**
-		 * API name: {@code doc_count_error}
+		 * API name: {@code doc_count_error_upper_bound}
 		 */
-		public final BuilderT docCountError(@Nullable Long value) {
-			this.docCountError = value;
+		public final BuilderT docCountErrorUpperBound(@Nullable Long value) {
+			this.docCountErrorUpperBound = value;
 			return self();
 		}
 
@@ -107,7 +107,8 @@ public abstract class TermsBucketBase extends MultiBucketBase {
 	protected static <BuilderT extends AbstractBuilder<BuilderT>> void setupTermsBucketBaseDeserializer(
 			ObjectDeserializer<BuilderT> op) {
 		MultiBucketBase.setupMultiBucketBaseDeserializer(op);
-		op.add(AbstractBuilder::docCountError, JsonpDeserializer.longDeserializer(), "doc_count_error");
+		op.add(AbstractBuilder::docCountErrorUpperBound, JsonpDeserializer.longDeserializer(),
+				"doc_count_error_upper_bound");
 
 	}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/mtermvectors/MultiTermVectorsOperation.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/mtermvectors/MultiTermVectorsOperation.java
@@ -66,6 +66,7 @@ import javax.annotation.Nullable;
  */
 @JsonpDeserializable
 public class MultiTermVectorsOperation implements JsonpSerializable {
+	@Nullable
 	private final String id;
 
 	@Nullable
@@ -107,7 +108,7 @@ public class MultiTermVectorsOperation implements JsonpSerializable {
 
 	private MultiTermVectorsOperation(Builder builder) {
 
-		this.id = ApiTypeHelper.requireNonNull(builder.id, this, "id");
+		this.id = builder.id;
 		this.index = builder.index;
 		this.doc = builder.doc;
 		this.fields = ApiTypeHelper.unmodifiable(builder.fields);
@@ -128,10 +129,11 @@ public class MultiTermVectorsOperation implements JsonpSerializable {
 	}
 
 	/**
-	 * Required - The ID of the document.
+	 * The ID of the document.
 	 * <p>
 	 * API name: {@code _id}
 	 */
+	@Nullable
 	public final String id() {
 		return this.id;
 	}
@@ -271,9 +273,11 @@ public class MultiTermVectorsOperation implements JsonpSerializable {
 
 	protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
-		generator.writeKey("_id");
-		generator.write(this.id);
+		if (this.id != null) {
+			generator.writeKey("_id");
+			generator.write(this.id);
 
+		}
 		if (this.index != null) {
 			generator.writeKey("_index");
 			generator.write(this.index);
@@ -355,6 +359,7 @@ public class MultiTermVectorsOperation implements JsonpSerializable {
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>
 			implements
 				ObjectBuilder<MultiTermVectorsOperation> {
+		@Nullable
 		private String id;
 
 		@Nullable
@@ -394,11 +399,11 @@ public class MultiTermVectorsOperation implements JsonpSerializable {
 		private VersionType versionType;
 
 		/**
-		 * Required - The ID of the document.
+		 * The ID of the document.
 		 * <p>
 		 * API name: {@code _id}
 		 */
-		public final Builder id(String value) {
+		public final Builder id(@Nullable String value) {
 			this.id = value;
 			return this;
 		}

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/doc-files/api-spec.html
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/doc-files/api-spec.html
@@ -2720,10 +2720,10 @@
         if (hash.length > 1) {
             hash = hash.substring(1);
         }
-        window.location = "https://github.com/elastic/elasticsearch-specification/tree/b1f91f1a0ae5d09da92cf0859b0ff92410cdb6e3/specification/" + (paths[hash] || "");
+        window.location = "https://github.com/elastic/elasticsearch-specification/tree/6fdb2c26900d426863c4f01c165f932bb7633d20/specification/" + (paths[hash] || "");
     </script>
 </head>
 <body>
-    Please see the <a href="https://github.com/elastic/elasticsearch-specification/tree/b1f91f1a0ae5d09da92cf0859b0ff92410cdb6e3/specification/">Elasticsearch API specification</a>.
+    Please see the <a href="https://github.com/elastic/elasticsearch-specification/tree/6fdb2c26900d426863c4f01c165f932bb7633d20/specification/">Elasticsearch API specification</a>.
 </body>
 </html>

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/info/NodeInfoScript.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/info/NodeInfoScript.java
@@ -61,6 +61,7 @@ import javax.annotation.Nullable;
 public class NodeInfoScript implements JsonpSerializable {
 	private final String allowedTypes;
 
+	@Nullable
 	private final String disableMaxCompilationsRate;
 
 	// ---------------------------------------------------------------------------------------------
@@ -68,8 +69,7 @@ public class NodeInfoScript implements JsonpSerializable {
 	private NodeInfoScript(Builder builder) {
 
 		this.allowedTypes = ApiTypeHelper.requireNonNull(builder.allowedTypes, this, "allowedTypes");
-		this.disableMaxCompilationsRate = ApiTypeHelper.requireNonNull(builder.disableMaxCompilationsRate, this,
-				"disableMaxCompilationsRate");
+		this.disableMaxCompilationsRate = builder.disableMaxCompilationsRate;
 
 	}
 
@@ -85,8 +85,9 @@ public class NodeInfoScript implements JsonpSerializable {
 	}
 
 	/**
-	 * Required - API name: {@code disable_max_compilations_rate}
+	 * API name: {@code disable_max_compilations_rate}
 	 */
+	@Nullable
 	public final String disableMaxCompilationsRate() {
 		return this.disableMaxCompilationsRate;
 	}
@@ -105,8 +106,11 @@ public class NodeInfoScript implements JsonpSerializable {
 		generator.writeKey("allowed_types");
 		generator.write(this.allowedTypes);
 
-		generator.writeKey("disable_max_compilations_rate");
-		generator.write(this.disableMaxCompilationsRate);
+		if (this.disableMaxCompilationsRate != null) {
+			generator.writeKey("disable_max_compilations_rate");
+			generator.write(this.disableMaxCompilationsRate);
+
+		}
 
 	}
 
@@ -124,6 +128,7 @@ public class NodeInfoScript implements JsonpSerializable {
 	public static class Builder extends WithJsonObjectBuilderBase<Builder> implements ObjectBuilder<NodeInfoScript> {
 		private String allowedTypes;
 
+		@Nullable
 		private String disableMaxCompilationsRate;
 
 		/**
@@ -135,9 +140,9 @@ public class NodeInfoScript implements JsonpSerializable {
 		}
 
 		/**
-		 * Required - API name: {@code disable_max_compilations_rate}
+		 * API name: {@code disable_max_compilations_rate}
 		 */
-		public final Builder disableMaxCompilationsRate(String value) {
+		public final Builder disableMaxCompilationsRate(@Nullable String value) {
 			this.disableMaxCompilationsRate = value;
 			return this;
 		}

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/info/NodeInfoSettings.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/info/NodeInfoSettings.java
@@ -74,6 +74,7 @@ public class NodeInfoSettings implements JsonpSerializable {
 	@Nullable
 	private final NodeInfoAction action;
 
+	@Nullable
 	private final NodeInfoClient client;
 
 	private final NodeInfoSettingsHttp http;
@@ -108,7 +109,7 @@ public class NodeInfoSettings implements JsonpSerializable {
 		this.repositories = builder.repositories;
 		this.discovery = builder.discovery;
 		this.action = builder.action;
-		this.client = ApiTypeHelper.requireNonNull(builder.client, this, "client");
+		this.client = builder.client;
 		this.http = ApiTypeHelper.requireNonNull(builder.http, this, "http");
 		this.bootstrap = builder.bootstrap;
 		this.transport = ApiTypeHelper.requireNonNull(builder.transport, this, "transport");
@@ -171,8 +172,9 @@ public class NodeInfoSettings implements JsonpSerializable {
 	}
 
 	/**
-	 * Required - API name: {@code client}
+	 * API name: {@code client}
 	 */
+	@Nullable
 	public final NodeInfoClient client() {
 		return this.client;
 	}
@@ -276,9 +278,11 @@ public class NodeInfoSettings implements JsonpSerializable {
 			this.action.serialize(generator, mapper);
 
 		}
-		generator.writeKey("client");
-		this.client.serialize(generator, mapper);
+		if (this.client != null) {
+			generator.writeKey("client");
+			this.client.serialize(generator, mapper);
 
+		}
 		generator.writeKey("http");
 		this.http.serialize(generator, mapper);
 
@@ -346,6 +350,7 @@ public class NodeInfoSettings implements JsonpSerializable {
 		@Nullable
 		private NodeInfoAction action;
 
+		@Nullable
 		private NodeInfoClient client;
 
 		private NodeInfoSettingsHttp http;
@@ -463,15 +468,15 @@ public class NodeInfoSettings implements JsonpSerializable {
 		}
 
 		/**
-		 * Required - API name: {@code client}
+		 * API name: {@code client}
 		 */
-		public final Builder client(NodeInfoClient value) {
+		public final Builder client(@Nullable NodeInfoClient value) {
 			this.client = value;
 			return this;
 		}
 
 		/**
-		 * Required - API name: {@code client}
+		 * API name: {@code client}
 		 */
 		public final Builder client(Function<NodeInfoClient.Builder, ObjectBuilder<NodeInfoClient>> fn) {
 			return this.client(fn.apply(new NodeInfoClient.Builder()).build());

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/info/NodeInfoSettingsNetwork.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/nodes/info/NodeInfoSettingsNetwork.java
@@ -26,7 +26,6 @@ import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.ObjectBuilderDeserializer;
 import co.elastic.clients.json.ObjectDeserializer;
-import co.elastic.clients.util.ApiTypeHelper;
 import co.elastic.clients.util.ObjectBuilder;
 import co.elastic.clients.util.WithJsonObjectBuilderBase;
 import jakarta.json.stream.JsonGenerator;
@@ -60,13 +59,14 @@ import javax.annotation.Nullable;
  */
 @JsonpDeserializable
 public class NodeInfoSettingsNetwork implements JsonpSerializable {
+	@Nullable
 	private final String host;
 
 	// ---------------------------------------------------------------------------------------------
 
 	private NodeInfoSettingsNetwork(Builder builder) {
 
-		this.host = ApiTypeHelper.requireNonNull(builder.host, this, "host");
+		this.host = builder.host;
 
 	}
 
@@ -75,8 +75,9 @@ public class NodeInfoSettingsNetwork implements JsonpSerializable {
 	}
 
 	/**
-	 * Required - API name: {@code host}
+	 * API name: {@code host}
 	 */
+	@Nullable
 	public final String host() {
 		return this.host;
 	}
@@ -92,8 +93,11 @@ public class NodeInfoSettingsNetwork implements JsonpSerializable {
 
 	protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
 
-		generator.writeKey("host");
-		generator.write(this.host);
+		if (this.host != null) {
+			generator.writeKey("host");
+			generator.write(this.host);
+
+		}
 
 	}
 
@@ -111,12 +115,13 @@ public class NodeInfoSettingsNetwork implements JsonpSerializable {
 	public static class Builder extends WithJsonObjectBuilderBase<Builder>
 			implements
 				ObjectBuilder<NodeInfoSettingsNetwork> {
+		@Nullable
 		private String host;
 
 		/**
-		 * Required - API name: {@code host}
+		 * API name: {@code host}
 		 */
-		public final Builder host(String value) {
+		public final Builder host(@Nullable String value) {
 			this.host = value;
 			return this;
 		}


### PR DESCRIPTION
Update to the generated code from the latest specification and code-generator. This includes https://github.com/elastic/elasticsearch-specification/pull/2597, which fixes https://github.com/elastic/elasticsearch-java/issues/558, fixes https://github.com/elastic/elasticsearch-java/issues/716, fixes https://github.com/elastic/elasticsearch-java/issues/783, fixes https://github.com/elastic/elasticsearch-java/issues/785, fixes https://github.com/elastic/elasticsearch-java/issues/707.