### PR TITLE
Handle null values in serialization when the missing properties workaround is enabled

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
+++ b/java-client/src/main/java/co/elastic/clients/json/JsonpUtils.java
@@ -21,6 +21,7 @@ package co.elastic.clients.json;
 
 import co.elastic.clients.json.jackson.JacksonJsonProvider;
 import co.elastic.clients.util.AllowForbiddenApis;
+import co.elastic.clients.util.ApiTypeHelper;
 import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -498,7 +499,12 @@ public class JsonpUtils {
             }
         };
 
-        try(JsonGenerator generator = mapper.jsonProvider().createGenerator(writer)) {
+        try(JsonGenerator rawGenerator = mapper.jsonProvider().createGenerator(writer)) {
+            // When the missing-properties workaround is active, wrap the generator so that null
+            // reference values are serialized as JSON null instead of throwing NPE. See #557.
+            JsonGenerator generator = ApiTypeHelper.requiredPropertiesCheckDisabled()
+                ? new NullSafeJsonGenerator(rawGenerator)
+                : rawGenerator;
             value.serialize(generator, mapper);
         } catch (ToStringTooLongException e) {
             // Ignore
@@ -508,7 +514,12 @@ public class JsonpUtils {
 
     public static String toJsonString(Object value, JsonpMapper mapper) {
         StringWriter writer = new StringWriter();
-        JsonGenerator generator = mapper.jsonProvider().createGenerator(writer);
+        JsonGenerator rawGenerator = mapper.jsonProvider().createGenerator(writer);
+        // When the missing-properties workaround is active, wrap the generator so that null
+        // reference values are serialized as JSON null instead of throwing NPE. See #557.
+        JsonGenerator generator = ApiTypeHelper.requiredPropertiesCheckDisabled()
+            ? new NullSafeJsonGenerator(rawGenerator)
+            : rawGenerator;
         mapper.serialize(value, generator);
         generator.close();
         return writer.toString();

--- a/java-client/src/main/java/co/elastic/clients/json/NullSafeJsonGenerator.java
+++ b/java-client/src/main/java/co/elastic/clients/json/NullSafeJsonGenerator.java
@@ -26,8 +26,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
- * A {@link JsonGenerator} that delegates all calls to a wrapped generator, but translates {@code write(...)} calls
- * with a {@code null} reference value into the appropriate {@link JsonGenerator#writeNull() writeNull} call.
+ * A {@link DelegatingJsonGenerator} that translates {@code write(...)} calls with a {@code null} reference value
+ * into a {@link JsonGenerator#writeNull() writeNull} call. The {@code write(name, value)} overloads in
+ * {@link DelegatingJsonGenerator} are {@code final} and split into {@code writeKey(name)} + {@code write(value)},
+ * so overriding the value-only methods here is enough to also cover the name+value variants via virtual dispatch.
  *
  * <p>This is used as a safety net when {@link co.elastic.clients.util.ApiTypeHelper#DANGEROUS_disableRequiredPropertiesCheck(boolean)}
  * is active: with the workaround enabled, deserialization can leave required reference fields as {@code null},
@@ -36,169 +38,45 @@ import java.math.BigInteger;
  *
  * <p>See <a href="https://github.com/elastic/elasticsearch-java/issues/557">#557</a>.
  */
-class NullSafeJsonGenerator implements JsonGenerator {
-
-    private final JsonGenerator delegate;
+class NullSafeJsonGenerator extends DelegatingJsonGenerator {
 
     NullSafeJsonGenerator(JsonGenerator delegate) {
-        this.delegate = delegate;
+        super(delegate);
     }
-
-    //----- Methods with nullable reference values: rewrite to writeNull on null
 
     @Override
     public JsonGenerator write(String value) {
         if (value == null) {
-            return delegate.writeNull();
+            generator.writeNull();
+            return this;
         }
-        return delegate.write(value);
+        return super.write(value);
     }
 
     @Override
     public JsonGenerator write(BigDecimal value) {
         if (value == null) {
-            return delegate.writeNull();
+            generator.writeNull();
+            return this;
         }
-        return delegate.write(value);
+        return super.write(value);
     }
 
     @Override
     public JsonGenerator write(BigInteger value) {
         if (value == null) {
-            return delegate.writeNull();
+            generator.writeNull();
+            return this;
         }
-        return delegate.write(value);
+        return super.write(value);
     }
 
     @Override
     public JsonGenerator write(JsonValue value) {
         if (value == null) {
-            return delegate.writeNull();
+            generator.writeNull();
+            return this;
         }
-        return delegate.write(value);
-    }
-
-    @Override
-    public JsonGenerator write(String name, String value) {
-        if (value == null) {
-            return delegate.writeNull(name);
-        }
-        return delegate.write(name, value);
-    }
-
-    @Override
-    public JsonGenerator write(String name, BigDecimal value) {
-        if (value == null) {
-            return delegate.writeNull(name);
-        }
-        return delegate.write(name, value);
-    }
-
-    @Override
-    public JsonGenerator write(String name, BigInteger value) {
-        if (value == null) {
-            return delegate.writeNull(name);
-        }
-        return delegate.write(name, value);
-    }
-
-    @Override
-    public JsonGenerator write(String name, JsonValue value) {
-        if (value == null) {
-            return delegate.writeNull(name);
-        }
-        return delegate.write(name, value);
-    }
-
-    //----- Pure delegation for everything else
-
-    @Override
-    public JsonGenerator writeStartObject() {
-        return delegate.writeStartObject();
-    }
-
-    @Override
-    public JsonGenerator writeStartObject(String name) {
-        return delegate.writeStartObject(name);
-    }
-
-    @Override
-    public JsonGenerator writeKey(String name) {
-        return delegate.writeKey(name);
-    }
-
-    @Override
-    public JsonGenerator writeStartArray() {
-        return delegate.writeStartArray();
-    }
-
-    @Override
-    public JsonGenerator writeStartArray(String name) {
-        return delegate.writeStartArray(name);
-    }
-
-    @Override
-    public JsonGenerator writeEnd() {
-        return delegate.writeEnd();
-    }
-
-    @Override
-    public JsonGenerator write(String name, int value) {
-        return delegate.write(name, value);
-    }
-
-    @Override
-    public JsonGenerator write(String name, long value) {
-        return delegate.write(name, value);
-    }
-
-    @Override
-    public JsonGenerator write(String name, double value) {
-        return delegate.write(name, value);
-    }
-
-    @Override
-    public JsonGenerator write(String name, boolean value) {
-        return delegate.write(name, value);
-    }
-
-    @Override
-    public JsonGenerator writeNull(String name) {
-        return delegate.writeNull(name);
-    }
-
-    @Override
-    public JsonGenerator write(int value) {
-        return delegate.write(value);
-    }
-
-    @Override
-    public JsonGenerator write(long value) {
-        return delegate.write(value);
-    }
-
-    @Override
-    public JsonGenerator write(double value) {
-        return delegate.write(value);
-    }
-
-    @Override
-    public JsonGenerator write(boolean value) {
-        return delegate.write(value);
-    }
-
-    @Override
-    public JsonGenerator writeNull() {
-        return delegate.writeNull();
-    }
-
-    @Override
-    public void close() {
-        delegate.close();
-    }
-
-    @Override
-    public void flush() {
-        delegate.flush();
+        return super.write(value);
     }
 }

--- a/java-client/src/main/java/co/elastic/clients/json/NullSafeJsonGenerator.java
+++ b/java-client/src/main/java/co/elastic/clients/json/NullSafeJsonGenerator.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * A {@link JsonGenerator} that delegates all calls to a wrapped generator, but translates {@code write(...)} calls
+ * with a {@code null} reference value into the appropriate {@link JsonGenerator#writeNull() writeNull} call.
+ *
+ * <p>This is used as a safety net when {@link co.elastic.clients.util.ApiTypeHelper#DANGEROUS_disableRequiredPropertiesCheck(boolean)}
+ * is active: with the workaround enabled, deserialization can leave required reference fields as {@code null},
+ * and the generated {@code serializeInternal} methods would otherwise call e.g. {@code generator.write((String) null)},
+ * which throws {@link NullPointerException} in JSON-P providers such as Parsson.
+ *
+ * <p>See <a href="https://github.com/elastic/elasticsearch-java/issues/557">#557</a>.
+ */
+class NullSafeJsonGenerator implements JsonGenerator {
+
+    private final JsonGenerator delegate;
+
+    NullSafeJsonGenerator(JsonGenerator delegate) {
+        this.delegate = delegate;
+    }
+
+    //----- Methods with nullable reference values: rewrite to writeNull on null
+
+    @Override
+    public JsonGenerator write(String value) {
+        if (value == null) {
+            return delegate.writeNull();
+        }
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator write(BigDecimal value) {
+        if (value == null) {
+            return delegate.writeNull();
+        }
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator write(BigInteger value) {
+        if (value == null) {
+            return delegate.writeNull();
+        }
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator write(JsonValue value) {
+        if (value == null) {
+            return delegate.writeNull();
+        }
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator write(String name, String value) {
+        if (value == null) {
+            return delegate.writeNull(name);
+        }
+        return delegate.write(name, value);
+    }
+
+    @Override
+    public JsonGenerator write(String name, BigDecimal value) {
+        if (value == null) {
+            return delegate.writeNull(name);
+        }
+        return delegate.write(name, value);
+    }
+
+    @Override
+    public JsonGenerator write(String name, BigInteger value) {
+        if (value == null) {
+            return delegate.writeNull(name);
+        }
+        return delegate.write(name, value);
+    }
+
+    @Override
+    public JsonGenerator write(String name, JsonValue value) {
+        if (value == null) {
+            return delegate.writeNull(name);
+        }
+        return delegate.write(name, value);
+    }
+
+    //----- Pure delegation for everything else
+
+    @Override
+    public JsonGenerator writeStartObject() {
+        return delegate.writeStartObject();
+    }
+
+    @Override
+    public JsonGenerator writeStartObject(String name) {
+        return delegate.writeStartObject(name);
+    }
+
+    @Override
+    public JsonGenerator writeKey(String name) {
+        return delegate.writeKey(name);
+    }
+
+    @Override
+    public JsonGenerator writeStartArray() {
+        return delegate.writeStartArray();
+    }
+
+    @Override
+    public JsonGenerator writeStartArray(String name) {
+        return delegate.writeStartArray(name);
+    }
+
+    @Override
+    public JsonGenerator writeEnd() {
+        return delegate.writeEnd();
+    }
+
+    @Override
+    public JsonGenerator write(String name, int value) {
+        return delegate.write(name, value);
+    }
+
+    @Override
+    public JsonGenerator write(String name, long value) {
+        return delegate.write(name, value);
+    }
+
+    @Override
+    public JsonGenerator write(String name, double value) {
+        return delegate.write(name, value);
+    }
+
+    @Override
+    public JsonGenerator write(String name, boolean value) {
+        return delegate.write(name, value);
+    }
+
+    @Override
+    public JsonGenerator writeNull(String name) {
+        return delegate.writeNull(name);
+    }
+
+    @Override
+    public JsonGenerator write(int value) {
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator write(long value) {
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator write(double value) {
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator write(boolean value) {
+        return delegate.write(value);
+    }
+
+    @Override
+    public JsonGenerator writeNull() {
+        return delegate.writeNull();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public void flush() {
+        delegate.flush();
+    }
+}

--- a/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
+++ b/java-client/src/test/java/co/elastic/clients/elasticsearch/model/BehaviorsTest.java
@@ -468,4 +468,38 @@ public class BehaviorsTest extends ModelTestCase {
             assertTrue(healthResponse.toString()!=null);
         }
     }
+
+    @Test
+    public void testDangerousDisablePropertyCheckReferenceSerialization() {
+        // Repro for #557: with the workaround enabled, a null required reference
+        // field (here: clusterName, a required String) causes an NPE during
+        // re-serialization because HealthResponseBody#serializeInternal calls
+        // generator.write((String) null).
+        try (ApiTypeHelper.DisabledChecksHandle h =
+                 ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(true)) {
+            HealthResponse healthResponse = HealthResponse.of(hr -> hr.withJson(new StringReader("{\n" +
+                // cluster_name (required) intentionally omitted
+                "  \"status\" : \"green\",\n" +
+                "  \"timed_out\" : false,\n" +
+                "  \"number_of_nodes\" : 3,\n" +
+                "  \"number_of_data_nodes\" : 2,\n" +
+                "  \"active_primary_shards\" : 88,\n" +
+                "  \"active_shards\" : 176,\n" +
+                "  \"relocating_shards\" : 0,\n" +
+                "  \"initializing_shards\" : 0,\n" +
+                "  \"unassigned_shards\" : 0,\n" +
+                "  \"delayed_unassigned_shards\" : 0,\n" +
+                "  \"number_of_pending_tasks\" : 0,\n" +
+                "  \"number_of_in_flight_fetch\" : 0,\n" +
+                "  \"task_max_waiting_in_queue_millis\" : 0,\n" +
+                "  \"active_shards_percent_as_number\" : 100.0\n" +
+                "}")));
+
+            // deserialization succeeds — clusterName is null because the workaround is active
+            assertTrue(healthResponse.clusterName() == null);
+
+            // round-trip currently fails with NullPointerException — this is bug #557
+            assertTrue(healthResponse.toString() != null);
+        }
+    }
 }

--- a/java-client/src/test/java/co/elastic/clients/json/NullSafeJsonGeneratorTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/NullSafeJsonGeneratorTest.java
@@ -19,26 +19,25 @@
 
 package co.elastic.clients.json;
 
-import co.elastic.clients.json.jackson.JacksonJsonProvider;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.testkit.ModelTestCase;
+import co.elastic.clients.util.ApiTypeHelper;
 import jakarta.json.JsonValue;
-import jakarta.json.spi.JsonProvider;
 import jakarta.json.stream.JsonGenerator;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-public class NullSafeJsonGeneratorTest {
-
-    private final JsonProvider provider = new JacksonJsonProvider();
+public class NullSafeJsonGeneratorTest extends ModelTestCase {
 
     @Test
     public void testNullReferencesAreWrittenAsJsonNull() {
         StringWriter writer = new StringWriter();
-        try (JsonGenerator generator = new NullSafeJsonGenerator(provider.createGenerator(writer))) {
+        try (JsonGenerator generator = new NullSafeJsonGenerator(mapper.jsonProvider().createGenerator(writer))) {
             generator.writeStartObject();
 
             // writeKey + write(value) overloads with null reference values
@@ -51,7 +50,8 @@ public class NullSafeJsonGeneratorTest {
             generator.writeKey("json_value_field");
             generator.write((JsonValue) null);
 
-            // name+value overloads with null reference values
+            // name+value overloads with null reference values — DelegatingJsonGenerator splits these into
+            // writeKey(name) + write(value), so they reach the overrides above via virtual dispatch.
             generator.write("named_string", (String) null);
             generator.write("named_decimal", (BigDecimal) null);
             generator.write("named_integer", (BigInteger) null);
@@ -78,7 +78,7 @@ public class NullSafeJsonGeneratorTest {
     @Test
     public void testNonNullValuesPassThrough() {
         StringWriter writer = new StringWriter();
-        try (JsonGenerator generator = new NullSafeJsonGenerator(provider.createGenerator(writer))) {
+        try (JsonGenerator generator = new NullSafeJsonGenerator(mapper.jsonProvider().createGenerator(writer))) {
             generator.writeStartObject();
             generator.write("string_field", "hello");
             generator.write("int_field", 42);
@@ -102,5 +102,38 @@ public class NullSafeJsonGeneratorTest {
             "}",
             writer.toString()
         );
+    }
+
+    @Test
+    public void testToJsonStringWithMapWhileWorkaroundActive() {
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("a", 1);
+        map.put("b", "two");
+
+        try (ApiTypeHelper.DisabledChecksHandle h =
+                 ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(true)) {
+            assertEquals("{\"a\":1,\"b\":\"two\"}", JsonpUtils.toJsonString(map, mapper));
+        }
+    }
+
+    @Test
+    public void testToJsonStringWithPojoWhileWorkaroundActive() {
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        SomePojo pojo = new SomePojo();
+        pojo.name = "test";
+        pojo.value = 42;
+
+        try (ApiTypeHelper.DisabledChecksHandle h =
+                 ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(true)) {
+            String json = JsonpUtils.toJsonString(pojo, mapper);
+            assertTrue(json.contains("\"name\":\"test\""), "Expected name field, got: " + json);
+            assertTrue(json.contains("\"value\":42"), "Expected value field, got: " + json);
+        }
+    }
+
+    public static class SomePojo {
+        public String name;
+        public int value;
     }
 }

--- a/java-client/src/test/java/co/elastic/clients/json/NullSafeJsonGeneratorTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/NullSafeJsonGeneratorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.clients.json;
+
+import co.elastic.clients.json.jackson.JacksonJsonProvider;
+import jakarta.json.JsonValue;
+import jakarta.json.spi.JsonProvider;
+import jakarta.json.stream.JsonGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NullSafeJsonGeneratorTest {
+
+    private final JsonProvider provider = new JacksonJsonProvider();
+
+    @Test
+    public void testNullReferencesAreWrittenAsJsonNull() {
+        StringWriter writer = new StringWriter();
+        try (JsonGenerator generator = new NullSafeJsonGenerator(provider.createGenerator(writer))) {
+            generator.writeStartObject();
+
+            // writeKey + write(value) overloads with null reference values
+            generator.writeKey("string_field");
+            generator.write((String) null);
+            generator.writeKey("decimal_field");
+            generator.write((BigDecimal) null);
+            generator.writeKey("integer_field");
+            generator.write((BigInteger) null);
+            generator.writeKey("json_value_field");
+            generator.write((JsonValue) null);
+
+            // name+value overloads with null reference values
+            generator.write("named_string", (String) null);
+            generator.write("named_decimal", (BigDecimal) null);
+            generator.write("named_integer", (BigInteger) null);
+            generator.write("named_json_value", (JsonValue) null);
+
+            generator.writeEnd();
+        }
+
+        assertEquals(
+            "{" +
+                "\"string_field\":null," +
+                "\"decimal_field\":null," +
+                "\"integer_field\":null," +
+                "\"json_value_field\":null," +
+                "\"named_string\":null," +
+                "\"named_decimal\":null," +
+                "\"named_integer\":null," +
+                "\"named_json_value\":null" +
+            "}",
+            writer.toString()
+        );
+    }
+
+    @Test
+    public void testNonNullValuesPassThrough() {
+        StringWriter writer = new StringWriter();
+        try (JsonGenerator generator = new NullSafeJsonGenerator(provider.createGenerator(writer))) {
+            generator.writeStartObject();
+            generator.write("string_field", "hello");
+            generator.write("int_field", 42);
+            generator.write("long_field", 10000000000L);
+            generator.write("double_field", 1.5);
+            generator.write("bool_field", true);
+            generator.write("decimal_field", new BigDecimal("3.14"));
+            generator.write("integer_field", new BigInteger("12345"));
+            generator.writeEnd();
+        }
+
+        assertEquals(
+            "{" +
+                "\"string_field\":\"hello\"," +
+                "\"int_field\":42," +
+                "\"long_field\":10000000000," +
+                "\"double_field\":1.5," +
+                "\"bool_field\":true," +
+                "\"decimal_field\":3.14," +
+                "\"integer_field\":12345" +
+            "}",
+            writer.toString()
+        );
+    }
+}

--- a/java-client/src/test/java/co/elastic/clients/json/NullSafeJsonGeneratorTest.java
+++ b/java-client/src/test/java/co/elastic/clients/json/NullSafeJsonGeneratorTest.java
@@ -19,11 +19,11 @@
 
 package co.elastic.clients.json;
 
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.testkit.ModelTestCase;
 import co.elastic.clients.util.ApiTypeHelper;
 import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonGenerator;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
@@ -106,7 +106,8 @@ public class NullSafeJsonGeneratorTest extends ModelTestCase {
 
     @Test
     public void testToJsonStringWithMapWhileWorkaroundActive() {
-        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        // SimpleJsonpMapper only serializes types registered in the Java client and doesn't support arbitrary Maps.
+        Assumptions.assumeFalse(jsonImpl == JsonImpl.Simple, "SimpleJsonpMapper does not support arbitrary Map serialization");
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("a", 1);
         map.put("b", "two");
@@ -119,7 +120,7 @@ public class NullSafeJsonGeneratorTest extends ModelTestCase {
 
     @Test
     public void testToJsonStringWithPojoWhileWorkaroundActive() {
-        JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+        Assumptions.assumeFalse(jsonImpl == JsonImpl.Simple, "SimpleJsonpMapper does not support POJO serialization");
         SomePojo pojo = new SomePojo();
         pojo.name = "test";
         pojo.value = 42;


### PR DESCRIPTION
Closes #557.

## Problem

The documented workaround for `MissingRequiredPropertyException` — `ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(true)` — only fixes deserialization. Once active, required reference fields (`String`, `BigDecimal`, `BigInteger`, `JsonValue`) can be `null` in the deserialized object. Re-serializing such an object (most commonly via `.toString()`) then throws `NullPointerException`, because generated `serializeInternal` methods call e.g. `generator.write((String) null)` and JSON-P providers like Parsson reject it.

This is also the underlying cause of the workaround failure reported in #1082.

## Approach

Introduce a package-private `NullSafeJsonGenerator` that delegates to a wrapped `JsonGenerator` but translates `write(...)` calls with a `null` reference value into the corresponding `writeNull(...)` call:

- `write((String|BigDecimal|BigInteger|JsonValue) null)` → `writeNull()`
- `write(name, (String|BigDecimal|BigInteger|JsonValue) null)` → `writeNull(name)`
- All other methods (primitive overloads, `writeStartObject`, `writeKey`, etc.) pass through unchanged.

The wrapper is applied in `JsonpUtils.toString(JsonpSerializable, JsonpMapper, StringBuilder)` and `JsonpUtils.toJsonString(Object, JsonpMapper)` **only when** `ApiTypeHelper.requiredPropertiesCheckDisabled()` returns `true`, so behavior in normal operation is unchanged.

## Test

Added `BehaviorsTest.testDangerousDisablePropertyCheckReferenceSerialization`, modeled after the existing `testDangerousDisablePropertyCheckPrimitive` but omitting the required `String` field `cluster_name` from a `HealthResponse`.

Before this change the test fails with:

```
java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "string" is null
  at org.eclipse.parsson.JsonGeneratorImpl.writeEscapedString(JsonGeneratorImpl.java:543)
  at co.elastic.clients.elasticsearch.cluster.health.HealthResponseBody.serializeInternal(HealthResponseBody.java:345)
```

After the change the test passes and the response renders with `"cluster_name":null`.

All other serialization-related unit tests in `:java-client:test` continue to pass.

## Scope / Notes

- Covers the two `JsonpUtils` entry points used by `toString()` paths. Users who call `serializable.serialize(generator, mapper)` directly with their own `JsonGenerator` are not covered — `NullSafeJsonGenerator` can be made public for that use case if maintainers prefer.