### PR TITLE
Allow requests to be serialized as nothing instead of an empty object

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -26,3 +26,33 @@ spec:
         devtools-team: {}
         everyone:
           access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-java-release
+  description: Buildkite release pipeline for elasticsearch-java
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-java-release
+
+spec:
+  type: buildkite-pipeline
+  owner: group:devtools-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Elasticsearch Java Client
+      name: elasticsearch-java-release
+    spec:
+      repository: elastic/elasticsearch-java
+      pipeline_file: ".buildkite/release.yml"
+      teams:
+        devtools-team:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY

--- a/examples/esql-article/src/main/java/co/elastic/clients/esql/article/EsqlArticle.java
+++ b/examples/esql-article/src/main/java/co/elastic/clients/esql/article/EsqlArticle.java
@@ -38,7 +38,6 @@ import org.apache.http.HttpHost;
 import org.apache.http.message.BasicHeader;
 import org.elasticsearch.client.RestClient;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -46,20 +45,17 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 public class EsqlArticle {
 
     public static void main(String[] args) throws IOException, SQLException, InterruptedException {
-        
+
         String serverUrl = System.getenv("server-url");
         String apiKey = System.getenv("api-key");
         String booksUrl = "https://raw.githubusercontent" +

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
@@ -66,7 +66,7 @@ import javax.annotation.Nullable;
 
 /**
  * Count search results. Get the number of documents matching a query.
- *
+ * 
  * @see <a href="../doc-files/api-spec.html#_global.count.Request">API
  *      specification</a>
  */

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/CountRequest.java
@@ -66,7 +66,7 @@ import javax.annotation.Nullable;
 
 /**
  * Count search results. Get the number of documents matching a query.
- * 
+ *
  * @see <a href="../doc-files/api-spec.html#_global.count.Request">API
  *      specification</a>
  */
@@ -760,5 +760,6 @@ public class CountRequest extends RequestBase implements JsonpSerializable {
 				}
 				return params;
 
-			}, SimpleEndpoint.emptyMap(), true, CountResponse._DESERIALIZER);
+			}, SimpleEndpoint.emptyMap(), SimpleEndpoint.nonEmptyJsonObject(SimpleEndpoint.returnSelf()),
+			CountResponse._DESERIALIZER);
 }

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExplainRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/ExplainRequest.java
@@ -704,7 +704,8 @@ public class ExplainRequest extends RequestBase implements JsonpSerializable {
 				}
 				return params;
 
-			}, SimpleEndpoint.emptyMap(), true, ExplainResponse._DESERIALIZER);
+			}, SimpleEndpoint.emptyMap(), SimpleEndpoint.nonEmptyJsonObject(SimpleEndpoint.returnSelf()),
+			ExplainResponse._DESERIALIZER);
 
 	/**
 	 * Create an "{@code explain}" endpoint.

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ValidateQueryRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/indices/ValidateQueryRequest.java
@@ -698,5 +698,6 @@ public class ValidateQueryRequest extends RequestBase implements JsonpSerializab
 				}
 				return params;
 
-			}, SimpleEndpoint.emptyMap(), true, ValidateQueryResponse._DESERIALIZER);
+			}, SimpleEndpoint.emptyMap(), SimpleEndpoint.nonEmptyJsonObject(SimpleEndpoint.returnSelf()),
+			ValidateQueryResponse._DESERIALIZER);
 }

--- a/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonGenerator.java
+++ b/java-client/src/main/java/co/elastic/clients/json/DelegatingJsonGenerator.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * A JSON generator that delegates to another generator.
+ * <p>
+ * All convenience methods that accept a property name and an event (value, start object, start array) call separately
+ * {@link #writeKey(String)} and the same method without the key name. This is meant to facilitate overloading
+ * of methods.
+ */
+public class DelegatingJsonGenerator implements JsonGenerator {
+    protected final JsonGenerator generator;
+
+    public DelegatingJsonGenerator(JsonGenerator generator) {
+        this.generator = generator;
+    }
+
+    public JsonGenerator unwrap() {
+        return generator;
+    };
+
+    @Override
+    public JsonGenerator writeStartObject() {
+        generator.writeStartObject();
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeKey(String s) {
+        generator.writeKey(s);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeStartArray() {
+        generator.writeStartArray();
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeEnd() {
+        generator.writeEnd();
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(JsonValue jsonValue) {
+        generator.write(jsonValue);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(String s) {
+        generator.write(s);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(BigDecimal bigDecimal) {
+        generator.write(bigDecimal);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(BigInteger bigInteger) {
+        generator.write(bigInteger);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(int i) {
+        generator.write(i);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(long l) {
+        generator.write(l);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(double v) {
+        generator.write(v);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator write(boolean b) {
+        generator.write(b);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNull() {
+        generator.writeNull();
+        return this;
+    }
+
+    @Override
+    public void close() {
+        generator.close();
+    }
+
+    @Override
+    public void flush() {
+        generator.flush();
+    }
+
+    //----- Convenience key+value methods
+
+    @Override
+    public final JsonGenerator writeStartObject(String s) {
+        this.writeKey(s);
+        return this.writeStartObject();
+    }
+
+    @Override
+    public final JsonGenerator writeStartArray(String s) {
+        this.writeKey(s);
+        return this.writeStartArray();
+    }
+
+    @Override
+    public final JsonGenerator write(String s, JsonValue jsonValue) {
+        this.writeKey(s);
+        return this.write(jsonValue);
+    }
+
+    @Override
+    public final JsonGenerator write(String s, String s1) {
+        this.writeKey(s);
+        return this.write(s1);
+    }
+
+    @Override
+    public final JsonGenerator write(String s, BigInteger bigInteger) {
+        this.writeKey(s);
+        return this.write(bigInteger);
+    }
+
+    @Override
+    public final JsonGenerator write(String s, BigDecimal bigDecimal) {
+        this.writeKey(s);
+        return this.write(bigDecimal);
+    }
+
+    @Override
+    public final JsonGenerator write(String s, int i) {
+        this.writeKey(s);
+        return this.write(i);
+    }
+
+    @Override
+    public final JsonGenerator write(String s, long l) {
+        this.writeKey(s);
+        return this.write(l);
+    }
+
+    @Override
+    public final JsonGenerator write(String s, double v) {
+        this.writeKey(s);
+        return this.write(v);
+    }
+
+    @Override
+    public final JsonGenerator write(String s, boolean b) {
+        this.writeKey(s);
+        return this.write(b);
+    }
+
+    @Override
+    public final JsonGenerator writeNull(String s) {
+        this.writeKey(s);
+        return this.writeNull();
+    }
+}

--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -21,7 +21,6 @@ package co.elastic.clients.transport;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
-import co.elastic.clients.json.DelegatingJsonGenerator;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.NdJsonpSerializable;

--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -259,8 +259,21 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
                 NoCopyByteArrayOutputStream baos = new NoCopyByteArrayOutputStream();
                 JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
                 mapper.serialize(body, generator);
-                generator.close();
+
+                // Some generators (e.g. Parsson) throw an exception if we close a generator
+                // that hasn't received any event. In that case, we ignore the exception
+                RuntimeException closeException = null;
+                try {
+                    generator.close();
+                } catch (RuntimeException e) {
+                    closeException = e;
+                }
+
                 if (baos.size() > 0) {
+                    if (closeException != null) {
+                        // We got some content and close failed
+                        throw closeException;
+                    }
                     bodyBuffers = Collections.singletonList(baos.asByteBuffer());
                     headers = JsonContentTypeHeaders;
                 }

--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -21,6 +21,7 @@ package co.elastic.clients.transport;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
+import co.elastic.clients.json.DelegatingJsonGenerator;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.NdJsonpSerializable;
@@ -260,8 +261,10 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
                 JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
                 mapper.serialize(body, generator);
                 generator.close();
-                bodyBuffers = Collections.singletonList(baos.asByteBuffer());
-                headers = JsonContentTypeHeaders;
+                if (baos.size() > 0) {
+                    bodyBuffers = Collections.singletonList(baos.asByteBuffer());
+                    headers = JsonContentTypeHeaders;
+                }
             }
         }
 

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/EndpointBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/EndpointBase.java
@@ -83,7 +83,7 @@ public class EndpointBase<RequestT, ResponseT> implements Endpoint<RequestT, Res
     private static final class NonEmptySerializable implements JsonpSerializable {
         private final Object value;
 
-        public NonEmptySerializable(Object value) {
+        NonEmptySerializable(Object value) {
             this.value = value;
         }
 

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/EndpointBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/EndpointBase.java
@@ -21,14 +21,11 @@ package co.elastic.clients.transport.endpoints;
 
 import co.elastic.clients.elasticsearch._types.ErrorCause;
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
-import co.elastic.clients.json.DelegatingJsonGenerator;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpDeserializerBase;
 import co.elastic.clients.json.JsonpMapper;
-import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.JsonpUtils;
 import co.elastic.clients.transport.Endpoint;
-import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
 import javax.annotation.Nullable;
@@ -68,60 +65,8 @@ public class EndpointBase<RequestT, ResponseT> implements Endpoint<RequestT, Res
      * that the input and output generic parameters are different, making it suitable for use in a wider range of use cases.
      */
     @SuppressWarnings("unchecked")
-    static <T, U> Function<T, U> returnSelf() {
+    public static <T, U> Function<T, U> returnSelf() {
         return (Function<T, U>) RETURN_SELF;
-    }
-
-    /**
-     * Wraps a function's result with a serializable object that will serialize to nothing if the wrapped
-     * object's serialization has no property, i.e. it will either produce an empty object or nothing.
-     */
-    public static <T, U extends JsonpSerializable> Function<T, Object> nonEmptyJsonObject(Function<T, U> getter) {
-        return (x -> x == null ? null : new NonEmptySerializable(getter.apply(x)));
-    }
-
-    private static final class NonEmptySerializable implements JsonpSerializable {
-        private final Object value;
-
-        NonEmptySerializable(Object value) {
-            this.value = value;
-        }
-
-        @Override
-        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
-            // Track the first property to start the top-level object, and end it if needed in close()
-            JsonGenerator filter = new DelegatingJsonGenerator(generator) {
-                boolean gotKey = false;
-
-                @Override
-                public JsonGenerator writeStartObject() {
-                    if (gotKey) {
-                        super.writeStartObject();
-                    }
-                    return this;
-                }
-
-                @Override
-                public JsonGenerator writeKey(String s) {
-                    if (!gotKey) {
-                        gotKey = true;
-                        super.writeStartObject();
-                    }
-                    super.writeKey(s);
-                    return this;
-                }
-
-                @Override
-                public JsonGenerator writeEnd() {
-                    if (gotKey) {
-                        super.writeEnd();
-                    }
-                    return this;
-                }
-            };
-
-            mapper.serialize(value, filter);
-        }
     }
 
     protected final String id;

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
@@ -52,7 +52,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
         Function<RequestT, Map<String, String>> pathParameters,
         Function<RequestT, Map<String, String>> queryParameters,
         Function<RequestT, Map<String, String>> headers,
-        boolean hasResponseBody,
+        boolean hasRequestBody,
         JsonpDeserializer<ResponseT> responseParser
     ) {
         this(
@@ -62,7 +62,7 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
             pathParameters,
             queryParameters,
             headers,
-            hasResponseBody ? returnSelf() : returnNull(),
+            hasRequestBody ? returnSelf() : returnNull(),
             responseParser
         );
     }

--- a/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/endpoints/SimpleEndpoint.java
@@ -20,8 +20,12 @@
 package co.elastic.clients.transport.endpoints;
 
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
+import co.elastic.clients.json.DelegatingJsonGenerator;
 import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.transport.JsonEndpoint;
+import jakarta.json.stream.JsonGenerator;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -85,5 +89,57 @@ public class SimpleEndpoint<RequestT, ResponseT> extends EndpointBase<RequestT, 
             body,
             newResponseParser
         );
+    }
+
+    /**
+     * Wraps a function's result with a serializable object that will serialize to nothing if the wrapped
+     * object's serialization has no property, i.e. it will either produce an empty object or nothing.
+     */
+    public static <T, U extends JsonpSerializable> Function<T, Object> nonEmptyJsonObject(Function<T, U> getter) {
+        return (x -> x == null ? null : new NonEmptySerializable(getter.apply(x)));
+    }
+
+    private static final class NonEmptySerializable implements JsonpSerializable {
+        private final Object value;
+
+        NonEmptySerializable(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+            // Track the first property to start the top-level object, and end it if needed in close()
+            JsonGenerator filter = new DelegatingJsonGenerator(generator) {
+                boolean gotKey = false;
+
+                @Override
+                public JsonGenerator writeStartObject() {
+                    if (gotKey) {
+                        super.writeStartObject();
+                    }
+                    return this;
+                }
+
+                @Override
+                public JsonGenerator writeKey(String s) {
+                    if (!gotKey) {
+                        gotKey = true;
+                        super.writeStartObject();
+                    }
+                    super.writeKey(s);
+                    return this;
+                }
+
+                @Override
+                public JsonGenerator writeEnd() {
+                    if (gotKey) {
+                        super.writeEnd();
+                    }
+                    return this;
+                }
+            };
+
+            mapper.serialize(value, filter);
+        }
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/transport/TransportTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/TransportTest.java
@@ -20,41 +20,26 @@
 package co.elastic.clients.transport;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.json.JsonpMapper;
-import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.testkit.MockHttpClient;
-import co.elastic.clients.transport.endpoints.EndpointBase;
-import co.elastic.clients.transport.endpoints.SimpleEndpoint;
-import co.elastic.clients.transport.endpoints.SimpleJsonEndpoint;
 import co.elastic.clients.transport.http.RepeatableBodyResponse;
-import co.elastic.clients.transport.http.TransportHttpClient;
 import co.elastic.clients.transport.rest_client.RestClientOptions;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import co.elastic.clients.util.BinaryData;
 import com.sun.net.httpserver.HttpServer;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.stream.JsonGenerator;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 import static co.elastic.clients.util.ContentType.APPLICATION_JSON;
 
@@ -165,62 +150,6 @@ public class TransportTest extends Assertions {
                 }
                 br.close();
             assertEquals("definitely not json",sb.toString());
-        }
-    }
-
-    @Test
-    public void testNoBodyForEmptyObject() throws Exception {
-
-        List<TransportHttpClient.Request> requests = new ArrayList<>();
-
-        MockHttpClient httpClient = new MockHttpClient() {
-            @Override
-            public Response performRequest(String endpointId, @Nullable Node node, Request request, TransportOptions option) throws IOException {
-                requests.add(request);
-                return super.performRequest(endpointId, node, request, option);
-            }
-        };
-
-        httpClient.add("/test", "text/plain", "hello");
-
-        JsonpMapper mapper = new JacksonJsonpMapper();
-        ElasticsearchTransport transport = new ElasticsearchTransportBase(httpClient, null, mapper) {};
-
-        // Send empty object = true (legacy constructor)
-        SimpleEndpoint<TestValue, Void> endpoint = new SimpleEndpoint<>(
-            "test-endpoint",
-            x -> "GET",
-            x -> "/test",
-            x -> Collections.emptyMap(), // path params
-            x -> Collections.emptyMap(), // query params
-            x -> Collections.emptyMap(), // headers
-            EndpointBase.nonEmptyJsonObject(x -> x),
-            null
-        );
-
-        transport.performRequest(new TestValue(null), endpoint, null);
-        transport.performRequest(new TestValue("hi"), endpoint, null);
-
-        assertNull(requests.get(0).body());
-        assertNotNull(requests.get(1).body());
-
-    }
-
-    private static class TestValue implements JsonpSerializable {
-
-        private final String value;
-
-        public TestValue(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public void serialize(JsonGenerator generator, JsonpMapper mapper) {
-            generator.writeStartObject();
-            if (value != null) {
-                generator.write("value", value);
-            }
-            generator.writeEnd();
         }
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/transport/endpoints/SimpleEndpointTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/endpoints/SimpleEndpointTest.java
@@ -1,4 +1,71 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package co.elastic.clients.transport.endpoints;
 
-public class SimpleEndpointTest {
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.CountResponse;
+import co.elastic.clients.testkit.MockHttpClient;
+import co.elastic.clients.testkit.ModelTestCase;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.ElasticsearchTransportBase;
+import co.elastic.clients.transport.TransportOptions;
+import co.elastic.clients.transport.http.TransportHttpClient;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimpleEndpointTest extends ModelTestCase {
+
+    @Test
+    public void testNoBodyForEmptyObject() throws Exception {
+
+        List<TransportHttpClient.Request> requests = new ArrayList<>();
+
+        MockHttpClient httpClient = new MockHttpClient() {
+            @Override
+            public Response performRequest(
+                String endpointId, @Nullable Node node, Request request, TransportOptions option
+            ) throws IOException {
+                requests.add(request);
+                return super.performRequest(endpointId, node, request, option);
+            }
+        };
+
+        httpClient.add("/_count", "application/json", toJson(
+            CountResponse.of(c -> c
+                .count(1)
+                .shards(s -> s.successful(1).failed(0).total(1))
+        )));
+
+        ElasticsearchTransport transport = new ElasticsearchTransportBase(httpClient, null, mapper) {};
+        ElasticsearchClient client = new ElasticsearchClient(transport, null);
+
+        client.count();
+        client.count(c -> c.q("foo:bar"));
+        client.count(c -> c.query(q -> q.term(t -> t.field("foo").value("bar"))));
+
+        assertNull(requests.get(0).body());
+        assertNull(requests.get(1).body());
+        assertNotNull(requests.get(2).body());
+    }
 }

--- a/java-client/src/test/java/co/elastic/clients/transport/endpoints/SimpleEndpointTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/endpoints/SimpleEndpointTest.java
@@ -1,0 +1,4 @@
+package co.elastic.clients.transport.endpoints;
+
+public class SimpleEndpointTest {
+}


### PR DESCRIPTION
Allow requests that have all-optional properties to be serialized as an empty body (zero bytes) instead of an empty object (`{}`)

Some endpoints (e.g. `/_validate/query`) require this behavior and reject requests that have an empty object body. 

This is achieved by wrapping the body accessor in endpoint definitions using `EndpointBase.nonEmptyJsonObject(bodyGetter)`. This will be added to the relevant endpoints in the code generator.