### PR TITLE
Update apache http5 client dependency

### DIFF
--- a/rest5-client/build.gradle.kts
+++ b/rest5-client/build.gradle.kts
@@ -140,7 +140,7 @@ signing {
 dependencies {
     // Apache 2.0
     // https://hc.apache.org/httpcomponents-client-ga/
-    api("org.apache.httpcomponents.client5","httpclient5","5.6.1")
+    api("org.apache.httpcomponents.client5","httpclient5","5.6.3")
 
     // Apache 2.0
     // http://commons.apache.org/logging/


### PR DESCRIPTION
Closes #1289. Updating the apache httpclient dependency to [5.6.0](https://github.com/elastic/elasticsearch-java/pull/1143)(and later [5.6.1](https://github.com/elastic/elasticsearch-java/pull/1227)) meant transitively updating the httpcore library to 5.4.0, this version brought a latency regression due to a [bug](https://www.mail-archive.com/dev@hc.apache.org/msg39690.html) that was fixed with [release 5.4.1](https://github.com/apache/httpcomponents-core/blob/rel/v5.4.1/RELEASE_NOTES.txt). 

The PR updates the httpclient dependency to the latest 5.6.3, which uses httpcore 5.4.3, fixing the issue. 