### PR TITLE
Increase gradle memory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
Increasing the size of the heap for gradle tasks, since builds are starting to fail due to memory issues (see: https://github.com/elastic/elasticsearch-java/actions/runs/28162185379/job/83408777970?pr=1254) 