### PR TITLE
rest5-client: remove jackson-databind dependency

### DIFF
--- a/rest5-client/build.gradle.kts
+++ b/rest5-client/build.gradle.kts
@@ -154,7 +154,6 @@ dependencies {
     // Apache 2.0
     // https://github.com/FasterXML/jackson
     implementation("com.fasterxml.jackson.core", "jackson-core", jacksonVersion)
-    implementation("com.fasterxml.jackson.core", "jackson-databind", jacksonVersion)
 
 //    // Apache-2.0
 //    testImplementation("commons-io:commons-io:2.17.0")


### PR DESCRIPTION
sniffer client only depends on jackson-core. so, jackson-databind is not needed.

`./gradlew check` passed 
<img width="659" height="160" alt="image" src="https://github.com/user-attachments/assets/f3359000-a9cc-49e4-8095-2239384d23b3" />
