### PR TITLE
 [Backport 9.2] update apache http5 client dependency

### DIFF
--- a/rest5-client/build.gradle.kts
+++ b/rest5-client/build.gradle.kts
@@ -142,7 +142,7 @@ dependencies {
 
     // Apache 2.0
     // https://hc.apache.org/httpcomponents-client-ga/
-    api("org.apache.httpcomponents.client5","httpclient5","5.6")
+    api("org.apache.httpcomponents.client5","httpclient5","5.6.3")
 
     // Apache 2.0
     // http://commons.apache.org/logging/


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch-java/commit/5bbaea0293b988602e853d22cd0b8aa283b42c60 from https://github.com/elastic/elasticsearch-java/pull/1292