### PR TITLE
Refine BooleanEndpoint so that 4xx status codes other than  404 are considered as errors

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/BooleanEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/BooleanEndpoint.java
@@ -41,7 +41,8 @@ public class BooleanEndpoint<RequestT> extends EndpointBase<RequestT, BooleanRes
 
     @Override
     public boolean isError(int statusCode) {
-        return statusCode >= 500;
+        // 404 indicates a 'false' result.
+        return statusCode != 404 && super.isError(statusCode);
     }
 
     public boolean getResult(int statusCode) {


### PR DESCRIPTION
4xx errors other than 404 should throw an exception and not return a valid `false` result.

Fixes #850 