### PR TITLE
Use Jackson as the default JSON implementations, update libraries

### DIFF
--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -22,7 +22,6 @@ This page guides you through the installation process of the Java client, shows 
 ```groovy
 dependencies {
     implementation 'co.elastic.clients:elasticsearch-java:9.0.0-beta1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 ```
 
@@ -39,12 +38,6 @@ In the `pom.xml` of your project, add the following repository definition and de
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
       <version>9.0.0-beta1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.17.0</version>
     </dependency>
 
   </dependencies>

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -18,7 +18,6 @@ Releases are hosted on [Maven Central](https://search.maven.org/search?q=g:co.el
 ```groovy
 dependencies {
     implementation 'co.elastic.clients:elasticsearch-java:9.0.0-beta1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 ```
 
@@ -35,12 +34,6 @@ In the `pom.xml` of your project, add the following repository definition and de
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
       <version>9.0.0-beta1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.17.0</version>
     </dependency>
 
   </dependencies>

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -198,15 +198,16 @@ signing {
 }
 
 dependencies {
-    // Compile and test with the last 7.x version to make sure transition scenarios where
-    // the Java API client coexists with a 7.x HLRC work fine
+    // Compile and test with the last 8.x version to make sure transition scenarios where
+    // the Java API client coexists with a 8.x HLRC work fine
     val elasticsearchVersion = "8.17.0"
-    val jacksonVersion = "2.17.0"
+    val jacksonVersion = "2.18.3"
     val openTelemetryVersion = "1.29.0"
 
     // Apache 2.0
     // https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html
-    api("org.elasticsearch.client", "elasticsearch-rest-client", elasticsearchVersion)
+    compileOnly("org.elasticsearch.client", "elasticsearch-rest-client", elasticsearchVersion)
+    testImplementation("org.elasticsearch.client", "elasticsearch-rest-client", elasticsearchVersion)
 
     api("org.apache.httpcomponents.client5","httpclient5","5.4")
 
@@ -216,12 +217,12 @@ dependencies {
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/jsonp
-    api("jakarta.json:jakarta.json-api:2.0.1")
+    api("jakarta.json:jakarta.json-api:2.1.3")
 
     // Needed even if using Jackson to have an implementation of the Jsonp object model
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/parsson
-    api("org.eclipse.parsson:parsson:1.0.5")
+    api("org.eclipse.parsson:parsson:1.1.7")
 
     // OpenTelemetry API for native instrumentation of the client.
     // Apache 2.0
@@ -229,25 +230,21 @@ dependencies {
     implementation("io.opentelemetry", "opentelemetry-api", openTelemetryVersion)
     // Use it once it's stable (see Instrumentation.java). Limited to tests for now.
     testImplementation("io.opentelemetry", "opentelemetry-semconv", "$openTelemetryVersion-alpha")
+    testImplementation("io.opentelemetry", "opentelemetry-sdk", openTelemetryVersion)
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/jsonb-api
-    compileOnly("jakarta.json.bind", "jakarta.json.bind-api", "2.0.0")
-    testImplementation("jakarta.json.bind", "jakarta.json.bind-api", "2.0.0")
+    compileOnly("jakarta.json.bind", "jakarta.json.bind-api", "3.0.1")
+    testImplementation("jakarta.json.bind", "jakarta.json.bind-api", "3.0.1")
 
     // Apache 2.0
     // https://github.com/FasterXML/jackson
-    compileOnly("com.fasterxml.jackson.core", "jackson-core", jacksonVersion)
-    compileOnly("com.fasterxml.jackson.core", "jackson-databind", jacksonVersion)
-    testImplementation("com.fasterxml.jackson.core", "jackson-core", jacksonVersion)
-    testImplementation("com.fasterxml.jackson.core", "jackson-databind", jacksonVersion)
+    implementation("com.fasterxml.jackson.core", "jackson-core", jacksonVersion)
+    implementation("com.fasterxml.jackson.core", "jackson-databind", jacksonVersion)
 
     // EPL-2.0 OR BSD-3-Clause
     // https://eclipse-ee4j.github.io/yasson/
-    testImplementation("org.eclipse", "yasson", "2.0.4") {
-        // Exclude Glassfish as we use Parsson (basically Glassfish renamed in the Jakarta namespace).
-        exclude(group = "org.glassfish", module = "jakarta.json")
-    }
+    testImplementation("org.eclipse", "yasson", "3.0.4")
 
     // Apache-2.0
     testImplementation("commons-io:commons-io:2.17.0")
@@ -267,8 +264,6 @@ dependencies {
     testImplementation("org.testcontainers", "elasticsearch", "1.17.3")
     // updating transitive dependency from testcontainers
     testImplementation("org.apache.commons","commons-compress","1.26.1")
-
-    testImplementation("io.opentelemetry", "opentelemetry-sdk", openTelemetryVersion)
 
     // Apache-2.0
     // https://github.com/awaitility/awaitility

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -319,10 +319,15 @@ class SpdxReporter(val dest: File) : ReportRenderer {
                 val depName = dep.group + ":" + dep.name
 
                 val info = LicenseDataCollector.multiModuleLicenseInfo(dep)
-                val depUrl = if (depName.startsWith("org.apache.httpcomponents")) {
-                    "https://hc.apache.org/"
-                } else {
-                    info.moduleUrls.first()
+                val depUrl = when(dep.group) {
+                    "org.apache.httpcomponents.client5" -> "https://hc.apache.org/"
+                    "org.apache.httpcomponents.core5" -> "https://hc.apache.org/"
+                    "com.fasterxml.jackson" -> "https://github.com/FasterXML/jackson"
+                    else -> if (info.moduleUrls.isEmpty()) {
+                                throw RuntimeException("No URL found for module '$depName'")
+                            } else {
+                                info.moduleUrls.first()
+                            }
                 }
 
                 val licenseIds = info.licenses.mapNotNull { license ->

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -160,6 +160,9 @@ publishing {
                 }
 
                 withXml {
+                    // Note: org.elasticsearch.client is now an optional dependency, so the below is no more useful.
+                    // It's kept in case it ever comes back as a required dependency.
+
                     // Set the version of dependencies of the org.elasticsearch.client group to the one that we are building.
                     // Since the unified release process releases everything at once, this ensures all published artifacts depend
                     // on the exact same version. This assumes of course that the binary API and the behavior of these dependencies
@@ -169,20 +172,13 @@ publishing {
                             .compile("/project/dependencies/dependency[groupId/text() = 'org.elasticsearch.client']")
                     val versionSelector = xPathFactory.newXPath().compile("version")
 
-                    var foundVersion = false;
-
                     val deps = depSelector.evaluate(asElement().ownerDocument, javax.xml.xpath.XPathConstants.NODESET)
                             as org.w3c.dom.NodeList
 
                     for (i in 0 until deps.length) {
                         val dep = deps.item(i)
                         val version = versionSelector.evaluate(dep, javax.xml.xpath.XPathConstants.NODE) as org.w3c.dom.Element
-                        foundVersion = true;
                         version.textContent = project.version.toString()
-                    }
-
-                    if (!foundVersion) {
-                        throw GradleException("Could not find a 'org.elasticsearch.client' to update dependency version in the POM.")
                     }
                 }
             }

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
@@ -70,11 +70,11 @@ public class JsonpUtils {
     static JsonProvider findProvider() {
         try {
             // Default to Jackson
+            Class.forName("com.fasterxml.jackson.databind.ObjectMapper");
             return new JacksonJsonProvider();
-        } catch (NoClassDefFoundError e) {
-            // Ignore
+        } catch (ClassNotFoundException e) {
+            return findSystemProvider();
         }
-        return findSystemProvider();
     }
 
     /**

--- a/java-client/src/main/java/co/elastic/clients/json/SimpleJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/SimpleJsonpMapper.java
@@ -90,7 +90,7 @@ public class SimpleJsonpMapper extends JsonpMapperBase {
 
     @Override
     public JsonProvider jsonProvider() {
-        return JsonpUtils.provider();
+        return JsonpUtils.systemProvider();
     }
 
     @Override

--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonProvider.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JacksonJsonProvider.java
@@ -133,7 +133,7 @@ public class JacksonJsonProvider extends JsonProvider {
          */
         @Override
         public JsonParser createParser(JsonObject obj) {
-            return JsonpUtils.provider().createParserFactory(null).createParser(obj);
+            return JsonpUtils.systemProvider().createParserFactory(null).createParser(obj);
         }
 
         /**
@@ -141,7 +141,7 @@ public class JacksonJsonProvider extends JsonProvider {
          */
         @Override
         public JsonParser createParser(JsonArray array) {
-            return JsonpUtils.provider().createParserFactory(null).createParser(array);
+            return JsonpUtils.systemProvider().createParserFactory(null).createParser(array);
         }
 
         /**

--- a/java-client/src/main/java/co/elastic/clients/json/jackson/JsonValueParser.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jackson/JsonValueParser.java
@@ -40,11 +40,11 @@ import java.math.BigInteger;
  * object (e.g. START_OBJECT, VALUE_NUMBER, etc).
  */
 class JsonValueParser {
-    private final JsonProvider provider = JsonpUtils.provider();
+    private final JsonProvider systemProvider = JsonpUtils.systemProvider();
 
     public JsonObject parseObject(JsonParser parser) throws IOException {
 
-        JsonObjectBuilder ob = provider.createObjectBuilder();
+        JsonObjectBuilder ob = systemProvider.createObjectBuilder();
 
         JsonToken token;
         while((token = parser.nextToken()) != JsonToken.END_OBJECT) {
@@ -59,7 +59,7 @@ class JsonValueParser {
     }
 
     public JsonArray parseArray(JsonParser parser) throws IOException {
-        JsonArrayBuilder ab = provider.createArrayBuilder();
+        JsonArrayBuilder ab = systemProvider.createArrayBuilder();
 
         while(parser.nextToken() != JsonToken.END_ARRAY) {
             ab.add(parseValue(parser));
@@ -86,23 +86,23 @@ class JsonValueParser {
                 return JsonValue.NULL;
 
             case VALUE_STRING:
-                return provider.createValue(parser.getText());
+                return systemProvider.createValue(parser.getText());
 
             case VALUE_NUMBER_FLOAT:
             case VALUE_NUMBER_INT:
                 switch(parser.getNumberType()) {
                     case INT:
-                        return provider.createValue(parser.getIntValue());
+                        return systemProvider.createValue(parser.getIntValue());
                     case LONG:
-                        return provider.createValue(parser.getLongValue());
+                        return systemProvider.createValue(parser.getLongValue());
                     case FLOAT:
                     case DOUBLE:
                         // Use double also for floats, as JSON-P has no support for float
                         return new DoubleNumber(parser.getDoubleValue());
                     case BIG_DECIMAL:
-                        return provider.createValue(parser.getDecimalValue());
+                        return systemProvider.createValue(parser.getDecimalValue());
                     case BIG_INTEGER:
-                        return provider.createValue(parser.getBigIntegerValue());
+                        return systemProvider.createValue(parser.getBigIntegerValue());
                 }
 
             default:

--- a/java-client/src/main/java/co/elastic/clients/json/jsonb/JsonbJsonpMapper.java
+++ b/java-client/src/main/java/co/elastic/clients/json/jsonb/JsonbJsonpMapper.java
@@ -52,7 +52,8 @@ public class JsonbJsonpMapper extends JsonpMapperBase {
     }
 
     public JsonbJsonpMapper() {
-        this(JsonpUtils.provider(), JsonbProvider.provider());
+        // Use a native JSON-P/JSON-B implementations.
+        this(JsonpUtils.systemProvider(), JsonbProvider.provider());
     }
 
     @Override

--- a/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
@@ -58,13 +58,7 @@ public class JsonpUtilsTest extends ModelTestCase {
         ClassLoader savedLoader = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(emptyLoader);
-
-            assertThrows(JsonException.class, () -> {
-                assertNotNull(JsonProvider.provider());
-            });
-
             assertNotNull(JsonpUtils.provider());
-
         } finally {
             Thread.currentThread().setContextClassLoader(savedLoader);
         }

--- a/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
@@ -26,7 +26,6 @@ import co.elastic.clients.elasticsearch.security.IndicesPrivileges;
 import co.elastic.clients.elasticsearch.security.RoleTemplateScript;
 import co.elastic.clients.elasticsearch.security.UserIndicesPrivileges;
 import co.elastic.clients.util.AllowForbiddenApis;
-import jakarta.json.JsonException;
 import jakarta.json.spi.JsonProvider;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;

--- a/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/JsonpUtilsTest.java
@@ -20,6 +20,7 @@
 package co.elastic.clients.json;
 
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.json.jackson.JacksonJsonProvider;
 import co.elastic.clients.testkit.ModelTestCase;
 import co.elastic.clients.elasticsearch.security.IndexPrivilege;
 import co.elastic.clients.elasticsearch.security.IndicesPrivileges;
@@ -82,6 +83,15 @@ public class JsonpUtilsTest extends ModelTestCase {
             .id("id1")
         );
         assertEquals("Hit: {\"_index\":\"idx\",\"_id\":\"id1\",\"_source\":\"Some user data\"}", hit.toString());
+    }
+
+    @Test
+    public void testDefaultProvider() {
+        // Provider defaults to Jackson
+        assertTrue(JsonpUtils.provider() instanceof JacksonJsonProvider);
+
+        // System provider uses service lookup
+        assertFalse(JsonpUtils.systemProvider() instanceof JacksonJsonProvider);
     }
 
     private static class SomeUserData {

--- a/java-client/src/test/java/co/elastic/clients/testkit/ModelTestCase.java
+++ b/java-client/src/test/java/co/elastic/clients/testkit/ModelTestCase.java
@@ -50,7 +50,7 @@ public abstract class ModelTestCase extends Assertions {
     protected final JsonpMapper mapper;
 
     private static JsonImpl chooseJsonImpl(EnumSet<JsonImpl> jsonImplCandidates, int rand) {
-        // Converting an EnumSet to an array always uses the same order.
+        // Converting an EnumSet an array always uses the same order.
         return jsonImplCandidates.toArray(new JsonImpl[jsonImplCandidates.size()])[rand % jsonImplCandidates.size()];
     }
 


### PR DESCRIPTION
Our docs illustrate/promote using Jackson as a `JsonMapper` implementation, and yet it was an optional dependency.

This PR makes Jackson the default implementation, and makes it a required dependency. It also updates all JSON-related libraries to their latest version.