### PR TITLE
Run tests in non-strict JSON mode, like real applications

### DIFF
--- a/java-client/src/test/java/co/elastic/clients/json/JsonpMappingExceptionTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpMappingExceptionTest.java
@@ -98,7 +98,7 @@ public class JsonpMappingExceptionTest extends ModelTestCase {
         // Unknown field 'baz' (JSON path: properties['foo-bar'].baz) (...line no=1, column no=36, offset=35)
 
         JsonpMappingException e = assertThrows(JsonpMappingException.class, () -> {
-            fromJson(json, TypeMapping.class);
+            fromJson(json, TypeMapping.class, SimpleJsonpMapper.INSTANCE_REJECT_UNKNOWN_FIELDS);
         });
 
         // Check escaping of non identifier path elements and path from map elements

--- a/java-client/src/test/java/co/elastic/clients/testkit/ModelTestCase.java
+++ b/java-client/src/test/java/co/elastic/clients/testkit/ModelTestCase.java
@@ -58,25 +58,15 @@ public abstract class ModelTestCase extends Assertions {
         switch(jsonImpl) {
             case Jsonb:
                 System.out.println("Using a JsonB mapper (rand = " + rand + ").");
-                return new JsonbJsonpMapper() {
-                    @Override
-                    public boolean ignoreUnknownFields() {
-                        return false;
-                    }
-                };
+                return new JsonbJsonpMapper();
 
             case Jackson:
                 System.out.println("Using a Jackson mapper (rand = " + rand + ").");
-                return new JacksonJsonpMapper() {
-                    @Override
-                    public boolean ignoreUnknownFields() {
-                        return false;
-                    }
-                };
+                return new JacksonJsonpMapper();
 
             default:
                 System.out.println("Using a simple mapper (rand = " + rand + ").");
-                return SimpleJsonpMapper.INSTANCE_REJECT_UNKNOWN_FIELDS;
+                return SimpleJsonpMapper.INSTANCE;
         }
     }
 


### PR DESCRIPTION
The JSON mappers used in tests are in strict mode and will reject unknown fields when deserializing objects. This was useful in the early days of the Java Client when the API spec was still in flux. We now have extensive validation for the API spec that catches these unknown fields.

This PR removes strict mode from test JSON mappers, so that they behave like regular applications.