### PR TITLE
[docs] Fix various syntax and rendering errors 

### DIFF
--- a/docs/reference/transport/rest-client/sniffer/maven_repository.md
+++ b/docs/reference/transport/rest-client/sniffer/maven_repository.md
@@ -29,7 +29,7 @@ Here is how you can configure the dependency using maven as a dependency manager
 
 Here is how you can configure the dependency using gradle as a dependency manager. Add the following to your `build.gradle` file:
 
-```groovy
+```groovy subs=true
 dependencies {
     compile 'org.elasticsearch.client:elasticsearch-rest-client-sniffer:{{version}}'
 }

--- a/docs/reference/transport/rest-client/usage/maven.md
+++ b/docs/reference/transport/rest-client/usage/maven.md
@@ -31,7 +31,7 @@ Here is how you can configure the dependency using maven as a dependency manager
 
 Here is how you can configure the dependency using gradle as a dependency manager. Add the following to your `build.gradle` file:
 
-```groovy
+```groovy subs=true
 dependencies {
     compile 'org.elasticsearch.client:elasticsearch-rest-client:{{version}}'
 }

--- a/docs/reference/transport/rest-client/usage/requests.md
+++ b/docs/reference/transport/rest-client/usage/requests.md
@@ -163,20 +163,17 @@ Cancellable cancellable = restClient.performRequestAsync(
     new ResponseListener() {
         @Override
         public void onSuccess(Response response) {
-            <1>
+          // Process the returned response, in case it was
+          // ready before the request got cancelled
         }
 
         @Override
         public void onFailure(Exception exception) {
-            <2>
+          // Handle the returned exception, which will most
+          // likely be a `CancellationException` as the request
+          // got cancelled
         }
     }
 );
 cancellable.cancel();
 ```
-
-1. Process the returned response, in case it was ready before the request got cancelled
-2. Handle the returned exception, which will most likely be a `CancellationException` as the request got cancelled
-
-
-


### PR DESCRIPTION
Fixes various syntax and rendering errors that might include:

* Fixing broken images
* Hardcoding book-level substitution values
* Fixing incorrectly closed blocks (admonitions, tab sets, code blocks, dropdowns etc.)
* Fixing poorly migrated complex tables
* Fixing poorly migrated lists
* Fixing poorly migrated tab sets
* Removing inline text formatting from directive titles where they won't be rendered (for example, inline `code` formatting in dropdown titles)
* Specifying if a version is trying to communicate if a feature was added, deprecated, or coming (for example, during migration `deprecated:[8.15.0]` became `[8.15.0]`, which doesn't give any information about _what_ happened in 8.15.0)
* Fixing nested dropdowns / definition lists
* Fixing poorly migrated footnotes
* Updating references to prerelease `9.0.0` versions