### PR TITLE
Remove invalid `mapped_pages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="Elastic logo" align="right" width="auto" height="auto" src="https://www.elastic.co/static-res/images/elastic-logo-200.png">
+\<img alt="Elastic logo" align="right" width="auto" height="auto" src="https://www.elastic.co/static-res/images/elastic-logo-200.png">
 
 # Elasticsearch Java Client
 Elasticsearch is a distributed, RESTful search engine optimized for speed and relevance on production-scale workloads. You can use Elasticsearch to perform real-time search over massive datasets for applications including Vector search, Full-text search, Logs, Metrics, Application Performance Monitoring, Security Logs and more ! 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-\<img alt="Elastic logo" align="right" width="auto" height="auto" src="https://www.elastic.co/static-res/images/elastic-logo-200.png">
+<img alt="Elastic logo" align="right" width="auto" height="auto" src="https://www.elastic.co/static-res/images/elastic-logo-200.png">
 
 # Elasticsearch Java Client
 Elasticsearch is a distributed, RESTful search engine optimized for speed and relevance on production-scale workloads. You can use Elasticsearch to perform real-time search over massive datasets for applications including Vector search, Full-text search, Logs, Metrics, Application Performance Monitoring, Security Logs and more ! 

--- a/docs/reference/transport/rest-client/sniffer/usage.md
+++ b/docs/reference/transport/rest-client/sniffer/usage.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest-client/sniffer/usage.html
 navigation_title: Usage
 ---
 

--- a/docs/reference/transport/rest5-client/config/basic_authentication.md
+++ b/docs/reference/transport/rest5-client/config/basic_authentication.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages: 
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config/basic_authentication.html
 navigation_title: Basic authentication
 ---
 

--- a/docs/reference/transport/rest5-client/config/encrypted_communication.md
+++ b/docs/reference/transport/rest5-client/config/encrypted_communication.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config/encrypted_communication.html
 navigation_title: Encrypted communication
 ---
 

--- a/docs/reference/transport/rest5-client/config/index.md
+++ b/docs/reference/transport/rest5-client/config/index.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages: 
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config.html
 navigation_title: Common configuration
 ---
 

--- a/docs/reference/transport/rest5-client/config/node_selector.md
+++ b/docs/reference/transport/rest5-client/config/node_selector.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config/node_selector.html
 navigation_title: Node selector
 ---
 

--- a/docs/reference/transport/rest5-client/config/number_of_threads.md
+++ b/docs/reference/transport/rest5-client/config/number_of_threads.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config/number_of_threads.html
 navigation_title: Number of threads
 ---
 

--- a/docs/reference/transport/rest5-client/config/other_authentication_methods.md
+++ b/docs/reference/transport/rest5-client/config/other_authentication_methods.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config/other_authentication_methods.html
 navigation_title: Other authentication methods
 ---
 

--- a/docs/reference/transport/rest5-client/config/others.md
+++ b/docs/reference/transport/rest5-client/config/others.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config/others.html
 navigation_title: More config options
 ---
 

--- a/docs/reference/transport/rest5-client/config/timeouts.md
+++ b/docs/reference/transport/rest5-client/config/timeouts.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/config/timeouts.html
 navigation_title: Timeouts
 ---
 

--- a/docs/reference/transport/rest5-client/sniffer/index.md
+++ b/docs/reference/transport/rest5-client/sniffer/index.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/sniffer.html
 navigation_title: Sniffer
 ---
 # Sniffer in the {{es}} Java REST 5 client

--- a/docs/reference/transport/rest5-client/usage/index.md
+++ b/docs/reference/transport/rest5-client/usage/index.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages: 
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/usage.html
 navigation_title: Getting started
 ---
 

--- a/docs/reference/transport/rest5-client/usage/initialization.md
+++ b/docs/reference/transport/rest5-client/usage/initialization.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/usage/initialization.html
 navigation_title: Initialization
 ---
 

--- a/docs/reference/transport/rest5-client/usage/logging.md
+++ b/docs/reference/transport/rest5-client/usage/logging.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/usage/logging.html
 navigation_title: Logging
 ---
 

--- a/docs/reference/transport/rest5-client/usage/requests.md
+++ b/docs/reference/transport/rest5-client/usage/requests.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/usage/requests.html
 navigation_title: Performing requests
 ---
 

--- a/docs/reference/transport/rest5-client/usage/responses.md
+++ b/docs/reference/transport/rest5-client/usage/responses.md
@@ -1,6 +1,4 @@
 ---
-mapped_pages:
-  - https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/usage/responses.html
 navigation_title: Reading responses
 ---
 


### PR DESCRIPTION
## Context

Needed for https://github.com/elastic/docs-builder/pull/1899

docs-builder can only handle mapped_pages to `/guide`