### PR TITLE
Addressing bulk ingester stuck threads

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/BulkIngester.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_helpers/bulk/BulkIngester.java
@@ -363,6 +363,9 @@ public class BulkIngester<Context> implements AutoCloseable {
             if (!canAddOperation()) {
                 flush();
             }
+            else {
+                addCondition.signalIfReady();
+            }
         });
     }
 

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/_helpers/bulk/BulkIngesterTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/_helpers/bulk/BulkIngesterTest.java
@@ -28,6 +28,7 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import co.elastic.clients.elasticsearch.end_to_end.RequestTest;
+import co.elastic.clients.elasticsearch.indices.IndicesStatsResponse;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.json.SimpleJsonpMapper;
@@ -154,6 +155,58 @@ class BulkIngesterTest extends Assertions {
         assertEquals(expectedRequests, ingester.requestCount());
         assertEquals(expectedRequests, listener.requests.get());
         assertEquals(expectedRequests, transport.requestsStarted.get());
+    }
+
+    @Test
+    public void multiThreadStressTest() throws InterruptedException, IOException {
+
+        Runtime runtime = Runtime.getRuntime();
+        long usedMemoryBefore = runtime.totalMemory() - runtime.freeMemory();
+        System.out.println("Used Memory before: " + usedMemoryBefore);
+
+
+        String index = "bulk-ingester-stress-test";
+        ElasticsearchClient client = ElasticsearchTestServer.global().client();
+
+        // DISCLAIMER: this configuration is highly inefficient and only used here to showcase an extreme
+        // situation where the number of adding threads greatly exceeds the number of concurrent requests
+        // handled by the ingester. It's strongly recommended to always tweak maxConcurrentRequests accordingly.
+        BulkIngester<?> ingester = BulkIngester.of(b -> b
+                .client(client)
+                .globalSettings(s -> s.index(index))
+                .flushInterval(5, TimeUnit.SECONDS)
+        );
+
+        RequestTest.AppData appData = new RequestTest.AppData();
+        appData.setIntValue(42);
+        appData.setMsg("Some message");
+
+        ExecutorService executor = Executors.newFixedThreadPool(50);
+
+        for (int i = 0; i < 100000; i++) {
+            int ii = i;
+            Runnable thread = () -> {
+                int finalI = ii;
+                ingester.add(_1 -> _1
+                    .create(_2 -> _2
+                        .id(String.valueOf(finalI))
+                        .document(appData)
+                    ));
+            };
+            executor.submit(thread);
+        }
+
+        executor.awaitTermination(10,TimeUnit.SECONDS);
+        ingester.close();
+
+        client.indices().refresh();
+
+        IndicesStatsResponse indexStats = client.indices().stats(g -> g.index(index));
+
+        assertTrue(indexStats.indices().get(index).primaries().docs().count()==100000);
+
+        long usedMemoryAfter = runtime.totalMemory() - runtime.freeMemory();
+        System.out.println("Memory increased:" + (usedMemoryAfter-usedMemoryBefore));
     }
 
     @Test

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/_helpers/bulk/BulkIngesterTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/_helpers/bulk/BulkIngesterTest.java
@@ -160,11 +160,6 @@ class BulkIngesterTest extends Assertions {
     @Test
     public void multiThreadStressTest() throws InterruptedException, IOException {
 
-        Runtime runtime = Runtime.getRuntime();
-        long usedMemoryBefore = runtime.totalMemory() - runtime.freeMemory();
-        System.out.println("Used Memory before: " + usedMemoryBefore);
-
-
         String index = "bulk-ingester-stress-test";
         ElasticsearchClient client = ElasticsearchTestServer.global().client();
 
@@ -204,9 +199,6 @@ class BulkIngesterTest extends Assertions {
         IndicesStatsResponse indexStats = client.indices().stats(g -> g.index(index));
 
         assertTrue(indexStats.indices().get(index).primaries().docs().count()==100000);
-
-        long usedMemoryAfter = runtime.totalMemory() - runtime.freeMemory();
-        System.out.println("Memory increased:" + (usedMemoryAfter-usedMemoryBefore));
     }
 
     @Test


### PR DESCRIPTION
When the Bulk Ingester is configured in such a way that the number of external threads performing the `add` operation is much higher than  `maxConcurrentRequests` (usually more than 50 to 1), after completing all of the request but the last one, the Bulk Ingester stops. 

If there's a flusher thread, it will keep adding requests one by one, and sending them one by one: this is because ~95% of the external threads will get stuck while adding, and a `send` operation will only free one of those at a time. 

Replacing `signal()` with `signalAll()` to free the threads is a possible solution, but it's also expensive and considering this is an extreme case it would affect performances for every other case; so the chosen solution is to add another `signal()` after a successful `add` operation, assuring that stuck threads will be released quickly if the condition that got them stuck no longer applies. 

Should fix #651