### PR TITLE
[Docs] Add mapping for deleted file

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html
   - https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/introduction.html
+  - https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/migrate-hlrc.html
 ---
 
 # Java [introduction]


### PR DESCRIPTION
The file `docs/reference/migrate-hlrc.md` was deleted in https://github.com/elastic/elasticsearch-java/pull/988/ so we lost a mapping for the old `current` URL: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/migrate-hlrc.html. We don't need the content of that old page in the v3 docs, so I mapped it to the Java client docs index page.