### PR TITLE
Testcontainer version update

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -248,8 +248,8 @@ dependencies {
 
     // MIT
     // https://www.testcontainers.org/
-    testImplementation("org.testcontainers", "testcontainers", "1.17.3")
-    testImplementation("org.testcontainers", "elasticsearch", "1.17.3")
+    testImplementation("org.testcontainers", "testcontainers", "1.21.4")
+    testImplementation("org.testcontainers", "elasticsearch", "1.21.4")
     // updating transitive dependency from testcontainers
     testImplementation("org.apache.commons","commons-compress","1.26.1")
 


### PR DESCRIPTION
Updating testcontainer version to work with Docker version >=29 (see https://github.com/testcontainers/testcontainers-java/releases/tag/1.21.4) 