### PR TITLE
[Deps] Bump Jackson 3 to 3.1.0

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -181,7 +181,7 @@ signing {
 dependencies {
     val elasticsearchVersion = "9.2.0"
     val jacksonVersion = "2.18.3"
-    val jackson3Version = "3.0.0"
+    val jackson3Version = "3.1.0"
     val openTelemetryVersion = "1.37.0"
 
     api(project(":rest5-client"))


### PR DESCRIPTION
This addresses https://security.snyk.io/vuln/SNYK-JAVA-TOOLSJACKSONCORE-15365915 (https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq)