### PR TITLE
Bump parsson to 1.1.9

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -202,7 +202,7 @@ dependencies {
     // Needed even if using Jackson to have an implementation of the Jsonp object model
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/parsson
-    api("org.eclipse.parsson:parsson:1.1.7")
+    api("org.eclipse.parsson:parsson:1.1.9")
 
     // Apache 2.0
     // http://commons.apache.org/logging/


### PR DESCRIPTION
Bump new parsson version due to https://github.com/elastic/ingest-dev/issues/8679 
