### PR TITLE
Fix gzip handling header bug, memory opt

### DIFF
--- a/rest5-client/src/main/java/co/elastic/clients/transport/rest5_client/low_level/BufferedByteConsumer.java
+++ b/rest5-client/src/main/java/co/elastic/clients/transport/rest5_client/low_level/BufferedByteConsumer.java
@@ -75,7 +75,7 @@ public class BufferedByteConsumer extends AbstractBinDataConsumer implements Asy
 
     @Override
     protected final void completed() throws IOException {
-        result = new ByteArrayEntity(buffer.toByteArray(), contentType, contentEncoding);
+        result = new ByteArrayEntity(buffer.array(), 0, buffer.length(), contentType, contentEncoding);
         if (resultCallback != null) {
             resultCallback.completed(result);
         }

--- a/rest5-client/src/main/java/co/elastic/clients/transport/rest5_client/low_level/Rest5Client.java
+++ b/rest5-client/src/main/java/co/elastic/clients/transport/rest5_client/low_level/Rest5Client.java
@@ -344,6 +344,15 @@ public class Rest5Client implements Closeable {
                 httpResponse.setEntity(new GzipDecompressingEntity(entity));
                 httpResponse.removeHeaders(CONTENT_ENCODING);
                 httpResponse.removeHeaders(CONTENT_LENGTH);
+            } else if ("gzip".equals(httpResponse.getFirstHeader(CONTENT_ENCODING) != null
+                ? httpResponse.getFirstHeader(CONTENT_ENCODING).getValue() : null)) {
+                // HC5 5.6+ auto-decompressed the entity, but left the headers as they were,
+                // meaning content encoding will still be gzip, fixing that.
+                httpResponse.removeHeaders(CONTENT_ENCODING);
+                httpResponse.removeHeaders(CONTENT_LENGTH);
+                if (entity.getContentLength() >= 0) {
+                    httpResponse.setHeader(CONTENT_LENGTH, Long.toString(entity.getContentLength()));
+                }
             }
         }
 

--- a/rest5-client/src/test/java/co/elastic/clients/transport/rest5_client/low_level/RestClientGzipCompressionTests.java
+++ b/rest5-client/src/test/java/co/elastic/clients/transport/rest5_client/low_level/RestClientGzipCompressionTests.java
@@ -59,7 +59,7 @@ public class RestClientGzipCompressionTests extends RestClientTestCase {
     }
 
     @AfterAll
-    public static void stopHttpServers() throws IOException {
+    public static void stopHttpServers() {
         httpServer.stop(0);
         httpServer = null;
     }
@@ -227,6 +227,31 @@ public class RestClientGzipCompressionTests extends RestClientTestCase {
         // Server should report it had a compressed request and sent back a compressed response
         Assert.assertTrue(response.getEntity().getContentLength() < 0);
         checkResponse("gzip#gzip#compressing client", response);
+
+        restClient.close();
+    }
+
+    /**
+     * Verifies that when HC5's built-in auto-decompression is active (the default since 5.6),
+     * response headers are reconciled with the already-decompressed entity, meaning the content encoding is
+     * not gzip.
+     */
+    @Test
+    public void testAutoDecompressionAsync() throws Exception {
+        InetSocketAddress address = httpServer.getAddress();
+        Rest5Client restClient = Rest5Client.builder(new HttpHost("http", address.getHostString(),
+                address.getPort()))
+            .setCompressionEnabled(true)
+            .build();
+
+        Request request = new Request("POST", "/");
+        request.setEntity(new StringEntity("auto-decompress client", ContentType.TEXT_PLAIN));
+
+        FutureResponse futureResponse = new FutureResponse();
+        restClient.performRequestAsync(request, futureResponse);
+        Response response = futureResponse.get();
+
+        checkResponse("gzip#gzip#auto-decompress client", response);
 
         restClient.close();
     }


### PR DESCRIPTION
Related to #1143, when the apache 5 http client's autocompression is enabled, the response headers and content length must be adjusted. Bonus: little memory improvement for BufferedByteConsumer (avoid useless memory allocation by removing toByteArray()). 