### PR TITLE
Add cause to elasticsearch exception message

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/ElasticsearchException.java
+++ b/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/ElasticsearchException.java
@@ -40,7 +40,7 @@ public class ElasticsearchException extends RuntimeException {
 
 	public ElasticsearchException(String endpointId, ErrorResponse response,
 			@Nullable TransportHttpClient.Response httpResponse) {
-		super("[" + endpointId + "] failed: [" + response.error().type() + "] " + response.error().reason());
+		super("[" + endpointId + "] failed: [" + response.error().type() + "] " + response.error().reason() + (response.error().causedBy() != null ? " - " + response.error().causedBy().reason() : null));
 		this.response = response;
 		this.endpointId = endpointId;
 		this.httpResponse = httpResponse;


### PR DESCRIPTION
Useful in case of all shards failed, where users need to dig deeper to find the actual exception.