### PR TITLE
Adopt latest patch release for http client

### DIFF
--- a/rest5-client/build.gradle.kts
+++ b/rest5-client/build.gradle.kts
@@ -140,7 +140,7 @@ signing {
 dependencies {
     // Apache 2.0
     // https://hc.apache.org/httpcomponents-client-ga/
-    api("org.apache.httpcomponents.client5","httpclient5","5.6")
+    api("org.apache.httpcomponents.client5","httpclient5","5.6.1")
 
     // Apache 2.0
     // http://commons.apache.org/logging/


### PR DESCRIPTION
This commit updates the `org.apache.httpcomponents.client5` dep to get the latest bug fixes.

Release notes: https://github.com/apache/httpcomponents-client/blob/rel/v5.6.1/RELEASE_NOTES.txt