### PR TITLE
[docs] Fix external links

### DIFF
--- a/docs/reference/_basic_authentication.md
+++ b/docs/reference/_basic_authentication.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Basic authentication [_basic_authentication]
 
-Configuring basic authentication can be done by providing an `HttpClientConfigCallback` while building the `RestClient` through its builder. The interface has one method that receives an instance of [`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.md) as an argument and has the same return type. The http client builder can be modified and then returned. In the following example we set a default credentials provider that requires basic authentication.
+Configuring basic authentication can be done by providing an `HttpClientConfigCallback` while building the `RestClient` through its builder. The interface has one method that receives an instance of [`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html) as an argument and has the same return type. The http client builder can be modified and then returned. In the following example we set a default credentials provider that requires basic authentication.
 
 ```java
 final CredentialsProvider credentialsProvider =

--- a/docs/reference/_encrypted_communication.md
+++ b/docs/reference/_encrypted_communication.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Encrypted communication [_encrypted_communication]
 
-Encrypted communication using TLS can also be configured through the `HttpClientConfigCallback`. The [`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.md) received as an argument exposes multiple methods to configure encrypted communication: `setSSLContext`, `setSSLSessionStrategy` and `setConnectionManager`, in order of precedence from the least important.
+Encrypted communication using TLS can also be configured through the `HttpClientConfigCallback`. The [`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html) received as an argument exposes multiple methods to configure encrypted communication: `setSSLContext`, `setSSLSessionStrategy` and `setConnectionManager`, in order of precedence from the least important.
 
 When accessing an Elasticsearch cluster that is setup for TLS on the HTTP layer, the client needs to trust the certificate that Elasticsearch is using. The following is an example of setting up the client to trust the CA that has signed the certificate that Elasticsearch is using, when that CA certificate is available in a PKCS#12 keystore:
 

--- a/docs/reference/_timeouts.md
+++ b/docs/reference/_timeouts.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Timeouts [_timeouts]
 
-Configuring requests timeouts can be done by providing an instance of `RequestConfigCallback` while building the `RestClient` through its builder. The interface has one method that receives an instance of [`org.apache.http.client.config.RequestConfig.Builder`](https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.md) as an argument and has the same return type. The request config builder can be modified and then returned. In the following example we increase the connect timeout (defaults to 1 second) and the socket timeout (defaults to 30 seconds).
+Configuring requests timeouts can be done by providing an instance of `RequestConfigCallback` while building the `RestClient` through its builder. The interface has one method that receives an instance of [`org.apache.http.client.config.RequestConfig.Builder`](https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html) as an argument and has the same return type. The request config builder can be modified and then returned. In the following example we increase the connect timeout (defaults to 1 second) and the socket timeout (defaults to 30 seconds).
 
 ```java
 RestClientBuilder builder = RestClient.builder(

--- a/docs/reference/java-rest-low-usage-initialization.md
+++ b/docs/reference/java-rest-low-usage-initialization.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Initialization [java-rest-low-usage-initialization]
 
-A `RestClient` instance can be built through the corresponding `RestClientBuilder` class, created via `RestClient#builder(HttpHost...)` static method. The only required argument is one or more hosts that the client will communicate with, provided as instances of [HttpHost](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpHost.md) as follows:
+A `RestClient` instance can be built through the corresponding `RestClientBuilder` class, created via `RestClient#builder(HttpHost...)` static method. The only required argument is one or more hosts that the client will communicate with, provided as instances of [HttpHost](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpHost.html) as follows:
 
 ```java
 RestClient restClient = RestClient.builder(
@@ -67,7 +67,7 @@ builder.setRequestConfigCallback(
     });
 ```
 
-1. Set a callback that allows to modify the default request configuration (e.g. request timeouts, authentication, or anything that the [`org.apache.http.client.config.RequestConfig.Builder`](https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.md) allows to set)
+1. Set a callback that allows to modify the default request configuration (e.g. request timeouts, authentication, or anything that the [`org.apache.http.client.config.RequestConfig.Builder`](https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html) allows to set)
 
 
 ```java
@@ -83,6 +83,6 @@ builder.setHttpClientConfigCallback(new HttpClientConfigCallback() {
     });
 ```
 
-1. Set a callback that allows to modify the http client configuration (e.g. encrypted communication over ssl, or anything that the [`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.md) allows to set)
+1. Set a callback that allows to modify the http client configuration (e.g. encrypted communication over ssl, or anything that the [`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html) allows to set)
 
 

--- a/docs/reference/java-rest-low-usage-logging.md
+++ b/docs/reference/java-rest-low-usage-logging.md
@@ -13,7 +13,7 @@ The request tracer logging can also be enabled to log every request and correspo
 
 ### Trace Logs [_trace_logs]
 
-In order to enable trace logs for logback, we have to use [jcl-over-slf4j bridging module](https://www.slf4j.org/legacy.md#jclOverSLF4J).
+In order to enable trace logs for logback, we have to use [jcl-over-slf4j bridging module](https://www.slf4j.org/legacy.html#jclOverSLF4J).
 
 1. Add the following to your Gradle setting:
 

--- a/docs/reference/java-rest-low-usage-responses.md
+++ b/docs/reference/java-rest-low-usage-responses.md
@@ -20,7 +20,7 @@ String responseBody = EntityUtils.toString(response.getEntity()); <5>
 2. The host that returned the response
 3. The response status line, from which you can for instance retrieve the status code
 4. The response headers, which can also be retrieved by name though `getHeader(String)`
-5. The response body enclosed in an [`org.apache.http.HttpEntity`](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpEntity.md) object
+5. The response body enclosed in an [`org.apache.http.HttpEntity`](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpEntity.html) object
 
 
 When performing a request, an exception is thrown (or received as an argument in `ResponseListener#onFailure(Exception)` in the following scenarios:
@@ -38,4 +38,4 @@ A `ResponseException` is **not** thrown for `HEAD` requests that return a `404` 
 
 Note that the low-level client doesn’t expose any helper for json marshalling and un-marshalling. Users are free to use the library that they prefer for that purpose.
 
-The underlying Apache Async Http Client ships with different [`org.apache.http.HttpEntity`](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpEntity.md) implementations that allow to provide the request body in different formats (stream, byte array, string etc.). As for reading the response body, the `HttpEntity#getContent` method comes handy which returns an `InputStream` reading from the previously buffered response body. As an alternative, it is possible to provide a custom [`org.apache.http.nio.protocol.HttpAsyncResponseConsumer`](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore-nio/apidocs/org/apache/http/nio/protocol/HttpAsyncResponseConsumer.md) that controls how bytes are read and buffered.
+The underlying Apache Async Http Client ships with different [`org.apache.http.HttpEntity`](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpEntity.html) implementations that allow to provide the request body in different formats (stream, byte array, string etc.). As for reading the response body, the `HttpEntity#getContent` method comes handy which returns an `InputStream` reading from the previously buffered response body. As an alternative, it is possible to provide a custom [`org.apache.http.nio.protocol.HttpAsyncResponseConsumer`](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore-nio/apidocs/org/apache/http/nio/protocol/HttpAsyncResponseConsumer.html) that controls how bytes are read and buffered.

--- a/docs/reference/java-rest-low-usage-shading.md
+++ b/docs/reference/java-rest-low-usage-shading.md
@@ -11,7 +11,7 @@ Be advised that shading a JAR also has implications. Shading the Commons Logging
 
 ## Maven configuration [java-rest-low-usage-shading-maven]
 
-Here is a configuration using the Maven [Shade](https://maven.apache.org/plugins/maven-shade-plugin/index.md) plugin. Add the following to your `pom.xml` file:
+Here is a configuration using the Maven [Shade](https://maven.apache.org/plugins/maven-shade-plugin/index.html) plugin. Add the following to your `pom.xml` file:
 
 ```xml
 <build>


### PR DESCRIPTION
Fix external links that incorrectly use `.md` instead of `.html`.