### PR TITLE
Http2 bug workaround

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -243,7 +243,7 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
         Map<String, String> params = endpoint.queryParameters(request);
 
         List<ByteBuffer> bodyBuffers = null;
-        HeaderMap headers = DefaultHeaders;
+        HeaderMap headers = JsonContentTypeHeaders;
 
         Object body = endpoint.body(request);
         if (body != null) {
@@ -251,17 +251,12 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
             if (body instanceof NdJsonpSerializable) {
                 bodyBuffers = new ArrayList<>();
                 collectNdJsonLines(bodyBuffers, (NdJsonpSerializable) request);
-                headers = JsonContentTypeHeaders;
-
             } else if (body instanceof BinaryData) {
                 BinaryData data = (BinaryData) body;
 
                 // ES expects the Accept and Content-Type headers to be consistent.
                 String dataContentType = data.contentType();
-                if (ContentType.APPLICATION_JSON.equals(dataContentType)) {
-                    // Fast path
-                    headers = JsonContentTypeHeaders;
-                } else {
+                if (!ContentType.APPLICATION_JSON.equals(dataContentType)) {
                     headers = new HeaderMap(DefaultHeaders);
                     headers.put(HeaderMap.CONTENT_TYPE, dataContentType);
                 }

--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -243,6 +243,10 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
         Map<String, String> params = endpoint.queryParameters(request);
 
         List<ByteBuffer> bodyBuffers = null;
+        // Setting the Content-type header for all requests, even the ones without body.
+        // This is a workaround for a bug with server version 9.1.2 and http2, where
+        // http2 stream requests are considered not to have a body. So if the client doesn't always send
+        // the Content-type header, empty body requests will fail with the above-described conditions.
         HeaderMap headers = JsonContentTypeHeaders;
 
         Object body = endpoint.body(request);

--- a/java-client/src/main/java/co/elastic/clients/transport/rest5_client/Rest5ClientOptions.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest5_client/Rest5ClientOptions.java
@@ -238,7 +238,7 @@ public class Rest5ClientOptions implements TransportOptions {
         VersionInfo httpClientVersion = null;
         try {
             httpClientVersion = VersionInfo.loadVersionInfo(
-                "org.apache.http.nio.client",
+                "org.apache.hc.core5",
                 HttpAsyncClientBuilder.class.getClassLoader()
             );
         } catch (Exception e) {

--- a/java-client/src/main/java/co/elastic/clients/transport/rest5_client/low_level/BufferedByteConsumer.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/rest5_client/low_level/BufferedByteConsumer.java
@@ -57,7 +57,7 @@ class BufferedByteConsumer extends AbstractBinAsyncEntityConsumer<ByteArrayEntit
     protected void data(final ByteBuffer src, final boolean endOfStream) throws ContentTooLongException {
         if (buffer.length() + src.limit() > limit) {
             throw new ContentTooLongException(
-                "entity content is too long [" + src.capacity() + "] for the configured buffer limit [" + limit + "]"
+                "entity content is too long [" + src.limit() + "] for the configured buffer limit [" + limit + "]"
             );
         }
         buffer.append(src);


### PR DESCRIPTION
This provides a workaround for a bug which affects empty body requests when sent with the Rest5Client configured to support http2.
The issue was introduced server side by https://github.com/elastic/elasticsearch/pull/129302 and results in empty body requests causing the following exception: `Invalid media-type value on headers [Accept, Content-Type]`.

(bonus: log fixes for Rest5Client)