### PR TITLE
[DOCS] Add wayfinding for shared GitHub and support links

### DIFF
--- a/docs/reference/release-highlights.md
+++ b/docs/reference/release-highlights.md
@@ -5,10 +5,35 @@ mapped_pages:
 
 # Release highlights [release-highlights]
 
-These are the important new features and changes in minor releases. Every release also updates the Java API Client to the latest [API specification](https://github.com/elastic/elasticsearch-specification). This includes new APIs and bug fixes in the specification of existing APIs.
+These are the important new features and changes in minor releases. Every release also updates the Java API Client to the latest [API specification](https://github.com/elastic/elasticsearch-specification). This includes new APIs, as well as bug fixes in the specification of existing APIs.
 
-For a list of detailed changes, including bug fixes, please see the [GitHub project release notes](https://github.com/elastic/elasticsearch-java/releases).
+For a list of detailed changes, including bug fixes, see the [GitHub project release notes](https://github.com/elastic/elasticsearch-java/releases).
 
 ## 9.0.0 [release-highlights-900]
 
 [Release notes](/release-notes/9-0-0.md)
+
+## Earlier versions
+
+To view release notes for earlier versions, use the version dropdown in the top right corner of this page.
+
+% For GitHub and support links, use the anchor pattern _version_X_X
+% List up to 5 most recent releases
+
+### Recent releases
+
+#### 8.18 [_version_8_18]
+
+[Release notes](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.18/release-highlights.html)
+
+#### 8.17 [_version_8_17]
+
+[Release notes](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.17/release-highlights.html)
+
+#### 8.16 [_version_8_16]
+
+[Release notes](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.16/release-highlights.html)
+
+#### 8.15 [_version_8_15]
+
+[Release notes](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.15/release-highlights.html)

--- a/docs/reference/release-highlights.md
+++ b/docs/reference/release-highlights.md
@@ -17,7 +17,7 @@ For a list of detailed changes, including bug fixes, see the [GitHub project rel
 
 To view release notes for earlier versions, use the version dropdown in the top right corner of this page.
 
-% For GitHub and support links, use the anchor pattern _version_X_X
+% To facilitate GitHub and community links, use the anchor pattern _version_X_X
 % List up to 5 most recent releases
 
 ### Recent releases


### PR DESCRIPTION
This PR adds anchors and text to the 9x release highlights page, to support links that have been shared on GitHub and in the community forum. It also adds comments so we can make similar additions as a best practice.

👉 [**Preview**](https://docs-v3-preview.elastic.dev/elastic/elasticsearch-java/pull/1025/reference/release-highlights)

plus 2 small fixes for clarity and style

⚠️ Do not merge unless all doc checks are passing