### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/aggregations.md
+++ b/docs/reference/aggregations.md
@@ -8,7 +8,7 @@ mapped_pages:
 An aggregation summarizes your data as metrics, statistics, or other analytics.
 
 ::::{note}
-See the [{{es}} documentation](elasticsearch://docs/reference/data-analysis/aggregations/index.md) for a full explanation of aggregations.
+See the [{{es}} documentation](elasticsearch://reference/data-analysis/aggregations/index.md) for a full explanation of aggregations.
 ::::
 
 

--- a/docs/reference/building-objects.md
+++ b/docs/reference/building-objects.md
@@ -55,7 +55,7 @@ CreateIndexResponse createResponse = client.indices()
     );
 ```
 
-Builder lambdas become particularly useful with complex nested queries like the one below, taken from the [intervals query API documentation](elasticsearch://docs/reference/query-languages/query-dsl-intervals-query.md).
+Builder lambdas become particularly useful with complex nested queries like the one below, taken from the [intervals query API documentation](elasticsearch://reference/query-languages/query-dsl-intervals-query.md).
 
 This example also highlights a useful naming convention for builder parameters in deeply nested structures. For lambda expressions with a single argument, Kotlin provides the implicit `it` parameter and Scala allows use of `_`. This can be approximated in Java by using an underscore or a single letter prefix followed by a number representing the depth level (i.e. `_0`, `_1`, or `b0`, `b1` and so on). Not only does this remove the need to create throw-away variable names, but it also improves code readability. Correct indentation also allows the structure of the query to stand out.
 

--- a/docs/reference/package-structure.md
+++ b/docs/reference/package-structure.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Package structure and namespace clients [package-structure]
 
-The {{es}} API is large and is organized into feature groups, as can be seen in the [{{es}} API documentation](elasticsearch://docs/reference/elasticsearch/rest-apis/index.md).
+The {{es}} API is large and is organized into feature groups, as can be seen in the [{{es}} API documentation](elasticsearch://reference/elasticsearch/rest-apis/index.md).
 
 The Java API Client follows this structure: feature groups are called “namespaces”, and each namespace is located in a subpackage of `co.elastic.clients.elasticsearch`.
 

--- a/docs/reference/using-java-api-client.md
+++ b/docs/reference/using-java-api-client.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 The sections below provide tutorials on the most frequently used and some less obvious features of {{es}}.
 
-For a full reference, see the [Elasticsearch documentation](docs-content://get-started/index.md) and in particular the [REST APIs](elasticsearch://docs/reference/elasticsearch/rest-apis/index.md) section. The Java API Client follows closely the JSON structures described there, using the [Java API conventions](/reference/api-conventions.md).
+For a full reference, see the [Elasticsearch documentation](docs-content://get-started/index.md) and in particular the [REST APIs](elasticsearch://reference/elasticsearch/rest-apis/index.md) section. The Java API Client follows closely the JSON structures described there, using the [Java API conventions](/reference/api-conventions.md).
 
 If you’re new to Elasticsearch, make sure also to read [Elasticsearch’s quick start](docs-content://solutions/search/get-started.md) that provides a good introduction.
 


### PR DESCRIPTION
Follow up to #952 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).