### PR TITLE
update jakarta.json-api

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -192,7 +192,7 @@ dependencies {
 
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
     // https://github.com/eclipse-ee4j/jsonp
-    api("jakarta.json:jakarta.json-api:2.0.1")
+    api("jakarta.json:jakarta.json-api:2.1.3")
 
     // Needed even if using Jackson to have an implementation of the Jsonp object model
     // EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0


### PR DESCRIPTION
Updating jakarta.json-api to 2.1.3 to align it with parsson. Closes https://github.com/elastic/elasticsearch-java/issues/1305.