### PR TITLE
[Docs] Fix broken Javadoc link

### DIFF
--- a/docs/reference/javadoc-source-code.md
+++ b/docs/reference/javadoc-source-code.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Javadoc and source code [java-client-javadoc]
 
-The Javadoc for the Java API Client is available at [https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/](https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/latest/index.html).
+The Javadoc for the Java client API is available at [https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/](https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/latest/index.html).
 
 The source code is at [https://github.com/elastic/elasticsearch-java/](https://github.com/elastic/elasticsearch-java/) and is licensed under the Apache 2.0 License.
 

--- a/docs/reference/javadoc-source-code.md
+++ b/docs/reference/javadoc-source-code.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Javadoc and source code [java-client-javadoc]
 
-The Javadoc for the Java client API is available at [https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/](https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/latest/index.html).
+The Javadoc for the Java API Client is available at [https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/](https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/latest/index.html).
 
 The source code is at [https://github.com/elastic/elasticsearch-java/](https://github.com/elastic/elasticsearch-java/) and is licensed under the Apache 2.0 License.
 

--- a/docs/reference/javadoc-source-code.md
+++ b/docs/reference/javadoc-source-code.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Javadoc and source code [java-client-javadoc]
 
-The javadoc for the Java API Client is available at [https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/](https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/latest/index.html).
+The Javadoc for the Java API Client is available at [https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/](https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/latest/index.html).
 
 The source code is at [https://github.com/elastic/elasticsearch-java/](https://github.com/elastic/elasticsearch-java/) and is licensed under the Apache 2.0 License.
 

--- a/docs/reference/javadoc-source-code.md
+++ b/docs/reference/javadoc-source-code.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Javadoc and source code [java-client-javadoc]
 
-The javadoc for the Java API Client can be found at [https://snapshots.elastic.co/javadoc/co/elastic/clients/elasticsearch-java/{{version}}/](https://snapshots.elastic.co/javadoc/co/elastic/clients/elasticsearch-java/{{version}}/).
+The javadoc for the Java API Client is available at [https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/](https://javadoc.io/doc/co.elastic.clients/elasticsearch-java/latest/index.html).
 
 The source code is at [https://github.com/elastic/elasticsearch-java/](https://github.com/elastic/elasticsearch-java/) and is licensed under the Apache 2.0 License.
 


### PR DESCRIPTION
Replaced stale snapshots link with link to latest Javadoc.

[Preview](https://docs-v3-preview.elastic.dev/elastic/elasticsearch-java/pull/1014/reference/javadoc-source-code)

via Slack