### PR TITLE
Handle path prefixes when creating clients using URIs

### DIFF
--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/ElasticsearchTestClient.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/ElasticsearchTestClient.java
@@ -73,4 +73,9 @@ public class ElasticsearchTestClient {
         var address = server.getAddress();
         return createClient("http://" + address.getHostString() + ":" + address.getPort(), mapper, null);
     }
+
+    public static Function<ElasticsearchTransportConfig, ElasticsearchTransport> transportFactory() {
+        System.out.println("Using a " + flavor + " client");
+        return flavor.transportFactory();
+    }
 }


### PR DESCRIPTION
Fixes the new client constructors that accept `java.net.URI` that were ignoring the path part. Also ensures all URIs have the same path, as RestClient and Rest5Client accept a single path prefix common to all nodes.