### PR TITLE
Using fixed minor version of rest-client - 8

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -162,33 +162,6 @@ publishing {
                     developerConnection.set("scm:git:ssh://git@github.com:elastic/elasticsearch-java.git")
                     url.set("https://github.com/elastic/elasticsearch-java/")
                 }
-
-                withXml {
-                    // Set the version of dependencies of the org.elasticsearch.client group to the one that we are building.
-                    // Since the unified release process releases everything at once, this ensures all published artifacts depend
-                    // on the exact same version. This assumes of course that the binary API and the behavior of these dependencies
-                    // are the same as the one used in the dependency section below.
-                    val xPathFactory = javax.xml.xpath.XPathFactory.newInstance()
-                    val depSelector = xPathFactory.newXPath()
-                        .compile("/project/dependencies/dependency[groupId/text() = 'org.elasticsearch.client']")
-                    val versionSelector = xPathFactory.newXPath().compile("version")
-
-                    var foundVersion = false;
-
-                    val deps = depSelector.evaluate(asElement().ownerDocument, javax.xml.xpath.XPathConstants.NODESET)
-                            as org.w3c.dom.NodeList
-
-                    for (i in 0 until deps.length) {
-                        val dep = deps.item(i)
-                        val version = versionSelector.evaluate(dep, javax.xml.xpath.XPathConstants.NODE) as org.w3c.dom.Element
-                        foundVersion = true;
-                        version.textContent = project.version.toString()
-                    }
-
-                    if (!foundVersion) {
-                        throw GradleException("Could not find a 'org.elasticsearch.client' to update dependency version in the POM.")
-                    }
-                }
             }
         }
     }
@@ -204,7 +177,7 @@ signing {
 dependencies {
     // Compile and test with the last 7.x version to make sure transition scenarios where
     // the Java API client coexists with a 7.x HLRC work fine
-    val elasticsearchVersion = "8.10.0"
+    val elasticsearchVersion = "8.19.0"
     val jacksonVersion = "2.17.0"
     val openTelemetryVersion = "1.29.0"
 

--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -177,7 +177,7 @@ signing {
 dependencies {
     // Compile and test with the last 7.x version to make sure transition scenarios where
     // the Java API client coexists with a 7.x HLRC work fine
-    val elasticsearchVersion = "8.19.0"
+    val elasticsearchVersion = "8.18.0" // update to 8.19.0 before release
     val jacksonVersion = "2.17.0"
     val openTelemetryVersion = "1.29.0"
 


### PR DESCRIPTION
Partially backporting https://github.com/elastic/elasticsearch-java/pull/1010 to 8.x branches, using the matching minor version for each version