### PR TITLE
Support SearchRequest compatibility for Msearch body and ScriptSource

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/ScriptSource.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/ScriptSource.java
@@ -19,6 +19,7 @@
 
 package co.elastic.clients.elasticsearch._types;
 
+import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.search.SearchRequestBody;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -160,6 +161,24 @@ public class ScriptSource implements TaggedUnion<ScriptSource.Kind, Object>, Jso
 		public ObjectBuilder<ScriptSource> scriptTemplate(SearchRequestBody v) {
 			this._kind = Kind.ScriptTemplate;
 			this._value = v;
+			return this;
+		}
+
+		public final ObjectBuilder<ScriptSource> scriptTemplate(SearchRequest value) {
+			this._kind = Kind.ScriptTemplate;
+			SearchRequestBody body = SearchRequestBody.of(srb -> srb.aggregations(value.aggregations())
+					.collapse(value.collapse()).explain(value.explain()).ext(value.ext()).from(value.from())
+					.highlight(value.highlight()).trackTotalHits(value.trackTotalHits())
+					.indicesBoost(value.indicesBoost()).docvalueFields(value.docvalueFields()).knn(value.knn())
+					.rank(value.rank()).minScore(value.minScore()).postFilter(value.postFilter())
+					.profile(value.profile()).query(value.query()).rescore(value.rescore()).retriever(value.retriever())
+					.scriptFields(value.scriptFields()).searchAfter(value.searchAfter()).size(value.size())
+					.slice(value.slice()).sort(value.sort()).source(value.source()).fields(value.fields())
+					.suggest(value.suggest()).terminateAfter(value.terminateAfter()).timeout(value.timeout())
+					.trackScores(value.trackScores()).version(value.version())
+					.seqNoPrimaryTerm(value.seqNoPrimaryTerm()).storedFields(value.storedFields()).pit(value.pit())
+					.runtimeMappings(value.runtimeMappings()).stats(value.stats()));
+			this._value = body;
 			return this;
 		}
 

--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/core/msearch/RequestItem.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/core/msearch/RequestItem.java
@@ -19,6 +19,7 @@
 
 package co.elastic.clients.elasticsearch.core.msearch;
 
+import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.search.SearchRequestBody;
 import co.elastic.clients.json.JsonpDeserializable;
 import co.elastic.clients.json.JsonpDeserializer;
@@ -161,6 +162,23 @@ public class RequestItem implements NdJsonpSerializable, JsonpSerializable {
 		 */
 		public final Builder body(Function<SearchRequestBody.Builder, ObjectBuilder<SearchRequestBody>> fn) {
 			return this.body(fn.apply(new SearchRequestBody.Builder()).build());
+		}
+
+		public final Builder body(SearchRequest value) {
+			SearchRequestBody body = SearchRequestBody.of(srb -> srb.aggregations(value.aggregations())
+					.collapse(value.collapse()).explain(value.explain()).ext(value.ext()).from(value.from())
+					.highlight(value.highlight()).trackTotalHits(value.trackTotalHits())
+					.indicesBoost(value.indicesBoost()).docvalueFields(value.docvalueFields()).knn(value.knn())
+					.rank(value.rank()).minScore(value.minScore()).postFilter(value.postFilter())
+					.profile(value.profile()).query(value.query()).rescore(value.rescore()).retriever(value.retriever())
+					.scriptFields(value.scriptFields()).searchAfter(value.searchAfter()).size(value.size())
+					.slice(value.slice()).sort(value.sort()).source(value.source()).fields(value.fields())
+					.suggest(value.suggest()).terminateAfter(value.terminateAfter()).timeout(value.timeout())
+					.trackScores(value.trackScores()).version(value.version())
+					.seqNoPrimaryTerm(value.seqNoPrimaryTerm()).storedFields(value.storedFields()).pit(value.pit())
+					.runtimeMappings(value.runtimeMappings()).stats(value.stats()));
+			this.body = body;
+			return this;
 		}
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-java/issues/151.
Adds an overload to the setter for the body of Msearch and the template of ScriptSource, both of which require an instance of SearchRequestBody, by converting an instance of SearchRequest to SearchRequestBody.

Usage:
```java
// Normal search request
SearchRequest searchRequest = SearchRequest.of(b -> b
    .size(10)
    .from(10)
    .query(q -> q
        .matchAll(m -> m)
    )
);

// Using it to build Msearch
MsearchRequest msearchRequestOverload = MsearchRequest.of(ms -> ms
    .searches(s -> s
        .header(h -> h.index("index"))
        .body(searchRequest)
    )
);

// Or script source
ScriptSource scriptSourceOverload = ScriptSource.of(s -> s
    .scriptTemplate(searchRequest)
);
```