### PR TITLE
Capture the Elasticsearch cluster name on OpenTelemetry spans from response headers

### DIFF
--- a/docs/reference/setup/opentelemetry.md
+++ b/docs/reference/setup/opentelemetry.md
@@ -60,6 +60,16 @@ ElasticsearchClient esClient = ElasticsearchClient.of(b -> b
 esClient.close();
 ```
 
+## Capturing the {{es}} cluster name [opentelemetry-cluster-name]
+
+The built-in instrumentation automatically captures the `db.elasticsearch.cluster.name` span attribute whenever {{es}} includes the cluster name in its response headers. No client-side configuration is required.
+
+The source of the cluster name depends on your deployment:
+
+* **Elastic Cloud**: Automatically populates the cluster's canonical, globally unique ID (extracted from the `X-Found-Handling-Cluster` proxy header).
+* **Self-managed {{es}} (v9.6+)**: Populates the configured `cluster.name` (extracted from the `Elastic-Cluster-Name` header). To enable this header, set `http.headers.cluster_name.enabled: true` in your cluster settings.
+
+
 ## Configuring the OpenTelemetry instrumentation [_configuring_the_opentelemetry_instrumentation]
 
 You can configure the OpenTelemetry instrumentation either through Java System properties or Environment Variables. The following configuration options are available.

--- a/java-client/src/main/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearch.java
+++ b/java-client/src/main/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearch.java
@@ -96,6 +96,21 @@ public class OpenTelemetryForElasticsearch implements Instrumentation {
 
     private static final Log logger = LogFactory.getLog(OpenTelemetryForElasticsearch.class);
 
+    /**
+     * Cluster-name header added by the Elastic Cloud proxy; carries the cluster's canonical,
+     * globally-unique id.
+     */
+    private static final String CLOUD_CLUSTER_HEADER = "X-Found-Handling-Cluster";
+
+    /**
+     * Cluster-name header emitted by self-managed Elasticsearch (9.6+) when
+     * {@code http.headers.cluster_name.enabled} is set; carries the configured {@code cluster.name}.
+     */
+    private static final String ONPREM_CLUSTER_HEADER = "Elastic-Cluster-Name";
+
+    private static final AttributeKey<String> DB_ES_CLUSTER_NAME =
+        AttributeKey.stringKey("db.elasticsearch.cluster.name");
+
     private final Tracer tracer;
     private final boolean captureSearchBody;
 
@@ -241,6 +256,19 @@ public class OpenTelemetryForElasticsearch implements Instrumentation {
                     span.setAttribute(SERVER_PORT, uri.getPort());
                     span.setAttribute(SERVER_ADDRESS, uri.getHost());
                     span.setAttribute(HTTP_RESPONSE_STATUS_CODE, httpResponse.statusCode());
+
+                    // Record the cluster identity as db.elasticsearch.cluster.name from the response headers —
+                    // address-independent, so it survives load balancers, proxies and node lists. A deployment
+                    // normally sends only one of these headers (Elastic Cloud sends X-Found-Handling-Cluster;
+                    // self-managed sends Elastic-Cluster-Name when enabled). If both are present, the Cloud
+                    // header takes precedence because it carries the canonical, globally-unique cluster id.
+                    String clusterName = httpResponse.header(CLOUD_CLUSTER_HEADER);
+                    if (clusterName == null || clusterName.isEmpty()) {
+                        clusterName = httpResponse.header(ONPREM_CLUSTER_HEADER);
+                    }
+                    if (clusterName != null && !clusterName.isEmpty()) {
+                        span.setAttribute(DB_ES_CLUSTER_NAME, clusterName);
+                    }
                 }
             } catch (RuntimeException e) {
                 logger.debug("Failed capturing response information for the OpenTelemetry span.", e);

--- a/java-client/src/test/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearchTest.java
+++ b/java-client/src/test/java/co/elastic/clients/transport/instrumentation/OpenTelemetryForElasticsearchTest.java
@@ -64,6 +64,10 @@ import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 public class OpenTelemetryForElasticsearchTest {
     private static final String INDEX = "test-index";
     private static final String DOC_ID = "1234567";
+    private static final AttributeKey<String> DB_ES_CLUSTER_NAME =
+            AttributeKey.stringKey("db.elasticsearch.cluster.name");
+    private static final String CLOUD_CLUSTER_HEADER = "X-Found-Handling-Cluster";
+    private static final String ONPREM_CLUSTER_HEADER = "Elastic-Cluster-Name";
     private static final String DOC_RESPONSE = "{\n" +
             "  \"_index\": \"" + INDEX + "\",\n" +
             "  \"_id\": \"" + DOC_ID + "\",\n" +
@@ -155,7 +159,34 @@ public class OpenTelemetryForElasticsearchTest {
             exchange.close();
         });
 
+        // handlers for the cluster-name capture scenarios: each index returns a specific
+        // combination of the cloud and on-prem cluster-name headers.
+        addDocHandler("cluster-cloud", "cloud-cluster-01", null);
+        addDocHandler("cluster-onprem", null, "onprem-cluster-01");
+        addDocHandler("cluster-both", "cloud-cluster-01", "onprem-cluster-01");
+        addDocHandler("cluster-none", null, null);
+        addDocHandler("cluster-empty-cloud", "", "onprem-cluster-01");
+        addDocHandler("cluster-empty-both", "", "");
+
         httpServer.start();
+    }
+
+    // Registers a GET-document handler for the given index that stamps the given cluster-name headers on the
+    // response. A null value omits the header; an empty string sends the header with an empty value.
+    private static void addDocHandler(String index, String cloudHeaderValue, String onPremHeaderValue) {
+        httpServer.createContext("/" + index + "/_doc/" + DOC_ID, exchange -> {
+            exchange.getResponseHeaders().set("X-Elastic-Product", "Elasticsearch");
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            if (cloudHeaderValue != null) {
+                exchange.getResponseHeaders().set(CLOUD_CLUSTER_HEADER, cloudHeaderValue);
+            }
+            if (onPremHeaderValue != null) {
+                exchange.getResponseHeaders().set(ONPREM_CLUSTER_HEADER, onPremHeaderValue);
+            }
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().write(DOC_RESPONSE.getBytes());
+            exchange.close();
+        });
     }
 
     private static void setupOTel() {
@@ -228,6 +259,54 @@ public class OpenTelemetryForElasticsearchTest {
 
         // We're not capturing bodies by default
         Assertions.assertNull(span.getAttributes().get(DbAttributes.DB_QUERY_TEXT));
+    }
+
+    @Test
+    public void testClusterNameFromCloudHeader() throws IOException {
+        // Elastic Cloud proxy header present -> captured directly.
+        client.get(r -> r.index("cluster-cloud").id(DOC_ID), Object.class);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertEquals("cloud-cluster-01", span.getAttributes().get(DB_ES_CLUSTER_NAME));
+    }
+
+    @Test
+    public void testClusterNameFromOnPremHeader() throws IOException {
+        // Self-managed header present (no cloud header) -> captured as fallback.
+        client.get(r -> r.index("cluster-onprem").id(DOC_ID), Object.class);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertEquals("onprem-cluster-01", span.getAttributes().get(DB_ES_CLUSTER_NAME));
+    }
+
+    @Test
+    public void testClusterNamePrefersCloudHeaderWhenBothPresent() throws IOException {
+        // Both headers present -> the cloud header wins (canonical, globally-unique id).
+        client.get(r -> r.index("cluster-both").id(DOC_ID), Object.class);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertEquals("cloud-cluster-01", span.getAttributes().get(DB_ES_CLUSTER_NAME));
+    }
+
+    @Test
+    public void testClusterNameAbsentWhenNoHeader() throws IOException {
+        // Neither header present -> the attribute is not stamped.
+        client.get(r -> r.index("cluster-none").id(DOC_ID), Object.class);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertNull(span.getAttributes().get(DB_ES_CLUSTER_NAME));
+    }
+
+    @Test
+    public void testClusterNameFallsBackToOnPremWhenCloudHeaderEmpty() throws IOException {
+        // Empty cloud header is treated as absent -> fall back to the on-prem header.
+        client.get(r -> r.index("cluster-empty-cloud").id(DOC_ID), Object.class);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertEquals("onprem-cluster-01", span.getAttributes().get(DB_ES_CLUSTER_NAME));
+    }
+
+    @Test
+    public void testClusterNameAbsentWhenHeadersEmpty() throws IOException {
+        // Both headers present but empty -> the attribute is not stamped.
+        client.get(r -> r.index("cluster-empty-both").id(DOC_ID), Object.class);
+        SpanData span = spanExporter.getSpans().get(0);
+        Assertions.assertNull(span.getAttributes().get(DB_ES_CLUSTER_NAME));
     }
 
     private static class MockSpanExporter implements SpanExporter {


### PR DESCRIPTION
## Summary

Records the Elasticsearch cluster name on the client's OpenTelemetry spans as `db.elasticsearch.cluster.name`, read from the response headers. This gives spans an address-independent cluster identity, so telemetry can be correlated to the right cluster even behind a load balancer, proxy or node list — where `server.address` doesn't identify the cluster.

Resolves #1304.

## What it does

In `OpenTelemetryForElasticsearch`, once the HTTP response is received, the cluster name is read from the response headers and stamped on the span, in this order of precedence:

1. `X-Found-Handling-Cluster` — set by the Elastic Cloud proxy (canonical, globally-unique cluster id).
2. `Elastic-Cluster-Name` — emitted by self-managed Elasticsearch when `http.headers.cluster_name.enabled: true` is set (added in elastic/elasticsearch#157191, available in 9.6+).

If neither header is present, the attribute is simply not set. The capture is automatic (no configuration), makes no extra request, and never affects the actual request.

## Why headers

Data-plane responses (`_search`, `_bulk`, …) never return `cluster_name`, and `server.address` reflects whichever node / load balancer / proxy the transport happened to hit — not the cluster's own identity. Reading the value the cluster itself stamps on the response is address-independent and works across all deployment topologies. This mirrors how the .NET client populates `db.elasticsearch.cluster.name`.

## Testing

Extended `OpenTelemetryForElasticsearchTest` with full scenario coverage:

- `X-Found-Handling-Cluster` only → captured
- `Elastic-Cluster-Name` only → captured
- both present → `X-Found-Handling-Cluster` wins (precedence)
- neither present → attribute not set
- empty `X-Found-Handling-Cluster` → falls back to `Elastic-Cluster-Name`
- both headers empty → attribute not set

`./gradlew check` passes (checkstyle + tests).

## Note

This replaces the earlier draft on this branch, which used an opt-in `GET /` active-discovery approach. Now that the server-side `Elastic-Cluster-Name` header has merged (elastic/elasticsearch#157191), the self-managed case is covered passively by a header too — so the active-discovery machinery is no longer needed, and the change is just the header read.
