### PR TITLE
[DOCS] Edit PR links in 9.1.0 release notes

### DIFF
--- a/docs/release-notes/9-1-0.md
+++ b/docs/release-notes/9-1-0.md
@@ -51,7 +51,7 @@ Example with `SearchRequest`:
 
 ::::{dropdown} Opentelemetry update to stable conventions   
 Following the stable release of Opentelemetry's database conventions, the client was updated to use the correct attribute names.
-More details in the PR: https://github.com/elastic/elasticsearch-java/pull/1017  
+More details in the PR: [#1017](https://github.com/elastic/elasticsearch-java/pull/1017)
 ::::
 
 ::::{dropdown} GetAliasResponse exception bug fix  
@@ -67,7 +67,7 @@ catch (ElasticsearchException e){
     assertEquals("test", aliases.keySet().iterator().next());
 }
 ```
-More details in the PR: https://github.com/elastic/elasticsearch-java/pull/1041  
+More details in the PR: [#1041](https://github.com/elastic/elasticsearch-java/pull/1041)
 ::::
 
 ### Deprecations [elasticsearch-java-client-910-deprecations]


### PR DESCRIPTION
This PR updates the links in the [9.1.0 release notes](https://www.elastic.co/docs/release-notes/elasticsearch/clients/java/9-1-0)