### PR TITLE
Avoid concurrent access to multibuffer entity iterator

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/transport/rest_client/MultiBufferEntity.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest_client/MultiBufferEntity.java
@@ -60,12 +60,13 @@ class MultiBufferEntity extends AbstractHttpEntity implements HttpAsyncContentPr
     }
 
     private void init() {
-        this.iterator = buffers.iterator();
-        if (this.iterator.hasNext()) {
-            this.currentBuffer = this.iterator.next().duplicate();
+        Iterator<ByteBuffer> localIterator = this.buffers.iterator();
+        if (localIterator.hasNext()) {
+            this.currentBuffer = localIterator.next().duplicate();
         } else {
             this.currentBuffer = null;
         }
+        this.iterator = localIterator;
     }
 
     @Override


### PR DESCRIPTION
As reported in #1003, it appears that the list of Buffers in `MultiBufferEntity` can be accessed by multiple threads in case of frequent connection exceptions, by calling the functions `init()` and `produceContent()` at the same time. This PR introduces a local iterator in `init()` so that it will not try to call `next()` on an empty iterable. 