### PR TITLE
Support include_names_queries_score

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/MsearchRequest.java
@@ -108,6 +108,9 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 	@Nullable
 	private final Boolean ignoreUnavailable;
 
+	@Nullable
+	private final Boolean includeNamedQueriesScore;
+
 	private final List<String> index;
 
 	@Nullable
@@ -136,6 +139,7 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 		this.expandWildcards = ApiTypeHelper.unmodifiable(builder.expandWildcards);
 		this.ignoreThrottled = builder.ignoreThrottled;
 		this.ignoreUnavailable = builder.ignoreUnavailable;
+		this.includeNamedQueriesScore = builder.includeNamedQueriesScore;
 		this.index = ApiTypeHelper.unmodifiable(builder.index);
 		this.maxConcurrentSearches = builder.maxConcurrentSearches;
 		this.maxConcurrentShardRequests = builder.maxConcurrentShardRequests;
@@ -208,6 +212,22 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 	@Nullable
 	public final Boolean ignoreUnavailable() {
 		return this.ignoreUnavailable;
+	}
+
+	/**
+	 * Indicates whether hit.matched_queries should be rendered as a map that
+	 * includes the name of the matched query associated with its score (true) or as
+	 * an array containing the name of the matched queries (false) This
+	 * functionality reruns each named query on every hit in a search response.
+	 * Typically, this adds a small overhead to a request. However, using
+	 * computationally expensive named queries on a large number of hits may add
+	 * significant overhead.
+	 * <p>
+	 * API name: {@code include_named_queries_score}
+	 */
+	@Nullable
+	public final Boolean includeNamedQueriesScore() {
+		return this.includeNamedQueriesScore;
 	}
 
 	/**
@@ -321,6 +341,9 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 		private Boolean ignoreUnavailable;
 
 		@Nullable
+		private Boolean includeNamedQueriesScore;
+
+		@Nullable
 		private List<String> index;
 
 		@Nullable
@@ -410,6 +433,22 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 		 */
 		public final Builder ignoreUnavailable(@Nullable Boolean value) {
 			this.ignoreUnavailable = value;
+			return this;
+		}
+
+		/**
+		 * Indicates whether hit.matched_queries should be rendered as a map that
+		 * includes the name of the matched query associated with its score (true) or as
+		 * an array containing the name of the matched queries (false) This
+		 * functionality reruns each named query on every hit in a search response.
+		 * Typically, this adds a small overhead to a request. However, using
+		 * computationally expensive named queries on a large number of hits may add
+		 * significant overhead.
+		 * <p>
+		 * API name: {@code include_named_queries_score}
+		 */
+		public final Builder includeNamedQueriesScore(@Nullable Boolean value) {
+			this.includeNamedQueriesScore = value;
 			return this;
 		}
 
@@ -612,6 +651,9 @@ public class MsearchRequest extends RequestBase implements NdJsonpSerializable, 
 				if (ApiTypeHelper.isDefined(request.expandWildcards)) {
 					params.put("expand_wildcards",
 							request.expandWildcards.stream().map(v -> v.jsonValue()).collect(Collectors.joining(",")));
+				}
+				if (request.includeNamedQueriesScore != null) {
+					params.put("include_named_queries_score", String.valueOf(request.includeNamedQueriesScore));
 				}
 				if (request.searchType != null) {
 					params.put("search_type", request.searchType.jsonValue());

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchRequest.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/SearchRequest.java
@@ -184,6 +184,9 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 	@Nullable
 	private final Boolean ignoreUnavailable;
 
+	@Nullable
+	private final Boolean includeNamedQueriesScore;
+
 	private final List<String> index;
 
 	private final List<NamedValue<Double>> indicesBoost;
@@ -304,6 +307,7 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 		this.highlight = builder.highlight;
 		this.ignoreThrottled = builder.ignoreThrottled;
 		this.ignoreUnavailable = builder.ignoreUnavailable;
+		this.includeNamedQueriesScore = builder.includeNamedQueriesScore;
 		this.index = ApiTypeHelper.unmodifiable(builder.index);
 		this.indicesBoost = ApiTypeHelper.unmodifiable(builder.indicesBoost);
 		this.knn = ApiTypeHelper.unmodifiable(builder.knn);
@@ -596,6 +600,22 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 	@Nullable
 	public final Boolean ignoreUnavailable() {
 		return this.ignoreUnavailable;
+	}
+
+	/**
+	 * If <code>true</code>, the response includes the score contribution from any
+	 * named queries.
+	 * <p>
+	 * This functionality reruns each named query on every hit in a search response.
+	 * Typically, this adds a small overhead to a request. However, using
+	 * computationally expensive named queries on a large number of hits may add
+	 * significant overhead.
+	 * <p>
+	 * API name: {@code include_named_queries_score}
+	 */
+	@Nullable
+	public final Boolean includeNamedQueriesScore() {
+		return this.includeNamedQueriesScore;
 	}
 
 	/**
@@ -1364,6 +1384,9 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 		private Boolean ignoreUnavailable;
 
 		@Nullable
+		private Boolean includeNamedQueriesScore;
+
+		@Nullable
 		private List<String> index;
 
 		@Nullable
@@ -1880,6 +1903,22 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 		 */
 		public final Builder ignoreUnavailable(@Nullable Boolean value) {
 			this.ignoreUnavailable = value;
+			return this;
+		}
+
+		/**
+		 * If <code>true</code>, the response includes the score contribution from any
+		 * named queries.
+		 * <p>
+		 * This functionality reruns each named query on every hit in a search response.
+		 * Typically, this adds a small overhead to a request. However, using
+		 * computationally expensive named queries on a large number of hits may add
+		 * significant overhead.
+		 * <p>
+		 * API name: {@code include_named_queries_score}
+		 */
+		public final Builder includeNamedQueriesScore(@Nullable Boolean value) {
+			this.includeNamedQueriesScore = value;
 			return this;
 		}
 
@@ -2908,6 +2947,9 @@ public class SearchRequest extends RequestBase implements JsonpSerializable {
 				}
 				if (request.forceSyntheticSource != null) {
 					params.put("force_synthetic_source", String.valueOf(request.forceSyntheticSource));
+				}
+				if (request.includeNamedQueriesScore != null) {
+					params.put("include_named_queries_score", String.valueOf(request.includeNamedQueriesScore));
 				}
 				if (request.lenient != null) {
 					params.put("lenient", String.valueOf(request.lenient));

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Hit.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/search/Hit.java
@@ -87,7 +87,7 @@ public class Hit<TDocument> implements JsonpSerializable {
 
 	private final Map<String, InnerHitsResult> innerHits;
 
-	private final List<String> matchedQueries;
+	private final Map<String, Double> matchedQueries;
 
 	@Nullable
 	private final NestedIdentity nested;
@@ -212,7 +212,7 @@ public class Hit<TDocument> implements JsonpSerializable {
 	/**
 	 * API name: {@code matched_queries}
 	 */
-	public final List<String> matchedQueries() {
+	public final Map<String, Double> matchedQueries() {
 		return this.matchedQueries;
 	}
 
@@ -380,12 +380,21 @@ public class Hit<TDocument> implements JsonpSerializable {
 		}
 		if (ApiTypeHelper.isDefined(this.matchedQueries)) {
 			generator.writeKey("matched_queries");
-			generator.writeStartArray();
-			for (String item0 : this.matchedQueries) {
-				generator.write(item0);
+			if (this.matchedQueries.values().stream().allMatch(Objects::isNull)) {
+				generator.writeStartArray();
+				for (String item0 : this.matchedQueries.keySet()) {
+					generator.write(item0);
+				}
+				generator.writeEnd();
+			} else {
+				generator.writeStartObject();
+				for (Map.Entry<String, Double> item0 : this.matchedQueries.entrySet()) {
+					generator.writeKey(item0.getKey());
+					generator.write(item0.getValue());
 
+				}
+				generator.writeEnd();
 			}
-			generator.writeEnd();
 
 		}
 		if (this.nested != null) {
@@ -509,7 +518,7 @@ public class Hit<TDocument> implements JsonpSerializable {
 		private Map<String, InnerHitsResult> innerHits;
 
 		@Nullable
-		private List<String> matchedQueries;
+		private Map<String, Double> matchedQueries;
 
 		@Nullable
 		private NestedIdentity nested;
@@ -662,20 +671,20 @@ public class Hit<TDocument> implements JsonpSerializable {
 		/**
 		 * API name: {@code matched_queries}
 		 * <p>
-		 * Adds all elements of <code>list</code> to <code>matchedQueries</code>.
+		 * Adds all entries of <code>map</code> to <code>matchedQueries</code>.
 		 */
-		public final Builder<TDocument> matchedQueries(List<String> list) {
-			this.matchedQueries = _listAddAll(this.matchedQueries, list);
+		public final Builder<TDocument> matchedQueries(Map<String, Double> map) {
+			this.matchedQueries = _mapPutAll(this.matchedQueries, map);
 			return this;
 		}
 
 		/**
 		 * API name: {@code matched_queries}
 		 * <p>
-		 * Adds one or more values to <code>matchedQueries</code>.
+		 * Adds an entry to <code>matchedQueries</code>.
 		 */
-		public final Builder<TDocument> matchedQueries(String value, String... values) {
-			this.matchedQueries = _listAdd(this.matchedQueries, value, values);
+		public final Builder<TDocument> matchedQueries(String key, Double value) {
+			this.matchedQueries = _mapPut(this.matchedQueries, key, value);
 			return this;
 		}
 
@@ -937,7 +946,8 @@ public class Hit<TDocument> implements JsonpSerializable {
 				JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer())), "highlight");
 		op.add(Builder::innerHits, JsonpDeserializer.stringMapDeserializer(InnerHitsResult._DESERIALIZER),
 				"inner_hits");
-		op.add(Builder::matchedQueries, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()),
+		op.add(Builder::matchedQueries,
+				JsonpDeserializer.stringArrayMapUnionDeserializer(JsonpDeserializer.doubleDeserializer()),
 				"matched_queries");
 		op.add(Builder::nested, NestedIdentity._DESERIALIZER, "_nested");
 		op.add(Builder::ignored, JsonpDeserializer.arrayDeserializer(JsonpDeserializer.stringDeserializer()),

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializer.java
@@ -221,6 +221,10 @@ public interface JsonpDeserializer<V> {
         return new JsonpDeserializerBase.StringMapDeserializer<T>(itemDeserializer);
     }
 
+    static <T> JsonpDeserializer<Map<String, T>> stringArrayMapUnionDeserializer(JsonpDeserializer<T> itemDeserializer) {
+        return new JsonpDeserializerBase.StringArrayMapUnionDeserializer<T>(itemDeserializer);
+    }
+
     static <K extends JsonEnum, V> JsonpDeserializer<Map<K, V>> enumMapDeserializer(
         JsonpDeserializer<K> keyDeserializer, JsonpDeserializer<V> valueDeserializer
     ) {

--- a/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializerBase.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpDeserializerBase.java
@@ -374,7 +374,7 @@ public abstract class JsonpDeserializerBase<V> implements JsonpDeserializer<V> {
                 // Array case, deserializing it into a map with null values
                 if (event == Event.START_ARRAY) {
                     while ((event = parser.next()) != Event.END_ARRAY) {
-                        JsonpUtils.ensureAccepts(itemDeserializer, parser, event);
+                        JsonpUtils.expectEvent(parser, Event.VALUE_STRING, event);
                         result.put(parser.getString(),null);
                     }
                 } else {

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
@@ -33,6 +33,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.ShapeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.connector.UpdateIndexNameRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.rank_eval.RankEvalQuery;
 import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import co.elastic.clients.json.JsonData;
@@ -41,6 +42,8 @@ import co.elastic.clients.json.ObjectDeserializer;
 import co.elastic.clients.testkit.ModelTestCase;
 import co.elastic.clients.util.MapBuilder;
 import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
 
 import static co.elastic.clients.elasticsearch._types.query_dsl.Query.Kind.MatchAll;
 
@@ -345,5 +348,44 @@ public class BehaviorsTest extends ModelTestCase {
 
         assertEquals(jsonValue,toJson(updateValue));
         assertEquals(jsonNull,toJson(updateNull));
+    }
+
+    @Test
+    public void testArrayToDict() {
+
+        String jsonValue = "{\n" +
+            "  \"took\": 0,\n" +
+            "  \"timed_out\": false,\n" +
+            "  \"_shards\": {\n" +
+            "    \"total\": 1,\n" +
+            "    \"successful\": 1,\n" +
+            "    \"skipped\": 0,\n" +
+            "    \"failed\": 0\n" +
+            "  },\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\n" +
+            "      \"value\": 1,\n" +
+            "      \"relation\": \"eq\"\n" +
+            "    },\n" +
+            "    \"max_score\": 1,\n" +
+            "    \"hits\": [\n" +
+            "      {\n" +
+            "        \"_index\": \"my-index\",\n" +
+            "        \"_id\": \"N6V065UBHxF3EsAetzcl\",\n" +
+            "        \"_score\": 1,\n" +
+            "        \"_source\": {\n" +
+            "          \"id\": \"park_rocky-mountain\",\n" +
+            "          \"title\": \"Rocky Mountain\",\n" +
+            "          \"description\": \"Bisected north to south by the Continental Divide, this portion of the Rockies has ecosystems varying from over 150 riparian lakes to montane and subalpine forests to treeless alpine tundra.\"\n" +
+            "        },\n" +
+            "        \"matched_queries\": [\n" +
+            "          \"test\"\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  }\n" +
+            "}";
+
+        SearchResponse resp = SearchResponse.of(s -> s.withJson(new StringReader(jsonValue)));
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
@@ -35,7 +35,6 @@ import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.connector.UpdateIndexNameRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.rank_eval.RankEvalQuery;
-import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.LazyDeserializer;
@@ -378,7 +377,7 @@ public class BehaviorsTest extends ModelTestCase {
             "        \"_source\": {\n" +
             "          \"id\": \"park_rocky-mountain\",\n" +
             "          \"title\": \"Rocky Mountain\",\n" +
-            "          \"description\": \"Bisected north to south by the Continental Divide, this portion of the Rockies has ecosystems varying from over 150 riparian lakes to montane and subalpine forests to treeless alpine tundra.\"\n" +
+            "          \"description\": \"description\"\n" +
             "        },\n" +
             "        \"matched_queries\": [\n" +
             "          \"test\"\n" +
@@ -419,7 +418,7 @@ public class BehaviorsTest extends ModelTestCase {
             "        \"_source\": {\n" +
             "          \"id\": \"park_rocky-mountain\",\n" +
             "          \"title\": \"Rocky Mountain\",\n" +
-            "          \"description\": \"Bisected north to south by the Continental Divide, this portion of the Rockies has ecosystems varying from over 150 riparian lakes to montane and subalpine forests to treeless alpine tundra.\"\n" +
+            "          \"description\": \"description\"\n" +
             "        },\n" +
             "        \"matched_queries\": {\n" +
             "          \"test\": 1\n" +

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.connector.UpdateIndexNameRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.rank_eval.RankEvalQuery;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.LazyDeserializer;
@@ -351,9 +352,10 @@ public class BehaviorsTest extends ModelTestCase {
     }
 
     @Test
-    public void testArrayToDict() {
+    public void testArrayToMapHitMatchedQueries() {
 
-        String jsonValue = "{\n" +
+        // matched_queries has a special deserialization because it can be either an array or a map
+        String jsonValueArray = "{\n" +
             "  \"took\": 0,\n" +
             "  \"timed_out\": false,\n" +
             "  \"_shards\": {\n" +
@@ -386,6 +388,53 @@ public class BehaviorsTest extends ModelTestCase {
             "  }\n" +
             "}";
 
-        SearchResponse resp = SearchResponse.of(s -> s.withJson(new StringReader(jsonValue)));
+        SearchResponse<Void> arrayResp = SearchResponse.of(s -> s.withJson(new StringReader(jsonValueArray)));
+
+        String roundtripArray = arrayResp.toString();
+        assertTrue(roundtripArray.contains("\"matched_queries\":[\"test\"]"));
+
+        assertTrue(arrayResp.hits().hits().get(0).matchedQueries().containsKey("test"));
+        assertTrue(arrayResp.hits().hits().get(0).matchedQueries().get("test") == null);
+
+        String jsonValueMap = "{\n" +
+            "  \"took\": 1,\n" +
+            "  \"timed_out\": false,\n" +
+            "  \"_shards\": {\n" +
+            "    \"total\": 1,\n" +
+            "    \"successful\": 1,\n" +
+            "    \"skipped\": 0,\n" +
+            "    \"failed\": 0\n" +
+            "  },\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\n" +
+            "      \"value\": 1,\n" +
+            "      \"relation\": \"eq\"\n" +
+            "    },\n" +
+            "    \"max_score\": 1,\n" +
+            "    \"hits\": [\n" +
+            "      {\n" +
+            "        \"_index\": \"my-index\",\n" +
+            "        \"_id\": \"N6V065UBHxF3EsAetzcl\",\n" +
+            "        \"_score\": 1,\n" +
+            "        \"_source\": {\n" +
+            "          \"id\": \"park_rocky-mountain\",\n" +
+            "          \"title\": \"Rocky Mountain\",\n" +
+            "          \"description\": \"Bisected north to south by the Continental Divide, this portion of the Rockies has ecosystems varying from over 150 riparian lakes to montane and subalpine forests to treeless alpine tundra.\"\n" +
+            "        },\n" +
+            "        \"matched_queries\": {\n" +
+            "          \"test\": 1\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  }\n" +
+            "}";
+
+        SearchResponse<Void> mapResp = SearchResponse.of(s -> s.withJson(new StringReader(jsonValueMap)));
+
+        String roundtripMap = mapResp.toString();
+        assertTrue(roundtripMap.contains("\"matched_queries\":{\"test\":1.0}"));
+
+        assertTrue(mapResp.hits().hits().get(0).matchedQueries().containsKey("test"));
+        assertTrue(mapResp.hits().hits().get(0).matchedQueries().get("test").equals(1D));
     }
 }


### PR DESCRIPTION
Generated output + unit test handling `matched_queries` as an actual array | map union. 
Generator reference: https://github.com/elastic/elastic-client-generator-java/pull/58
Fixes https://github.com/elastic/elasticsearch-java/issues/634