### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -67,15 +67,11 @@ esClient.close();
 
 Your Elasticsearch endpoint can be found on the **My deployment** page of your deployment:
 
-:::{image} images/es-endpoint.jpg
-:alt: Finding Elasticsearch endpoint
-:::
+![Finding Elasticsearch endpoint](images/es-endpoint.jpg)
 
 You can generate an API key on the **Management** page under Security.
 
-:::{image} images/create-api-key.png
-:alt: Create API key
-:::
+![Create API key](images/create-api-key.png)
 
 For other connection options, refer to the [Connecting](setup/connecting.md) section.
 

--- a/docs/reference/setup/opentelemetry.md
+++ b/docs/reference/setup/opentelemetry.md
@@ -9,24 +9,18 @@ You can use [OpenTelemetry](https://opentelemetry.io/) to monitor the performanc
 
 The native instrumentation in the Java API Client follows the [OpenTelemetry Semantic Conventions for {{es}}](https://opentelemetry.io/docs/specs/semconv/database/elasticsearch/). In particular, the instrumentation in the client covers the logical layer of {{es}} requests. A single span per request is created that is processed by the service through the Java API Client. The following image shows a trace that records the handling of three different {{es}} requests: an `index`, `get` and a search `request`:
 
-:::{image} ../images/otel-waterfall-instrumented-without-http.jpg
-:alt: Distributed trace with {{es}} spans
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Distributed trace with {{es}} spans](../images/otel-waterfall-instrumented-without-http.jpg)
 
 Usually, OpenTelemetry agents and auto-instrumentation modules come with instrumentation support for HTTP-level communication. In this case, in addition to the logical {{es}} client requests, spans will be captured for the physical HTTP requests emitted by the client. The following image shows a trace with both, {{es}} spans (in blue) and the corresponding HTTP-level spans (in red):
 
-:::{image} ../images/otel-waterfall-instrumented.jpg
-:alt: Distributed trace with {{es}} and HTTP spans
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Distributed trace with {{es}} and HTTP spans](../images/otel-waterfall-instrumented.jpg)
 
 Advanced Java API Client behavior such as nodes round-robin and request retries are revealed through the combination of logical {{es}} spans and the physical HTTP spans. The following example shows an `index` request in a scenario with two {{es}} nodes:
 
-:::{image} ../images/otel-waterfall-retries.jpg
-:alt: Distributed trace with request retries
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Distributed trace with request retries](../images/otel-waterfall-retries.jpg)
 
 The first node is unavailable and results in an HTTP error, while the retry to the second node succeeds. Both HTTP requests are subsumed by the logical {{es}} request span (in blue).
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting?