### PR TITLE
Adding spring data es metadata to runtime info

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/util/LanguageRuntimeVersions.java
+++ b/java-client/src/main/java/co/elastic/clients/util/LanguageRuntimeVersions.java
@@ -62,7 +62,7 @@ public class LanguageRuntimeVersions {
 
         version = springDataVersion();
         if (version != null) {
-            s.append(",sd_es=").append(version);
+            s.append(",sde=").append(version);
         }
 
         return s.toString();


### PR DESCRIPTION
Will allow us to track usage from spring data elasticsearch in cloud. 
