### PR TITLE
[Backport 8.19] Fix otel async path

### DIFF
--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -180,13 +180,6 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
             return future;
         }
 
-        // Propagate required property checks to the thread that will decode the response
-        boolean disableRequiredChecks = ApiTypeHelper.requiredPropertiesCheckDisabled();
-
-        CompletableFuture<TransportHttpClient.Response> clientFuture = httpClient.performRequestAsync(
-            endpoint.id(), null, clientReq, opts
-        );
-
         // Cancelling the result will cancel the upstream future created by the http client, allowing to
         // stop in-flight requests
         CompletableFuture<ResponseT> future = new CompletableFuture<ResponseT>() {

--- a/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/ElasticsearchTransportBase.java
@@ -129,6 +129,7 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
         @Nullable TransportOptions options
     ) throws IOException {
         try (Instrumentation.Context ctx = instrumentation.newContext(request, endpoint)) {
+            // HTTP client span is parented to the logical Elasticsearch request span
             try (Instrumentation.ThreadScope ts = ctx.makeCurrent()) {
 
                 TransportOptions opts = options == null ? transportOptions : options;
@@ -158,10 +159,18 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
         Instrumentation.Context ctx = instrumentation.newContext(request, endpoint);
 
         TransportOptions opts = options == null ? transportOptions : options;
-        TransportHttpClient.Request clientReq;
-        try (Instrumentation.ThreadScope ss = ctx.makeCurrent()) {
-            clientReq = prepareTransportRequest(request, endpoint);
+        // Propagate required property checks to the thread that will decode the response
+        boolean disableRequiredChecks = ApiTypeHelper.requiredPropertiesCheckDisabled();
+
+        CompletableFuture<TransportHttpClient.Response> clientFuture;
+        // HTTP client span is parented to the logical Elasticsearch request span
+        try (Instrumentation.ThreadScope ts = ctx.makeCurrent()) {
+            TransportHttpClient.Request clientReq = prepareTransportRequest(request, endpoint);
             ctx.beforeSendingHttpRequest(clientReq, options);
+
+            clientFuture = httpClient.performRequestAsync(
+                endpoint.id(), null, clientReq, opts
+            );
         } catch (Exception e) {
             // Terminate early
             ctx.recordException(e);
@@ -178,7 +187,8 @@ public abstract class ElasticsearchTransportBase implements ElasticsearchTranspo
             endpoint.id(), null, clientReq, opts
         );
 
-        // Cancelling the result will cancel the upstream future created by the http client, allowing to stop in-flight requests
+        // Cancelling the result will cancel the upstream future created by the http client, allowing to
+        // stop in-flight requests
         CompletableFuture<ResponseT> future = new CompletableFuture<ResponseT>() {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch-java/commit/e81ebf4b03b88758dfa849fcb7932bc53a591aab from https://github.com/elastic/elasticsearch-java/pull/1269