### PR TITLE
Fix duplicate jakarta.json classes between rest5-client and java-client

### DIFF
--- a/rest5-client/build.gradle.kts
+++ b/rest5-client/build.gradle.kts
@@ -149,9 +149,13 @@ dependencies {
     testImplementation("org.apache.commons:commons-lang3:3.14.0")
     testImplementation("junit:junit:4.13.2")
 
-    // EPL-2.0
+    // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+    // https://github.com/eclipse-ee4j/jsonp
+    api("jakarta.json:jakarta.json-api:2.1.3")
+
+    // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/parsson
-    implementation("org.eclipse.parsson:jakarta.json:1.1.7")
+    implementation("org.eclipse.parsson:parsson:1.1.7")
 
 //    // Apache-2.0
 //    testImplementation("commons-io:commons-io:2.17.0")


### PR DESCRIPTION
### Problem

`rest5-client` uses `org.eclipse.parsson:jakarta.json` (a bundled artifact containing both API and implementation), while `java-client` uses the split `jakarta.json:jakarta.json-api` + `org.eclipse.parsson:parsson`. Since `java-client` depends on `rest5-client`, this causes duplicate `jakarta.json.*` classes on the classpath.

### Solution

Replace the bundled artifact with the split dependencies to match `java-client`:

```
-implementation("org.eclipse.parsson:jakarta.json:1.1.7")
+api("jakarta.json:jakarta.json-api:2.1.3")
+implementation("org.eclipse.parsson:parsson:1.1.7")
```