### PR TITLE
Document elasticsearch-rest5-client migration details in 9.2.0 release notes

### DIFF
--- a/docs/release-notes/9-2-0.md
+++ b/docs/release-notes/9-2-0.md
@@ -107,6 +107,17 @@ try (ElasticsearchClient client = ElasticsearchClient.of(e -> e
 ```
 ::::
 
+::::{dropdown} elasticsearch-rest5-client as seperate jar
+The Elasticsearch Java client historically used a "Low Level Rest Client" (LLRC) based on Apache http client version 4 to handle http communications and distribution of requests among the nodes of a cluster.
+
+This directory is a port of this client to Apache http client version 5 that is mostly a drop-in replacement, except for the initialization phase.
+
+It is provided as an independent library as a convenience to users who have an existing code based on LLRC and would like to migrate to the more modern Apache http 5 library.
+
+https://mvnrepository.com/artifact/co.elastic.clients/elasticsearch-rest5-client
+
+::::
+
 ## Deprecations [elasticsearch-java-client-920-deprecations]
 
 Nothing was deprecated in this version of the client. 


### PR DESCRIPTION
Added information about the elasticsearch-rest5-client as a separate jar, detailing its purpose and migration from LLRC.